### PR TITLE
fix(decisions): address code review issues

### DIFF
--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -196,7 +196,9 @@ def decision_stale(
                 console.print("[red]Not in a git repository.[/red]")
                 raise typer.Exit(1)
             result = check_staleness(conn, decision_id, repo_path)
-            if result["stale"]:
+            if not result.get("checked", True):
+                console.print("[yellow]Warning: staleness check could not be completed (git error).[/yellow]")
+            elif result["stale"]:
                 console.print(f"[yellow]STALE[/yellow] — {len(result['changed_files'])} linked file(s) changed:")
                 for f in result["changed_files"]:
                     console.print(f"  - {f}")
@@ -318,6 +320,9 @@ def decision_unlink(
             removed = unlink_decision_from_commit(conn, decision_id, commit)
         else:
             removed = unlink_decision_from_file(conn, decision_id, file or "")
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
     finally:
         conn.close()
 
@@ -338,15 +343,15 @@ def decision_stale_all():
         console.print("[red]Not in a git repository.[/red]")
         raise typer.Exit(1)
 
-    from ..db import check_and_migrate, get_db
-
-    conn = get_db(repo_path)
+    conn = _get_repo_connection()
     try:
-        check_and_migrate(conn)
         decisions = list_decisions(conn, staleness_status="fresh", limit=1000)
         stale_count = 0
         for d in decisions:
             result = check_staleness(conn, d["id"], repo_path)
+            if not result.get("checked", True):
+                console.print(f"[yellow]SKIP[/yellow] {d['id'][:12]} — staleness check failed")
+                continue
             if result["stale"]:
                 stale_count += 1
                 update_decision_staleness(conn, d["id"], "stale")

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
@@ -512,7 +511,7 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
 def unlink_decision_from_file(conn, decision_id: str, file_path: str) -> bool:
     full_id = _resolve_decision_id(conn, decision_id)
     if full_id is None:
-        return False
+        raise ValueError(f"Decision '{decision_id}' not found")
     cursor = conn.execute("DELETE FROM decision_files WHERE decision_id = ? AND file_path = ?", (full_id, file_path))
     conn.commit()
     return cursor.rowcount > 0
@@ -521,7 +520,7 @@ def unlink_decision_from_file(conn, decision_id: str, file_path: str) -> bool:
 def unlink_decision_from_commit(conn, decision_id: str, commit_sha: str) -> bool:
     full_id = _resolve_decision_id(conn, decision_id)
     if full_id is None:
-        return False
+        raise ValueError(f"Decision '{decision_id}' not found")
     cursor = conn.execute(
         "DELETE FROM decision_commits WHERE decision_id = ? AND commit_sha = ?", (full_id, commit_sha)
     )
@@ -533,9 +532,11 @@ def unlink_decision_from_assessment(
     conn, decision_id: str, assessment_id: str, relation_type: str = "supports"
 ) -> bool:
     full_decision_id = _resolve_decision_id(conn, decision_id)
+    if full_decision_id is None:
+        raise ValueError(f"Decision '{decision_id}' not found")
     full_assessment_id = _resolve_assessment_id(conn, assessment_id)
-    if full_decision_id is None or full_assessment_id is None:
-        return False
+    if full_assessment_id is None:
+        raise ValueError(f"Assessment '{assessment_id}' not found")
     cursor = conn.execute(
         "DELETE FROM decision_assessments WHERE decision_id = ? AND assessment_id = ? AND relation_type = ?",
         (full_decision_id, full_assessment_id, relation_type),
@@ -546,9 +547,11 @@ def unlink_decision_from_assessment(
 
 def unlink_decision_from_checkpoint(conn, decision_id: str, checkpoint_id: str) -> bool:
     full_decision_id = _resolve_decision_id(conn, decision_id)
+    if full_decision_id is None:
+        raise ValueError(f"Decision '{decision_id}' not found")
     full_checkpoint_id = _resolve_checkpoint_id(conn, checkpoint_id)
-    if full_decision_id is None or full_checkpoint_id is None:
-        return False
+    if full_checkpoint_id is None:
+        raise ValueError(f"Checkpoint '{checkpoint_id}' not found")
     cursor = conn.execute(
         "DELETE FROM decision_checkpoints WHERE decision_id = ? AND checkpoint_id = ?",
         (full_decision_id, full_checkpoint_id),
@@ -560,37 +563,33 @@ def unlink_decision_from_checkpoint(conn, decision_id: str, checkpoint_id: str) 
 def check_staleness(conn, decision_id: str, repo_path: str) -> dict:
     """Check if linked files changed since decision creation.
 
-    Requires git >= 2.x for reliable ISO 8601 timestamp parsing in --since.
+    Returns a dict with ``checked`` indicating whether the git query succeeded.
+    When ``checked`` is False the remaining fields are defaults and should not
+    be treated as authoritative.
     """
+    from .git_utils import get_changed_files_since
+
     full_id = _resolve_decision_id(conn, decision_id)
     if full_id is None:
         raise ValueError(f"Decision '{decision_id}' not found")
 
     decision = get_decision(conn, full_id)
     linked_files = decision.get("files", []) if decision else []
-    not_stale = {"stale": False, "changed_files": [], "decision_id": full_id}
 
     if not linked_files:
-        return not_stale
+        return {"stale": False, "changed_files": [], "decision_id": full_id, "checked": True}
 
     since = decision.get("created_at") if decision else None
-    if since and since.endswith("+00:00"):
-        since = since[:-6] + "Z"
-    since_arg = f"--since={since}" if since else "--since=3 months ago"
+    since_value = since if since else "3 months ago"
 
-    try:
-        result = subprocess.run(
-            ["git", "log", since_arg, "--name-only", "--pretty=format:"],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            return not_stale
-        recently_changed = {line for line in result.stdout.strip().split("\n") if line}
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return not_stale
+    recently_changed = get_changed_files_since(repo_path, since_value)
+    if recently_changed is None:
+        return {"stale": False, "changed_files": [], "decision_id": full_id, "checked": False}
 
     changed_in_scope = sorted(set(linked_files) & recently_changed)
-    return {"stale": len(changed_in_scope) > 0, "changed_files": changed_in_scope, "decision_id": full_id}
+    return {
+        "stale": len(changed_in_scope) > 0,
+        "changed_files": changed_in_scope,
+        "decision_id": full_id,
+        "checked": True,
+    }

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -456,6 +456,9 @@ def update_decision(
     if full_id is None:
         raise ValueError(f"Decision '{decision_id}' not found")
 
+    if title is not _UNSET and title is None:
+        raise ValueError("title cannot be None (NOT NULL constraint)")
+
     updates: list[str] = []
     params: list[Any] = []
 

--- a/src/entirecontext/core/git_utils.py
+++ b/src/entirecontext/core/git_utils.py
@@ -85,3 +85,23 @@ def get_tracked_files_snapshot(repo_path: str) -> dict[str, str]:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     return {}
+
+
+def get_changed_files_since(repo_path: str, since: str) -> set[str] | None:
+    """Get set of file paths changed in commits since a given timestamp.
+
+    Returns None if the git command fails or times out.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", f"--since={since}", "--name-only", "--pretty=format:"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return {line for line in result.stdout.strip().split("\n") if line}
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -87,7 +87,14 @@ def _record_selection(
 
 
 from .tools.checkpoint import ec_checkpoint_list, ec_rewind  # noqa: E402
-from .tools.decisions import ec_decision_create, ec_decision_get, ec_decision_list, ec_decision_outcome, ec_decision_related, ec_decision_stale  # noqa: E402
+from .tools.decisions import (  # noqa: E402
+    ec_decision_create,
+    ec_decision_get,
+    ec_decision_list,
+    ec_decision_outcome,
+    ec_decision_related,
+    ec_decision_stale,
+)
 from .tools.futures import ec_assess, ec_assess_create, ec_assess_trends, ec_feedback, ec_lessons  # noqa: E402
 from .tools.misc import ec_dashboard, ec_graph  # noqa: E402
 from .tools.search import ec_activate, ec_ast_search, ec_related, ec_search  # noqa: E402

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -359,6 +359,11 @@ class TestUpdateDecision:
         with pytest.raises(ValueError, match="not found"):
             update_decision(ec_db, "nonexistent-id", title="Nope")
 
+    def test_update_title_to_none_raises(self, ec_db):
+        d = create_decision(ec_db, title="Has title")
+        with pytest.raises(ValueError, match="title cannot be None"):
+            update_decision(ec_db, d["id"], title=None)
+
     def test_no_changes_returns_current(self, ec_db):
         d = create_decision(ec_db, title="Same")
         result = update_decision(ec_db, d["id"])

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -406,9 +406,25 @@ class TestUnlinkDecision:
         fetched = get_decision(ec_db, d["id"])
         assert "src/a.py" not in fetched["files"]
 
-    def test_unlink_nonexistent_returns_false(self, ec_db):
+    def test_unlink_nonexistent_file_returns_false(self, ec_db):
         d = create_decision(ec_db, title="Test")
         assert unlink_decision_from_file(ec_db, d["id"], "nonexistent.py") is False
+
+    def test_unlink_file_nonexistent_decision_raises(self, ec_db):
+        with pytest.raises(ValueError, match="not found"):
+            unlink_decision_from_file(ec_db, "nonexistent", "src/a.py")
+
+    def test_unlink_commit_nonexistent_decision_raises(self, ec_db):
+        with pytest.raises(ValueError, match="not found"):
+            unlink_decision_from_commit(ec_db, "nonexistent", "abc123")
+
+    def test_unlink_assessment_nonexistent_decision_raises(self, ec_db):
+        with pytest.raises(ValueError, match="not found"):
+            unlink_decision_from_assessment(ec_db, "nonexistent", "some-assessment")
+
+    def test_unlink_checkpoint_nonexistent_decision_raises(self, ec_db):
+        with pytest.raises(ValueError, match="not found"):
+            unlink_decision_from_checkpoint(ec_db, "nonexistent", "some-checkpoint")
 
     def test_unlink_commit(self, ec_db):
         d = create_decision(ec_db, title="Test")
@@ -440,6 +456,7 @@ class TestCheckStaleness:
         result = check_staleness(ec_db, d["id"], str(ec_repo))
         assert result["stale"] is False
         assert result["changed_files"] == []
+        assert result["checked"] is True
 
     def test_nonexistent_raises(self, ec_db, ec_repo):
         with pytest.raises(ValueError, match="not found"):
@@ -463,6 +480,15 @@ class TestCheckStaleness:
         result = check_staleness(ec_db, d["id"], str(ec_repo))
         assert result["stale"] is True
         assert "staleness_test.py" in result["changed_files"]
+        assert result["checked"] is True
+
+    def test_checked_false_on_git_failure(self, ec_db, ec_repo, monkeypatch):
+        d = create_decision(ec_db, title="Git fail test")
+        link_decision_to_file(ec_db, d["id"], "some_file.py")
+        monkeypatch.setattr("entirecontext.core.git_utils.get_changed_files_since", lambda *a, **kw: None)
+        result = check_staleness(ec_db, d["id"], str(ec_repo))
+        assert result["stale"] is False
+        assert result["checked"] is False
 
 
 class TestFTSDecisions:


### PR DESCRIPTION
## Summary

- **Staleness check reliability**: `check_staleness` now returns a `checked` field to distinguish "not stale" from "git command failed". CLI `stale` and `stale-all` commands handle this gracefully.
- **Git helper extraction**: Moved `git log --since` subprocess call from `decisions.py` into `git_utils.get_changed_files_since()`, following existing project patterns.
- **Unlink error handling**: `unlink_decision_from_*` functions now raise `ValueError` on missing IDs (consistent with `link_*`, `update_*`, `supersede_*`). CLI `unlink` command catches it.
- **stale-all refactor**: Uses `_get_repo_connection()` instead of duplicating `get_db` + `check_and_migrate`.
- **title=None validation**: `update_decision` rejects `title=None` with a clear `ValueError` instead of leaking a SQLite IntegrityError.
- **Cleanup**: Removed unnecessary `+00:00` → `Z` timestamp conversion; broke long import line in `mcp/server.py`.

## Test plan

- [x] `uv run pytest tests/test_decisions_core.py -v` — 47 tests pass (6 new)
- [x] `uv run pytest tests/test_mcp_registration.py -v` — passes
- [x] `uv run pytest` — all 1108 tests pass
- [x] `uv run ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)