### PR TITLE
feat: add decision hooks for auto-detection, extraction and context surfacing

### DIFF
--- a/docs/superpowers/plans/2026-04-04-decision-hooks.md
+++ b/docs/superpowers/plans/2026-04-04-decision-hooks.md
@@ -644,10 +644,8 @@ from entirecontext.core.turn import create_turn
 class TestMaybeExtractDecisions:
     def _setup_session_with_summaries(self, ec_db, summaries):
         """Helper: create session with turns that have given summaries."""
-        from entirecontext.core.project import get_project
-
-        project = get_project(ec_db)
-        session = create_session(ec_db, project["id"])
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
         for i, summary in enumerate(summaries):
             turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
             ec_db.execute(
@@ -856,10 +854,8 @@ Append to `tests/test_decision_hooks.py`:
 class TestExtractFromSessionCLI:
     def _setup_session_with_turns(self, ec_db, turn_data):
         """Helper: create session with turns. turn_data = [(summary, files_touched), ...]"""
-        from entirecontext.core.project import get_project
-
-        project = get_project(ec_db)
-        session = create_session(ec_db, project["id"])
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
         for i, (summary, files) in enumerate(turn_data):
             turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
             ec_db.execute(
@@ -1174,7 +1170,8 @@ class TestHandlerIntegration:
     def test_session_end_calls_decision_hooks(self, ec_repo, ec_db, monkeypatch, isolated_global_db):
         from entirecontext.core.session import create_session
 
-        session = create_session(ec_db, session_type="claude", workspace_path=str(ec_repo))
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
         stale_called = []
         extract_called = []
         monkeypatch.setattr(
@@ -1304,36 +1301,108 @@ class TestStdoutContract:
         _handle_session_start({"cwd": str(ec_repo), "session_id": "stdout-test"})
         captured = capsys.readouterr()
         assert "Stdout test decision" in captured.out
+
+    def test_fallback_file_written(self, ec_repo, ec_db, monkeypatch):
+        """Verify fallback file is written alongside stdout."""
+        create_decision(ec_db, title="Fallback test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "fb-test"})
+        assert result is not None
+
+        from pathlib import Path
+
+        fallback_path = Path(str(ec_repo)) / ".entirecontext" / "decisions-context.md"
+        assert fallback_path.exists()
+        content = fallback_path.read_text(encoding="utf-8")
+        assert "Fallback test decision" in content
+
+    def test_fallback_file_cleaned_when_no_decisions(self, ec_repo, ec_db, monkeypatch):
+        """Verify fallback file is removed when there are no decisions to show."""
+        from pathlib import Path
+
+        fallback_path = Path(str(ec_repo)) / ".entirecontext" / "decisions-context.md"
+        fallback_path.parent.mkdir(parents=True, exist_ok=True)
+        fallback_path.write_text("old content")
+
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "cleanup-test"})
+        assert result is None
+        assert not fallback_path.exists()
 ```
 
-- [ ] **Step 2: Run test**
+- [ ] **Step 2: Run tests to verify they fail**
 
 Run: `uv run pytest tests/test_decision_hooks.py::TestStdoutContract -v`
-Expected: PASS (handler already prints in Task 7)
+Expected: FAIL — `test_fallback_file_written` and `test_fallback_file_cleaned_when_no_decisions` fail (fallback not implemented yet)
 
-- [ ] **Step 3: Manual validation**
+- [ ] **Step 3: Implement dual output (stdout + file fallback)**
 
-Run a real Claude Code session with `show_related_on_start = true` in `.entirecontext/config.toml` and verify the output appears as `additionalContext` in the system prompt. Document the result in the commit message.
+In `src/entirecontext/hooks/decision_hooks.py`, modify `on_session_start_decisions` to always write the fallback file alongside returning the text. Add this at two points:
 
-- [ ] **Step 4: If stdout doesn't work, implement file fallback**
-
-If manual validation shows stdout is NOT captured as agent context, add a fallback in `on_session_start_decisions` that writes the output to `.entirecontext/decisions-context.md`:
+At the end of the function, just before `return "\n\n".join(sections)`:
 
 ```python
-# At the end of on_session_start_decisions, before returning:
-from pathlib import Path
-context_file = Path(repo_path) / ".entirecontext" / "decisions-context.md"
-context_file.parent.mkdir(parents=True, exist_ok=True)
-context_file.write_text(output, encoding="utf-8")
+            # Write fallback file for agents that don't capture stdout
+            from pathlib import Path
+
+            fallback_path = Path(repo_path) / ".entirecontext" / "decisions-context.md"
+            if sections:
+                output = "\n\n".join(sections)
+                fallback_path.parent.mkdir(parents=True, exist_ok=True)
+                fallback_path.write_text(output, encoding="utf-8")
+                return output
+            else:
+                # Clean up stale fallback file
+                if fallback_path.exists():
+                    try:
+                        fallback_path.unlink()
+                    except OSError:
+                        pass
+                return None
 ```
 
-If stdout DOES work, skip this step and note "stdout validated" in the commit.
+Replace the existing `if not sections: return None` and `return "\n\n".join(sections)` with the above block.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestStdoutContract -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Manual validation in Claude Code**
+
+Create `.entirecontext/config.toml` with:
+```toml
+[decisions]
+show_related_on_start = true
+```
+
+Start a new Claude Code session (`claude` command) and check:
+1. Does the session start show `additionalContext` with the decisions Markdown?
+2. If yes: stdout works — both channels active (stdout for Claude, file for others)
+3. If no: file fallback at `.entirecontext/decisions-context.md` is available for agents to read
+
+Document the result in the commit message.
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add -u
-git commit -m "feat(hooks): validate stdout contract for decision context surfacing"
+git add src/entirecontext/hooks/decision_hooks.py tests/test_decision_hooks.py
+git commit -m "feat(hooks): add dual output (stdout + file fallback) for decision context
+
+stdout prints for Claude Code additionalContext injection.
+.entirecontext/decisions-context.md written as fallback for agents
+that don't capture hook stdout (Codex, Gemini, Copilot).
+File is cleaned up when no decisions are relevant."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-04-decision-hooks.md
+++ b/docs/superpowers/plans/2026-04-04-decision-hooks.md
@@ -240,8 +240,8 @@ from entirecontext.core.decisions import create_decision, link_decision_to_file,
 class TestMaybeCheckStaleDecisions:
     def test_disabled_by_config(self, ec_repo, monkeypatch):
         monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.load_config",
-            lambda _: {"decisions": {"auto_stale_check": False}},
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": False},
         )
         from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
 
@@ -250,8 +250,8 @@ class TestMaybeCheckStaleDecisions:
 
     def test_no_decisions_early_return(self, ec_repo, ec_db, monkeypatch):
         monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.load_config",
-            lambda _: {"decisions": {"auto_stale_check": True}},
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
         )
         from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
 
@@ -262,8 +262,8 @@ class TestMaybeCheckStaleDecisions:
         import subprocess
 
         monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.load_config",
-            lambda _: {"decisions": {"auto_stale_check": True}},
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
         )
         # Create a decision and link a file
         d = create_decision(ec_db, title="Test decision")
@@ -288,13 +288,14 @@ class TestMaybeCheckStaleDecisions:
 
     def test_exception_does_not_propagate(self, ec_repo, monkeypatch):
         monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.load_config",
-            lambda _: {"decisions": {"auto_stale_check": True}},
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
         )
-        monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.list_decisions",
-            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
-        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("entirecontext.core.decisions.list_decisions", _boom)
         from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
 
         # Must not raise
@@ -352,8 +353,7 @@ def maybe_check_stale_decisions(repo_path: str) -> None:
 
 ```
 
-Note: The monkeypatch targets in tests use the full module path (e.g., `"entirecontext.hooks.decision_hooks.load_config"`). Since `_load_decisions_config` wraps the import internally, tests monkeypatch `_load_decisions_config` directly instead of needing re-exports.
-```
+Note: Tests monkeypatch `_load_decisions_config` directly since it wraps the config import internally. No re-exports needed.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -491,7 +491,10 @@ import subprocess
 
 
 def _get_recently_changed_files(repo_path: str) -> list[str]:
-    """Get files changed in recent commits. Falls back to git log if git diff fails."""
+    """Get files changed in recent commits. Falls back to git log if git diff fails.
+
+    Records a warning via _record_hook_warning if both git diff and git log fail.
+    """
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", "HEAD~5..HEAD"],
@@ -512,6 +515,7 @@ def _get_recently_changed_files(repo_path: str) -> list[str]:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
+    _record_hook_warning(repo_path, "get_recently_changed_files", RuntimeError("both git diff and git log failed"))
     return []
 
 
@@ -552,21 +556,20 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
             sections = []
             seen_ids: set[str] = set()
 
-            # 1. Recently changed files → linked decisions
+            # 1. Recently changed files → linked decisions (using DB-level file_path filter)
             changed_files = _get_recently_changed_files(repo_path)
+            file_related = []
             if changed_files:
-                related = list_decisions(conn, limit=50)
-                file_related = []
-                for d in related:
-                    if d["id"] in seen_ids:
-                        continue
-                    linked_files = d.get("files") or []
-                    if not linked_files:
-                        full = get_decision(conn, d["id"])
-                        linked_files = full.get("files", []) if full else []
-                    if set(linked_files) & set(changed_files):
-                        file_related.append(d if d.get("files") else (get_decision(conn, d["id"]) or d))
-                        seen_ids.add(d["id"])
+                for f in changed_files:
+                    for d in list_decisions(conn, file_path=f, limit=10):
+                        if d["id"] not in seen_ids:
+                            full = get_decision(conn, d["id"]) or d
+                            file_related.append(full)
+                            seen_ids.add(d["id"])
+                        if len(seen_ids) >= 5:
+                            break
+                    if len(seen_ids) >= 5:
+                        break
 
                 if file_related:
                     entries = [_format_decision_entry(d) for d in file_related[:5]]
@@ -641,9 +644,12 @@ from entirecontext.core.turn import create_turn
 class TestMaybeExtractDecisions:
     def _setup_session_with_summaries(self, ec_db, summaries):
         """Helper: create session with turns that have given summaries."""
-        session = create_session(ec_db, session_type="claude", workspace_path="/tmp")
+        from entirecontext.core.project import get_project
+
+        project = get_project(ec_db)
+        session = create_session(ec_db, project["id"])
         for i, summary in enumerate(summaries):
-            turn = create_turn(ec_db, session_id=session["id"], user_message=f"msg {i}")
+            turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
             ec_db.execute(
                 "UPDATE turns SET assistant_summary = ?, turn_status = 'completed' WHERE id = ?",
                 (summary, turn["id"]),
@@ -850,9 +856,12 @@ Append to `tests/test_decision_hooks.py`:
 class TestExtractFromSessionCLI:
     def _setup_session_with_turns(self, ec_db, turn_data):
         """Helper: create session with turns. turn_data = [(summary, files_touched), ...]"""
-        session = create_session(ec_db, session_type="claude", workspace_path="/tmp")
+        from entirecontext.core.project import get_project
+
+        project = get_project(ec_db)
+        session = create_session(ec_db, project["id"])
         for i, (summary, files) in enumerate(turn_data):
-            turn = create_turn(ec_db, session_id=session["id"], user_message=f"msg {i}")
+            turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
             ec_db.execute(
                 "UPDATE turns SET assistant_summary = ?, files_touched = ?, turn_status = 'completed' WHERE id = ?",
                 (summary, json.dumps(files) if files else None, turn["id"]),
@@ -1237,16 +1246,7 @@ def _maybe_extract_decisions(repo_path: str, session_id: str) -> None:
         _record_hook_warning(repo_path, "decision_extract_dispatch", exc)
 ```
 
-Also, expose these for monkeypatching by adding at module level near the imports of `on_session_end`:
-```python
-# Re-exported for test monkeypatching
-maybe_check_stale_decisions = None  # type: ignore
-maybe_extract_decisions = None  # type: ignore
-```
-
-Wait — actually, the monkeypatch in the test patches `session_lifecycle.maybe_check_stale_decisions`. Since we use local wrapper functions `_maybe_check_stale_decisions` that import inside, the monkeypatch approach needs to target the wrapper's import. Adjust the test to monkeypatch the decision_hooks module directly instead:
-
-Update the test `test_session_end_calls_decision_hooks` to monkeypatch:
+The test monkeypatches the `decision_hooks` module directly (not `session_lifecycle`) since the wrappers use deferred imports. Update `test_session_end_calls_decision_hooks` test monkeypatch targets:
 ```python
         monkeypatch.setattr(
             "entirecontext.hooks.decision_hooks.maybe_check_stale_decisions",
@@ -1277,7 +1277,68 @@ git commit -m "feat(hooks): wire decision hooks into handler and session_lifecyc
 
 ---
 
-### Task 8: Full integration test and cleanup
+### Task 8: Validate stdout contract and implement fallback
+
+**Files:**
+- Modify: `src/entirecontext/hooks/decision_hooks.py`
+- Modify: `src/entirecontext/hooks/handler.py`
+- Test: `tests/test_decision_hooks.py`
+
+This task validates the design assumption that Claude Code captures hook stdout as `additionalContext`. If validation fails, implement the `.entirecontext/decisions-context.md` file fallback.
+
+- [ ] **Step 1: Write integration test for stdout output**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+class TestStdoutContract:
+    def test_handler_prints_decision_context(self, ec_repo, ec_db, monkeypatch, capsys):
+        """Verify _handle_session_start actually prints decision text to stdout."""
+        create_decision(ec_db, title="Stdout test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.handler import _handle_session_start
+
+        _handle_session_start({"cwd": str(ec_repo), "session_id": "stdout-test"})
+        captured = capsys.readouterr()
+        assert "Stdout test decision" in captured.out
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestStdoutContract -v`
+Expected: PASS (handler already prints in Task 7)
+
+- [ ] **Step 3: Manual validation**
+
+Run a real Claude Code session with `show_related_on_start = true` in `.entirecontext/config.toml` and verify the output appears as `additionalContext` in the system prompt. Document the result in the commit message.
+
+- [ ] **Step 4: If stdout doesn't work, implement file fallback**
+
+If manual validation shows stdout is NOT captured as agent context, add a fallback in `on_session_start_decisions` that writes the output to `.entirecontext/decisions-context.md`:
+
+```python
+# At the end of on_session_start_decisions, before returning:
+from pathlib import Path
+context_file = Path(repo_path) / ".entirecontext" / "decisions-context.md"
+context_file.parent.mkdir(parents=True, exist_ok=True)
+context_file.write_text(output, encoding="utf-8")
+```
+
+If stdout DOES work, skip this step and note "stdout validated" in the commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u
+git commit -m "feat(hooks): validate stdout contract for decision context surfacing"
+```
+
+---
+
+### Task 9: Full integration test and cleanup
 
 **Files:**
 - Test: `tests/test_decision_hooks.py`

--- a/docs/superpowers/plans/2026-04-04-decision-hooks.md
+++ b/docs/superpowers/plans/2026-04-04-decision-hooks.md
@@ -1,0 +1,1315 @@
+# Decision Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three decision-related hooks (SessionStart surfacing, SessionEnd stale detection, SessionEnd LLM extraction) to automate the decision lifecycle.
+
+**Architecture:** New `hooks/decision_hooks.py` module with three functions. SessionStart and stale check run inline. LLM extraction runs as a background worker via named PID file. All hooks are config-gated and exception-safe.
+
+**Tech Stack:** Python 3.12, SQLite, Typer CLI, subprocess (git), LLM backend (openai/anthropic via `core/llm.py`)
+
+**Spec:** `docs/superpowers/specs/2026-04-04-decision-hooks-design.md`
+
+---
+
+### Task 1: Add `decisions` config section
+
+**Files:**
+- Modify: `src/entirecontext/core/config.py:11-69` (DEFAULT_CONFIG dict)
+- Test: `tests/test_decision_hooks.py` (new file)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_decision_hooks.py`:
+
+```python
+"""Tests for decision hooks."""
+
+from __future__ import annotations
+
+from entirecontext.core.config import DEFAULT_CONFIG
+
+
+class TestDecisionConfig:
+    def test_decisions_section_exists(self):
+        assert "decisions" in DEFAULT_CONFIG
+
+    def test_decisions_defaults_all_off(self):
+        decisions = DEFAULT_CONFIG["decisions"]
+        assert decisions["auto_stale_check"] is False
+        assert decisions["auto_extract"] is False
+        assert decisions["show_related_on_start"] is False
+
+    def test_extract_keywords_present(self):
+        keywords = DEFAULT_CONFIG["decisions"]["extract_keywords"]
+        assert isinstance(keywords, list)
+        assert len(keywords) > 0
+        assert "decided" in keywords
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestDecisionConfig -v`
+Expected: FAIL with `KeyError: 'decisions'`
+
+- [ ] **Step 3: Add decisions section to DEFAULT_CONFIG**
+
+In `src/entirecontext/core/config.py`, add after the `"futures"` section (around line 68):
+
+```python
+    "decisions": {
+        "auto_stale_check": False,
+        "auto_extract": False,
+        "show_related_on_start": False,
+        "extract_keywords": [
+            "결정", "선택", "방식으로",
+            "decided", "chose", "approach", "instead of",
+        ],
+    },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestDecisionConfig -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/config.py tests/test_decision_hooks.py
+git commit -m "feat(config): add decisions section to DEFAULT_CONFIG"
+```
+
+---
+
+### Task 2: Add `pid_name` parameter to `async_worker`
+
+**Files:**
+- Modify: `src/entirecontext/core/async_worker.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from entirecontext.core.async_worker import launch_worker, worker_status, _pid_file
+
+
+class TestNamedWorker:
+    def test_pid_file_default_name(self, tmp_path):
+        result = _pid_file(str(tmp_path))
+        assert result == tmp_path / ".entirecontext" / "worker.pid"
+
+    def test_pid_file_custom_name(self, tmp_path):
+        result = _pid_file(str(tmp_path), pid_name="worker-decision")
+        assert result == tmp_path / ".entirecontext" / "worker-decision.pid"
+
+    def test_launch_worker_custom_pid(self, tmp_path):
+        ec_dir = tmp_path / ".entirecontext"
+        ec_dir.mkdir()
+        with patch("entirecontext.core.async_worker.subprocess.Popen") as mock_popen:
+            mock_proc = MagicMock()
+            mock_proc.pid = 12345
+            mock_popen.return_value = mock_proc
+            pid = launch_worker(str(tmp_path), ["echo", "test"], pid_name="worker-decision")
+            assert pid == 12345
+            pid_path = ec_dir / "worker-decision.pid"
+            assert pid_path.exists()
+            assert pid_path.read_text().strip() == "12345"
+            # Default pid file should NOT exist
+            assert not (ec_dir / "worker.pid").exists()
+
+    def test_worker_status_custom_pid(self, tmp_path):
+        ec_dir = tmp_path / ".entirecontext"
+        ec_dir.mkdir()
+        # No pid file → not running
+        status = worker_status(str(tmp_path), pid_name="worker-decision")
+        assert status["running"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestNamedWorker -v`
+Expected: FAIL with `TypeError: _pid_file() got an unexpected keyword argument 'pid_name'`
+
+- [ ] **Step 3: Add `pid_name` parameter to async_worker functions**
+
+Modify `src/entirecontext/core/async_worker.py`:
+
+Change `_pid_file`:
+```python
+def _pid_file(repo_path: str, pid_name: str = "worker") -> Path:
+    """Return the path to the worker PID file."""
+    return Path(repo_path) / ".entirecontext" / f"{pid_name}.pid"
+```
+
+Change `get_worker_pid`:
+```python
+def get_worker_pid(repo_path: str, pid_name: str = "worker") -> int | None:
+    pid_path = _pid_file(repo_path, pid_name)
+    if not pid_path.exists():
+        return None
+    try:
+        return int(pid_path.read_text().strip())
+    except (ValueError, OSError):
+        return None
+```
+
+Change `launch_worker`:
+```python
+def launch_worker(repo_path: str, cmd: list[str], pid_name: str = "worker") -> int:
+    pid_path = _pid_file(repo_path, pid_name)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.Popen(
+        cmd,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    pid_path.write_text(f"{proc.pid}\n")
+    return proc.pid
+```
+
+Change `stop_worker`:
+```python
+def stop_worker(repo_path: str, pid_name: str = "worker") -> str:
+    pid = get_worker_pid(repo_path, pid_name)
+    if pid is None:
+        return "none"
+    outcome = "killed"
+    try:
+        os.kill(pid, 15)
+    except ProcessLookupError:
+        outcome = "stale"
+    pid_path = _pid_file(repo_path, pid_name)
+    try:
+        pid_path.unlink()
+    except OSError:
+        pass
+    return outcome
+```
+
+Change `worker_status`:
+```python
+def worker_status(repo_path: str, pid_name: str = "worker") -> dict:
+    pid = get_worker_pid(repo_path, pid_name)
+    if pid is None:
+        return {"running": False, "pid": None}
+    if is_worker_running(pid):
+        return {"running": True, "pid": pid}
+    return {"running": False, "pid": pid, "stale": True}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestNamedWorker -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run existing async_worker tests to check backwards compatibility**
+
+Run: `uv run pytest tests/ -k "worker" -v`
+Expected: All existing tests still pass (default `pid_name="worker"` is backwards-compatible)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/async_worker.py tests/test_decision_hooks.py
+git commit -m "feat(async_worker): add pid_name parameter for named worker slots"
+```
+
+---
+
+### Task 3: Implement `maybe_check_stale_decisions` (SessionEnd stale check)
+
+**Files:**
+- Create: `src/entirecontext/hooks/decision_hooks.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+from unittest.mock import patch
+from entirecontext.core.decisions import create_decision, link_decision_to_file, get_decision
+
+
+class TestMaybeCheckStaleDecisions:
+    def test_disabled_by_config(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.load_config",
+            lambda _: {"decisions": {"auto_stale_check": False}},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        # Should not raise, should not touch DB
+        maybe_check_stale_decisions(str(ec_repo))
+
+    def test_no_decisions_early_return(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.load_config",
+            lambda _: {"decisions": {"auto_stale_check": True}},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))
+        # No error, no decisions to check
+
+    def test_stale_detection_updates_status(self, ec_repo, ec_db, monkeypatch):
+        import subprocess
+
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.load_config",
+            lambda _: {"decisions": {"auto_stale_check": True}},
+        )
+        # Create a decision and link a file
+        d = create_decision(ec_db, title="Test decision")
+        test_file = ec_repo / "src" / "app.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("x = 1")
+        link_decision_to_file(ec_db, d["id"], "src/app.py")
+
+        # Make a git commit that changes the linked file
+        subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(ec_repo), "commit", "-m", "change app"],
+            check=True, capture_output=True,
+        )
+
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))
+
+        updated = get_decision(ec_db, d["id"])
+        assert updated["staleness_status"] == "stale"
+
+    def test_exception_does_not_propagate(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.load_config",
+            lambda _: {"decisions": {"auto_stale_check": True}},
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.list_decisions",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        # Must not raise
+        maybe_check_stale_decisions(str(ec_repo))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestMaybeCheckStaleDecisions -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'entirecontext.hooks.decision_hooks'`
+
+- [ ] **Step 3: Create `decision_hooks.py` with `maybe_check_stale_decisions`**
+
+Create `src/entirecontext/hooks/decision_hooks.py`:
+
+```python
+"""Decision-related hook functions — stale detection, extraction, context surfacing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .session_lifecycle import _find_git_root, _record_hook_warning
+
+
+def _load_decisions_config(repo_path: str) -> dict:
+    from ..core.config import load_config
+
+    config = load_config(repo_path)
+    return config.get("decisions", {})
+
+
+def maybe_check_stale_decisions(repo_path: str) -> None:
+    """Auto-detect stale decisions on SessionEnd. Never raises."""
+    try:
+        config = _load_decisions_config(repo_path)
+        if not config.get("auto_stale_check", False):
+            return
+
+        from ..core.decisions import check_staleness, list_decisions, update_decision_staleness
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            decisions = list_decisions(conn, staleness_status="fresh", limit=50)
+            for d in decisions:
+                result = check_staleness(conn, d["id"], repo_path)
+                if result["stale"]:
+                    update_decision_staleness(conn, d["id"], "stale")
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "auto_stale_check", exc)
+
+
+```
+
+Note: The monkeypatch targets in tests use the full module path (e.g., `"entirecontext.hooks.decision_hooks.load_config"`). Since `_load_decisions_config` wraps the import internally, tests monkeypatch `_load_decisions_config` directly instead of needing re-exports.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestMaybeCheckStaleDecisions -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/hooks/decision_hooks.py tests/test_decision_hooks.py
+git commit -m "feat(hooks): add maybe_check_stale_decisions for SessionEnd"
+```
+
+---
+
+### Task 4: Implement `on_session_start_decisions` (SessionStart surfacing)
+
+**Files:**
+- Modify: `src/entirecontext/hooks/decision_hooks.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+import subprocess as _subprocess
+
+
+class TestOnSessionStartDecisions:
+    def test_disabled_by_config(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": False},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None
+
+    def test_no_related_decisions_returns_none(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None
+
+    def test_related_decisions_shown(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        # Create decision linked to a file
+        d = create_decision(ec_db, title="Arch decision")
+        link_decision_to_file(ec_db, d["id"], "src/app.py")
+
+        # Make git history with that file
+        test_file = ec_repo / "src" / "app.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("x = 1")
+        _subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
+        _subprocess.run(
+            ["git", "-C", str(ec_repo), "commit", "-m", "add app"],
+            check=True, capture_output=True,
+        )
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        assert "Arch decision" in result
+        assert "Related Decisions" in result
+
+    def test_stale_decisions_shown(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        create_decision(ec_db, title="Stale one", staleness_status="stale")
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        assert "Stale Decisions" in result
+        assert "Stale one" in result
+
+    def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        for i in range(8):
+            create_decision(ec_db, title=f"Stale {i}", staleness_status="stale")
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        # Count decision entries (lines starting with "- [")
+        entries = [line for line in result.split("\n") if line.strip().startswith("- [")]
+        assert len(entries) <= 5
+
+    def test_git_failure_returns_none(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        # Monkeypatch subprocess to fail AND no stale decisions
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=1, stdout=""),
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestOnSessionStartDecisions -v`
+Expected: FAIL with `ImportError: cannot import name 'on_session_start_decisions'`
+
+- [ ] **Step 3: Implement `on_session_start_decisions`**
+
+Add to `src/entirecontext/hooks/decision_hooks.py`:
+
+```python
+import re
+import subprocess
+
+
+def _get_recently_changed_files(repo_path: str) -> list[str]:
+    """Get files changed in recent commits. Falls back to git log if git diff fails."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD~5..HEAD"],
+            cwd=repo_path, capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [f for f in result.stdout.strip().split("\n") if f]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["git", "log", "--name-only", "--pretty=format:", "-5"],
+            cwd=repo_path, capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return list({f for f in result.stdout.strip().split("\n") if f})
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    return []
+
+
+def _format_decision_entry(d: dict, stale: bool = False) -> str:
+    """Format a single decision as Markdown list item."""
+    id_prefix = d["id"][:8]
+    title = d.get("title", "")
+    status = "STALE" if stale else d.get("staleness_status", "fresh")
+    rationale = d.get("rationale", "") or ""
+    rationale_short = rationale[:120] + "..." if len(rationale) > 120 else rationale
+    files = ", ".join(d.get("files", [])[:3])
+    parts = [f"- [{id_prefix}] {title}"]
+    parts.append(f"  Status: {status}")
+    if files:
+        parts.append(f"  Files: {files}")
+    if rationale_short:
+        parts.append(f"  Rationale: {rationale_short}")
+    return "\n".join(parts)
+
+
+def on_session_start_decisions(data: dict[str, Any]) -> str | None:
+    """Surface related and stale decisions at session start. Never raises."""
+    try:
+        cwd = data.get("cwd", ".")
+        repo_path = _find_git_root(cwd)
+        if not repo_path:
+            return None
+
+        config = _load_decisions_config(repo_path)
+        if not config.get("show_related_on_start", False):
+            return None
+
+        from ..core.decisions import get_decision, list_decisions
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            sections = []
+            seen_ids: set[str] = set()
+
+            # 1. Recently changed files → linked decisions
+            changed_files = _get_recently_changed_files(repo_path)
+            if changed_files:
+                related = list_decisions(conn, limit=50)
+                file_related = []
+                for d in related:
+                    if d["id"] in seen_ids:
+                        continue
+                    linked_files = d.get("files") or []
+                    if not linked_files:
+                        full = get_decision(conn, d["id"])
+                        linked_files = full.get("files", []) if full else []
+                    if set(linked_files) & set(changed_files):
+                        file_related.append(d if d.get("files") else (get_decision(conn, d["id"]) or d))
+                        seen_ids.add(d["id"])
+
+                if file_related:
+                    entries = [_format_decision_entry(d) for d in file_related[:5]]
+                    sections.append(
+                        "## Related Decisions\n\n"
+                        "The following decisions are linked to recently changed files:\n\n"
+                        + "\n\n".join(entries)
+                    )
+
+            # 2. Stale decisions
+            stale = list_decisions(conn, staleness_status="stale", limit=10)
+            stale_new = [d for d in stale if d["id"] not in seen_ids]
+            remaining = 5 - len(seen_ids)
+            if stale_new and remaining > 0:
+                stale_entries = []
+                for d in stale_new[:remaining]:
+                    full = get_decision(conn, d["id"]) or d
+                    stale_entries.append(_format_decision_entry(full, stale=True))
+                    seen_ids.add(d["id"])
+                sections.append(
+                    "## Stale Decisions (action needed)\n\n"
+                    + "\n\n".join(stale_entries)
+                    + "\n\nConsider updating stale decisions or marking them as superseded."
+                )
+
+            if not sections:
+                return None
+
+            return "\n\n".join(sections)
+        finally:
+            conn.close()
+    except Exception as exc:
+        try:
+            repo_path = _find_git_root(data.get("cwd", "."))
+            if repo_path:
+                _record_hook_warning(repo_path, "session_start_decisions", exc)
+        except Exception:
+            pass
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestOnSessionStartDecisions -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/hooks/decision_hooks.py tests/test_decision_hooks.py
+git commit -m "feat(hooks): add on_session_start_decisions for context surfacing"
+```
+
+---
+
+### Task 5: Implement `maybe_extract_decisions` (SessionEnd background extraction)
+
+**Files:**
+- Modify: `src/entirecontext/hooks/decision_hooks.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+import json
+from entirecontext.core.session import create_session
+from entirecontext.core.turn import create_turn
+
+
+class TestMaybeExtractDecisions:
+    def _setup_session_with_summaries(self, ec_db, summaries):
+        """Helper: create session with turns that have given summaries."""
+        session = create_session(ec_db, session_type="claude", workspace_path="/tmp")
+        for i, summary in enumerate(summaries):
+            turn = create_turn(ec_db, session_id=session["id"], user_message=f"msg {i}")
+            ec_db.execute(
+                "UPDATE turns SET assistant_summary = ?, turn_status = 'completed' WHERE id = ?",
+                (summary, turn["id"]),
+            )
+        ec_db.commit()
+        return session
+
+    def test_disabled_by_config(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": False, "extract_keywords": ["decided"]},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), "fake-session-id")
+
+    def test_no_keyword_matches_no_worker(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["just a normal conversation"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+
+    def test_keyword_match_launches_worker(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(kw) or 0,
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.worker_status",
+            lambda *a, **kw: {"running": False, "pid": None},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 1
+
+    def test_worker_already_running_skips(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.worker_status",
+            lambda *a, **kw: {"running": True, "pid": 999},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+
+    def test_idempotency_marker_skips(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        # Set marker
+        ec_db.execute(
+            "UPDATE sessions SET metadata = ? WHERE id = ?",
+            (json.dumps({"decisions_extracted": True}), session["id"]),
+        )
+        ec_db.commit()
+
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestMaybeExtractDecisions -v`
+Expected: FAIL with `ImportError: cannot import name 'maybe_extract_decisions'`
+
+- [ ] **Step 3: Implement `maybe_extract_decisions`**
+
+Add to `src/entirecontext/hooks/decision_hooks.py`:
+
+```python
+from ..core.async_worker import launch_worker, worker_status
+
+
+def _session_has_extraction_marker(conn, session_id: str) -> bool:
+    """Check if session metadata has decisions_extracted flag."""
+    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if not row or not row["metadata"]:
+        return False
+    try:
+        import json
+        meta = json.loads(row["metadata"])
+        return meta.get("decisions_extracted", False) is True
+    except (ValueError, TypeError):
+        return False
+
+
+def _summaries_match_keywords(summaries: list[str], keywords: list[str]) -> bool:
+    """Check if any summary matches any keyword."""
+    if not keywords:
+        return False
+    pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
+    return any(pattern.search(s) for s in summaries)
+
+
+def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
+    """Launch background decision extraction if keywords match. Never raises."""
+    try:
+        config = _load_decisions_config(repo_path)
+        if not config.get("auto_extract", False):
+            return
+
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            # Idempotency check
+            if _session_has_extraction_marker(conn, session_id):
+                return
+
+            # Collect summaries
+            rows = conn.execute(
+                "SELECT assistant_summary FROM turns "
+                "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+                "ORDER BY turn_number ASC",
+                (session_id,),
+            ).fetchall()
+            summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+            if not summaries:
+                return
+
+            # Keyword gate
+            keywords = config.get("extract_keywords", [])
+            if not _summaries_match_keywords(summaries, keywords):
+                return
+
+            # Check worker slot
+            if worker_status(repo_path, pid_name="worker-decision").get("running"):
+                return
+
+            # Launch background worker
+            import sys
+            launch_worker(
+                repo_path,
+                [sys.executable, "-m", "entirecontext.cli", "decision", "extract-from-session", session_id],
+                pid_name="worker-decision",
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "auto_extract_decisions", exc)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestMaybeExtractDecisions -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/hooks/decision_hooks.py tests/test_decision_hooks.py
+git commit -m "feat(hooks): add maybe_extract_decisions with keyword gate and background worker"
+```
+
+---
+
+### Task 6: Implement `extract-from-session` CLI command
+
+**Files:**
+- Modify: `src/entirecontext/cli/decisions_cmds.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+class TestExtractFromSessionCLI:
+    def _setup_session_with_turns(self, ec_db, turn_data):
+        """Helper: create session with turns. turn_data = [(summary, files_touched), ...]"""
+        session = create_session(ec_db, session_type="claude", workspace_path="/tmp")
+        for i, (summary, files) in enumerate(turn_data):
+            turn = create_turn(ec_db, session_id=session["id"], user_message=f"msg {i}")
+            ec_db.execute(
+                "UPDATE turns SET assistant_summary = ?, files_touched = ?, turn_status = 'completed' WHERE id = ?",
+                (summary, json.dumps(files) if files else None, turn["id"]),
+            )
+        ec_db.commit()
+        return session
+
+    def test_creates_decisions_from_llm_response(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided to use Redis for caching", ["src/cache.py"]),
+        ])
+        llm_response = json.dumps([
+            {"title": "Use Redis for caching", "rationale": "Fast in-memory store", "scope": "caching", "rejected_alternatives": ["memcached"]},
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        titles = [d["title"] for d in decisions]
+        assert "Use Redis for caching" in titles
+
+        # Check idempotency marker
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is True
+
+    def test_auto_links_files(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided to use Redis", ["src/cache.py", "src/config.py"]),
+        ])
+        llm_response = json.dumps([
+            {"title": "Use Redis", "rationale": "Fast", "scope": "cache", "rejected_alternatives": []},
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        d = get_decision(ec_db, decisions[0]["id"])
+        assert "src/cache.py" in d.get("files", [])
+
+    def test_empty_array_sets_marker(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided nothing", []),
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: "[]",
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is True
+
+    def test_invalid_json_no_marker(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided something", []),
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: "not json at all",
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is not True
+
+    def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("Many decisions decided", []),
+        ])
+        llm_response = json.dumps([
+            {"title": f"Decision {i}", "rationale": "r", "scope": "s", "rejected_alternatives": []}
+            for i in range(8)
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        assert len(decisions) <= 5
+
+    def test_idempotency_second_run_skips(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided X", []),
+        ])
+        call_count = []
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: (call_count.append(1), "[]")[1],
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        assert len(call_count) == 1  # LLM called only once
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestExtractFromSessionCLI -v`
+Expected: FAIL with `ImportError: cannot import name '_extract_from_session_impl'`
+
+- [ ] **Step 3: Implement in `decisions_cmds.py`**
+
+Add to `src/entirecontext/cli/decisions_cmds.py`, before the `register` function:
+
+```python
+def _get_llm_response(summaries: str, repo_path: str) -> str:
+    """Call LLM to extract decisions. Separated for testability."""
+    from ..core.config import load_config
+    from ..core.llm import get_backend
+
+    config = load_config(repo_path)
+    backend_name = config.get("futures", {}).get("default_backend", "openai")
+    model = config.get("futures", {}).get("default_model", None)
+    backend = get_backend(backend_name, model=model)
+
+    system = (
+        "Extract architectural/technical decisions from this coding session. "
+        "Return a JSON array: [{\"title\": str, \"rationale\": str, \"scope\": str, \"rejected_alternatives\": [str]}] "
+        "Only include actual decisions (choosing one approach over another), "
+        "not tasks, plans, or status updates. "
+        "Return [] if no decisions were made."
+    )
+    return backend.complete(system, summaries)
+
+
+def _extract_from_session_impl(conn, session_id: str, repo_path: str) -> None:
+    """Core extraction logic. Used by CLI command and testable directly."""
+    import json as _json
+    import re
+
+    from ..core.config import load_config
+    from ..core.decisions import create_decision, link_decision_to_file
+
+    # Idempotency check
+    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if row and row["metadata"]:
+        try:
+            meta = _json.loads(row["metadata"])
+            if meta.get("decisions_extracted") is True:
+                return
+        except (ValueError, TypeError):
+            pass
+
+    # Collect summaries with files
+    rows = conn.execute(
+        "SELECT assistant_summary, files_touched FROM turns "
+        "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+        "ORDER BY turn_number ASC",
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return
+
+    summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+    all_files: set[str] = set()
+    for r in rows:
+        if r["files_touched"]:
+            try:
+                files = _json.loads(r["files_touched"])
+                if isinstance(files, list):
+                    all_files.update(files)
+            except (ValueError, TypeError):
+                pass
+
+    # Keyword filter
+    config = load_config(repo_path)
+    keywords = config.get("decisions", {}).get("extract_keywords", [])
+    if keywords:
+        pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
+        summaries = [s for s in summaries if pattern.search(s)]
+    if not summaries:
+        return
+
+    # LLM call
+    combined = "\n".join(summaries)
+    raw = _get_llm_response(combined, repo_path)
+
+    # Parse
+    try:
+        decisions_data = _json.loads(raw)
+    except (ValueError, TypeError):
+        console.print(f"[yellow]Invalid JSON from LLM, skipping extraction[/yellow]")
+        return
+
+    if not isinstance(decisions_data, list):
+        return
+
+    # Truncate to 5
+    decisions_data = decisions_data[:5]
+
+    # Create decisions
+    for item in decisions_data:
+        try:
+            if not isinstance(item, dict) or "title" not in item:
+                continue
+            d = create_decision(
+                conn,
+                title=item["title"],
+                rationale=item.get("rationale"),
+                scope=item.get("scope"),
+                rejected_alternatives=item.get("rejected_alternatives"),
+            )
+            # Auto-link files
+            for f in all_files:
+                try:
+                    link_decision_to_file(conn, d["id"], f)
+                except Exception:
+                    pass
+        except Exception:
+            continue
+
+    # Set idempotency marker (null-safe)
+    conn.execute(
+        "UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), '$.decisions_extracted', json('true')) WHERE id = ?",
+        (session_id,),
+    )
+    conn.commit()
+
+
+@decision_app.command("extract-from-session")
+def decision_extract_from_session(
+    session_id: str = typer.Argument(..., help="Session ID to extract decisions from"),
+):
+    """Extract decisions from a session using LLM (background worker target)."""
+    conn = _get_repo_connection()
+    try:
+        from ..core.project import find_git_root
+
+        repo_path = find_git_root()
+        if not repo_path:
+            console.print("[red]Not in a git repository.[/red]")
+            raise typer.Exit(1)
+        _extract_from_session_impl(conn, session_id, repo_path)
+    except Exception as exc:
+        console.print(f"[red]Extraction failed: {exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestExtractFromSessionCLI -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/cli/decisions_cmds.py tests/test_decision_hooks.py
+git commit -m "feat(cli): add extract-from-session command with idempotency and auto file linking"
+```
+
+---
+
+### Task 7: Wire hooks into handler and session_lifecycle
+
+**Files:**
+- Modify: `src/entirecontext/hooks/handler.py`
+- Modify: `src/entirecontext/hooks/session_lifecycle.py`
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_decision_hooks.py`:
+
+```python
+import io
+import sys
+
+
+class TestHandlerIntegration:
+    def test_session_start_prints_decisions(self, ec_repo, ec_db, monkeypatch):
+        """Verify _handle_session_start prints decision context to stdout."""
+        create_decision(ec_db, title="Integration test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+
+        from entirecontext.hooks.handler import _handle_session_start
+
+        captured = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", captured)
+        _handle_session_start({"cwd": str(ec_repo), "session_id": "test-session"})
+        output = captured.getvalue()
+        assert "Integration test decision" in output
+
+    def test_session_end_calls_decision_hooks(self, ec_repo, ec_db, monkeypatch, isolated_global_db):
+        from entirecontext.core.session import create_session
+
+        session = create_session(ec_db, session_type="claude", workspace_path=str(ec_repo))
+        stale_called = []
+        extract_called = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.session_lifecycle.maybe_check_stale_decisions",
+            lambda rp: stale_called.append(rp),
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.session_lifecycle.maybe_extract_decisions",
+            lambda rp, sid: extract_called.append((rp, sid)),
+        )
+        from entirecontext.hooks.handler import _handle_session_end
+
+        _handle_session_end({"cwd": str(ec_repo), "session_id": session["id"]})
+        assert len(stale_called) == 1
+        assert len(extract_called) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestHandlerIntegration -v`
+Expected: FAIL (hooks not wired yet)
+
+- [ ] **Step 3: Modify `handler.py` — print decision context on SessionStart**
+
+In `src/entirecontext/hooks/handler.py`, change `_handle_session_start`:
+
+```python
+def _handle_session_start(data: dict[str, Any]) -> int:
+    from .session_lifecycle import on_session_start
+
+    on_session_start(data)
+
+    try:
+        from .decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions(data)
+        if result:
+            print(result)
+    except Exception:
+        pass
+    return 0
+```
+
+- [ ] **Step 4: Modify `session_lifecycle.py` — call decision hooks on SessionEnd**
+
+In `src/entirecontext/hooks/session_lifecycle.py`, at the end of `on_session_end` (after line 280), add:
+
+```python
+    _maybe_check_stale_decisions(repo_path)
+    _maybe_extract_decisions(repo_path, session_id)
+```
+
+And add these wrapper functions at the bottom of the file (before the final empty line):
+
+```python
+def _maybe_check_stale_decisions(repo_path: str) -> None:
+    try:
+        from .decision_hooks import maybe_check_stale_decisions
+        maybe_check_stale_decisions(repo_path)
+    except Exception as exc:
+        _record_hook_warning(repo_path, "decision_stale_dispatch", exc)
+
+
+def _maybe_extract_decisions(repo_path: str, session_id: str) -> None:
+    try:
+        from .decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(repo_path, session_id)
+    except Exception as exc:
+        _record_hook_warning(repo_path, "decision_extract_dispatch", exc)
+```
+
+Also, expose these for monkeypatching by adding at module level near the imports of `on_session_end`:
+```python
+# Re-exported for test monkeypatching
+maybe_check_stale_decisions = None  # type: ignore
+maybe_extract_decisions = None  # type: ignore
+```
+
+Wait — actually, the monkeypatch in the test patches `session_lifecycle.maybe_check_stale_decisions`. Since we use local wrapper functions `_maybe_check_stale_decisions` that import inside, the monkeypatch approach needs to target the wrapper's import. Adjust the test to monkeypatch the decision_hooks module directly instead:
+
+Update the test `test_session_end_calls_decision_hooks` to monkeypatch:
+```python
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.maybe_check_stale_decisions",
+            lambda rp: stale_called.append(rp),
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.maybe_extract_decisions",
+            lambda rp, sid: extract_called.append((rp, sid)),
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_decision_hooks.py::TestHandlerIntegration -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest -x -v`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entirecontext/hooks/handler.py src/entirecontext/hooks/session_lifecycle.py tests/test_decision_hooks.py
+git commit -m "feat(hooks): wire decision hooks into handler and session_lifecycle"
+```
+
+---
+
+### Task 8: Full integration test and cleanup
+
+**Files:**
+- Test: `tests/test_decision_hooks.py`
+
+- [ ] **Step 1: Run the complete test file**
+
+Run: `uv run pytest tests/test_decision_hooks.py -v`
+Expected: All tests pass
+
+- [ ] **Step 2: Run full test suite to check for regressions**
+
+Run: `uv run pytest -x`
+Expected: All tests pass
+
+- [ ] **Step 3: Run linter**
+
+Run: `uv run ruff check src/entirecontext/hooks/decision_hooks.py src/entirecontext/core/async_worker.py src/entirecontext/cli/decisions_cmds.py tests/test_decision_hooks.py --fix`
+Expected: No errors (or auto-fixed)
+
+- [ ] **Step 4: Run formatter**
+
+Run: `uv run ruff format src/entirecontext/hooks/decision_hooks.py src/entirecontext/core/async_worker.py src/entirecontext/cli/decisions_cmds.py tests/test_decision_hooks.py`
+Expected: Files formatted
+
+- [ ] **Step 5: Commit any formatting fixes**
+
+```bash
+git add -u
+git commit -m "style: format decision hooks code"
+```
+
+- [ ] **Step 6: Final full test run**
+
+Run: `uv run pytest -x -v`
+Expected: All tests pass

--- a/docs/superpowers/plans/2026-04-04-decision-hooks.md
+++ b/docs/superpowers/plans/2026-04-04-decision-hooks.md
@@ -1175,11 +1175,11 @@ class TestHandlerIntegration:
         stale_called = []
         extract_called = []
         monkeypatch.setattr(
-            "entirecontext.hooks.session_lifecycle.maybe_check_stale_decisions",
+            "entirecontext.hooks.decision_hooks.maybe_check_stale_decisions",
             lambda rp: stale_called.append(rp),
         )
         monkeypatch.setattr(
-            "entirecontext.hooks.session_lifecycle.maybe_extract_decisions",
+            "entirecontext.hooks.decision_hooks.maybe_extract_decisions",
             lambda rp, sid: extract_called.append((rp, sid)),
         )
         from entirecontext.hooks.handler import _handle_session_end
@@ -1243,17 +1243,7 @@ def _maybe_extract_decisions(repo_path: str, session_id: str) -> None:
         _record_hook_warning(repo_path, "decision_extract_dispatch", exc)
 ```
 
-The test monkeypatches the `decision_hooks` module directly (not `session_lifecycle`) since the wrappers use deferred imports. Update `test_session_end_calls_decision_hooks` test monkeypatch targets:
-```python
-        monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.maybe_check_stale_decisions",
-            lambda rp: stale_called.append(rp),
-        )
-        monkeypatch.setattr(
-            "entirecontext.hooks.decision_hooks.maybe_extract_decisions",
-            lambda rp, sid: extract_called.append((rp, sid)),
-        )
-```
+Note: The test monkeypatches `decision_hooks` module directly (not `session_lifecycle`) since the wrappers use deferred imports inside try/except.
 
 - [ ] **Step 5: Run tests to verify they pass**
 

--- a/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
+++ b/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
@@ -96,7 +96,7 @@ Consider updating stale decisions or marking them as superseded.
 - Markdown format — parseable by Claude, Codex, Gemini, Copilot
 - 0 decisions → no output (no noise)
 - Max 5 decisions (context budget)
-- `git diff` failure → fallback to `git log`, then `_record_hook_warning`, return None
+- `git diff` failure → fallback to `git log`. Only if `git log` also fails → `_record_hook_warning`, return None
 
 ## Hook 2: SessionEnd — Stale Auto-Detection
 
@@ -194,8 +194,8 @@ Runs in background. No hook timeout constraint.
      This ensures auto-extracted decisions are discoverable by
      SessionStart relevance and stale checks.
    - On individual failure: skip, continue to next
-8. Set idempotency marker:
-   - UPDATE sessions SET metadata = json_set(metadata, '$.decisions_extracted', true)
+8. Set idempotency marker (null-safe):
+   - UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), '$.decisions_extracted', true)
      WHERE id = ?
 ```
 

--- a/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
+++ b/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
@@ -1,0 +1,232 @@
+# Decision Hooks — Auto-Detection, Extraction & Context Surfacing
+
+**Date:** 2026-04-04
+**Status:** Approved
+**Scope:** hooks/decision_hooks.py, config, tests
+
+## Summary
+
+Add three decision-related hooks to EntireContext that automate the decision lifecycle:
+
+1. **SessionStart** — Surface related and stale decisions as agent context
+2. **SessionEnd (stale)** — Auto-detect stale decisions via git diff
+3. **SessionEnd (extract)** — Hybrid keyword + LLM extraction of decisions from session turns
+
+All hooks follow the existing `_maybe_*` pattern: config-gated, try/except wrapped, never crash the hook chain.
+
+## Architecture
+
+### New file
+
+`src/entirecontext/hooks/decision_hooks.py` — all three hook functions.
+
+Rationale: `session_lifecycle.py` is already 490 lines. Separate file follows the Architecture decision to separate responsibility boundaries (decision `7f791f28`).
+
+### Integration points
+
+```
+handler.py
+  SessionStart → session_lifecycle.on_session_start()
+                   └── decision_hooks.on_session_start_decisions()
+
+  SessionEnd   → session_lifecycle.on_session_end()
+                   ├── ... (existing _maybe_* chain)
+                   ├── decision_hooks.maybe_check_stale_decisions()
+                   └── decision_hooks.maybe_extract_decisions()
+```
+
+`on_session_end()` calls the two new functions at the end of its `_maybe_*` chain. `on_session_start()` calls `on_session_start_decisions()` after session creation/resume.
+
+### Config additions
+
+```toml
+[decisions]
+auto_stale_check = false
+auto_extract = false
+show_related_on_start = false
+extract_keywords = ["결정", "선택", "방식으로", "decided", "chose", "approach", "instead of"]
+```
+
+All default **off**. Added to `DEFAULT_CONFIG` in `core/config.py`.
+
+## Hook 1: SessionStart — Related Decision Surfacing
+
+### Function: `on_session_start_decisions(data) -> str | None`
+
+Returns text to be included in hook stdout (agent context). Returns `None` when nothing to show.
+
+### Flow
+
+1. Check config `decisions.show_related_on_start` — return if disabled
+2. Run `git diff --name-only HEAD~5` to get recently changed files
+3. Query `decision_files` table for decisions linked to those files
+4. Query `list_decisions(staleness_status="stale")` for stale decisions
+5. Deduplicate (a decision may appear in both sets)
+6. Format as Markdown and return
+
+### Output format (agent-agnostic)
+
+```markdown
+## Related Decisions
+
+The following decisions are linked to recently changed files:
+
+- [7f791f28] Architecture: Separate sync/MCP/cross-repo responsibility boundaries
+  Status: fresh | Files: sync/coordinator.py, mcp/server.py
+  Rationale: ...
+
+## Stale Decisions (action needed)
+
+- [629f4a79] Documentation: Emphasize product wedge over feature inventory
+  Status: STALE | Changed: README.md (since 2026-03-11)
+  Rationale: ...
+
+Consider updating stale decisions or marking them as superseded.
+```
+
+- Markdown format — parseable by Claude, Codex, Gemini, Copilot
+- 0 decisions → no output (no noise)
+- Max 5 decisions (context budget)
+- `git diff` failure → `_record_hook_warning`, return None
+
+## Hook 2: SessionEnd — Stale Auto-Detection
+
+### Function: `maybe_check_stale_decisions(repo_path: str) -> None`
+
+### Flow
+
+1. Check config `decisions.auto_stale_check` — return if disabled
+2. `list_decisions(conn, staleness_status="fresh", limit=50)`
+3. For each: `check_staleness(conn, decision_id, repo_path)`
+4. If stale: `update_decision_staleness(conn, decision_id, "stale")`
+
+### Constraints
+
+- Limit 50 fresh decisions per run (performance)
+- Each `check_staleness` runs `git log` subprocess — already has 10s timeout
+- All exceptions caught → `_record_hook_warning(repo_path, "auto_stale_check", exc)`
+
+## Hook 3: SessionEnd — Hybrid Decision Extraction
+
+### Function: `maybe_extract_decisions(repo_path: str, session_id: str) -> None`
+
+### Flow
+
+```
+1. Config gate: decisions.auto_extract
+2. Collect turn summaries:
+   SELECT assistant_summary FROM turns
+   WHERE session_id = ? AND assistant_summary IS NOT NULL
+   ORDER BY turn_number ASC
+3. Keyword filter (1st pass):
+   - Compile config extract_keywords as regex pattern (OR-joined)
+   - Match against each summary
+   - 0 matches → early return (no LLM call)
+4. LLM extraction (2nd pass):
+   - Use existing futures.default_backend / futures.default_model
+   - System prompt:
+     "Extract architectural/technical decisions from this coding session.
+      Return a JSON array: [{title, rationale, scope, rejected_alternatives}]
+      Only include actual decisions (choosing one approach over another),
+      not tasks, plans, or status updates.
+      Return [] if no decisions were made."
+   - Input: matched summaries joined with newlines
+5. Parse JSON response:
+   - Invalid JSON → _record_hook_warning, return
+   - Empty array → return
+   - Truncate to max 5 items
+6. For each extracted decision:
+   - create_decision(conn, title=..., rationale=..., scope=...)
+   - On individual failure: skip, continue to next
+```
+
+### Safety guards
+
+- Config default off
+- Keyword gate prevents unnecessary LLM calls
+- Max 5 decisions per session
+- Invalid LLM response → warning, no crash
+- LLM network failure → warning, no crash
+- Each decision creation is independent — one failure doesn't block others
+
+## Config Integration
+
+In `core/config.py` `DEFAULT_CONFIG`:
+
+```python
+"decisions": {
+    "auto_stale_check": False,
+    "auto_extract": False,
+    "show_related_on_start": False,
+    "extract_keywords": [
+        "결정", "선택", "방식으로",
+        "decided", "chose", "approach", "instead of",
+    ],
+},
+```
+
+Follows TOML deep merge: defaults ← global config ← per-repo config.
+
+## Test Strategy
+
+### Test file: `tests/test_decision_hooks.py`
+
+### SessionStart tests
+
+| Case | Expected |
+|------|----------|
+| Changed files linked to decisions | Markdown output with Related Decisions section |
+| Changed files, no linked decisions | None output |
+| Stale decisions exist | Stale Decisions section included |
+| Config disabled | None output, no DB/git calls |
+| git subprocess failure | Warning recorded, None output |
+
+### SessionEnd stale check tests
+
+| Case | Expected |
+|------|----------|
+| Fresh decision, linked file changed | Status updated to stale |
+| Fresh decision, no file changes | Status stays fresh |
+| Config disabled | No DB queries |
+| 0 decisions | Early return |
+
+### SessionEnd LLM extraction tests
+
+| Case | Expected |
+|------|----------|
+| 0 keyword matches | No LLM call, early return |
+| Keywords match, LLM returns valid JSON | Decisions created |
+| Keywords match, LLM returns empty array | No decisions created |
+| Keywords match, LLM returns invalid JSON | Warning recorded, no crash |
+| Keywords match, LLM call fails (network) | Warning recorded, no crash |
+| LLM returns >5 decisions | Only first 5 created |
+
+### Mock targets
+
+- `subprocess.run` — git commands
+- `LLM backend.complete()` — LLM calls
+- DB — real SQLite via existing `ec_db` fixture
+
+## Error Handling
+
+All functions follow the existing `_maybe_*` contract:
+
+```python
+def maybe_check_stale_decisions(repo_path: str) -> None:
+    try:
+        # ... logic
+    except Exception as exc:
+        _record_hook_warning(repo_path, "auto_stale_check", exc)
+```
+
+**No decision hook function ever propagates exceptions.** Hook failure must never block session start/end.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/entirecontext/hooks/decision_hooks.py` | NEW — all 3 hook functions |
+| `src/entirecontext/hooks/handler.py` | `_handle_session_start` prints `on_session_start_decisions()` return value to stdout when non-None |
+| `src/entirecontext/hooks/session_lifecycle.py` | Add calls to `maybe_check_stale_decisions` and `maybe_extract_decisions` at end of `on_session_end` |
+| `src/entirecontext/core/config.py` | Add `decisions` section to `DEFAULT_CONFIG` |
+| `tests/test_decision_hooks.py` | NEW — test suite |

--- a/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
+++ b/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
@@ -55,10 +55,13 @@ All default **off**. Added to `DEFAULT_CONFIG` in `core/config.py`.
 
 Returns text to be included in hook stdout (agent context). Returns `None` when nothing to show.
 
+**stdout contract verification:** The hook handler (`_handle_session_start`) will `print()` the returned string. Claude Code hooks capture stdout as `additionalContext` injected into the agent's system prompt. This is the same mechanism used by the existing SessionStart hook output. For non-Claude agents (Codex, Gemini, Copilot), the hook output appears in their respective context injection paths — the Markdown format is deliberately agent-agnostic so that any agent that receives the text can parse it. A dedicated integration test will verify that the return value is correctly printed to stdout.
+
 ### Flow
 
 1. Check config `decisions.show_related_on_start` — return if disabled
-2. Run `git diff --name-only HEAD~5` to get recently changed files
+2. Run `git diff --name-only HEAD~5..HEAD` to get recently changed files (explicit range, not relative ref)
+   - Falls back to `git log --name-only --pretty=format: -5` if diff fails (e.g. shallow clone with <5 commits)
 3. Query `decision_files` table for decisions linked to those files
 4. Query `list_decisions(staleness_status="stale")` for stale decisions
 5. Deduplicate (a decision may appear in both sets)
@@ -87,7 +90,7 @@ Consider updating stale decisions or marking them as superseded.
 - Markdown format — parseable by Claude, Codex, Gemini, Copilot
 - 0 decisions → no output (no noise)
 - Max 5 decisions (context budget)
-- `git diff` failure → `_record_hook_warning`, return None
+- `git diff` failure → fallback to `git log`, then `_record_hook_warning`, return None
 
 ## Hook 2: SessionEnd — Stale Auto-Detection
 
@@ -106,23 +109,38 @@ Consider updating stale decisions or marking them as superseded.
 - Each `check_staleness` runs `git log` subprocess — already has 10s timeout
 - All exceptions caught → `_record_hook_warning(repo_path, "auto_stale_check", exc)`
 
-## Hook 3: SessionEnd — Hybrid Decision Extraction
+## Hook 3: SessionEnd — Hybrid Decision Extraction (Background)
 
 ### Function: `maybe_extract_decisions(repo_path: str, session_id: str) -> None`
+
+**Critical constraint:** SessionEnd hook timeout is **5 seconds** (`project_cmds.py:246`). LLM calls take 10-120 seconds. Therefore LLM extraction MUST run as a **background process**, following the same pattern as `_maybe_trigger_auto_sync` which uses `async_worker.launch_worker`.
 
 ### Flow
 
 ```
 1. Config gate: decisions.auto_extract
-2. Collect turn summaries:
+2. Collect turn summaries (inline, fast — DB query only):
    SELECT assistant_summary FROM turns
    WHERE session_id = ? AND assistant_summary IS NOT NULL
    ORDER BY turn_number ASC
-3. Keyword filter (1st pass):
+3. Keyword filter (1st pass, inline):
    - Compile config extract_keywords as regex pattern (OR-joined)
    - Match against each summary
-   - 0 matches → early return (no LLM call)
-4. LLM extraction (2nd pass):
+   - 0 matches → early return (no background process spawned)
+4. Launch background worker:
+   - launch_worker(repo_path, [sys.executable, "-m", "entirecontext.cli",
+     "decision", "extract-from-session", session_id])
+   - Returns immediately (PID recorded in .entirecontext/worker.pid)
+```
+
+### New CLI command: `ec decision extract-from-session <session_id>`
+
+Runs in background. No hook timeout constraint.
+
+```
+1. Load config, open DB
+2. Collect matched turn summaries (same query as above)
+3. LLM extraction:
    - Use existing futures.default_backend / futures.default_model
    - System prompt:
      "Extract architectural/technical decisions from this coding session.
@@ -131,11 +149,11 @@ Consider updating stale decisions or marking them as superseded.
       not tasks, plans, or status updates.
       Return [] if no decisions were made."
    - Input: matched summaries joined with newlines
-5. Parse JSON response:
-   - Invalid JSON → _record_hook_warning, return
-   - Empty array → return
+4. Parse JSON response:
+   - Invalid JSON → log warning, exit
+   - Empty array → exit
    - Truncate to max 5 items
-6. For each extracted decision:
+5. For each extracted decision:
    - create_decision(conn, title=..., rationale=..., scope=...)
    - On individual failure: skip, continue to next
 ```
@@ -143,11 +161,13 @@ Consider updating stale decisions or marking them as superseded.
 ### Safety guards
 
 - Config default off
-- Keyword gate prevents unnecessary LLM calls
+- Keyword gate prevents unnecessary background process spawns
+- LLM call runs in background — never blocks hook chain
 - Max 5 decisions per session
 - Invalid LLM response → warning, no crash
 - LLM network failure → warning, no crash
 - Each decision creation is independent — one failure doesn't block others
+- If worker is already running (`worker_status`), skip to avoid contention
 
 ## Config Integration
 
@@ -179,7 +199,9 @@ Follows TOML deep merge: defaults ← global config ← per-repo config.
 | Changed files, no linked decisions | None output |
 | Stale decisions exist | Stale Decisions section included |
 | Config disabled | None output, no DB/git calls |
-| git subprocess failure | Warning recorded, None output |
+| git diff failure | Fallback to git log |
+| git log also fails | Warning recorded, None output |
+| stdout output is printed by handler | Verify `_handle_session_start` prints non-None return |
 
 ### SessionEnd stale check tests
 
@@ -194,12 +216,14 @@ Follows TOML deep merge: defaults ← global config ← per-repo config.
 
 | Case | Expected |
 |------|----------|
-| 0 keyword matches | No LLM call, early return |
-| Keywords match, LLM returns valid JSON | Decisions created |
-| Keywords match, LLM returns empty array | No decisions created |
-| Keywords match, LLM returns invalid JSON | Warning recorded, no crash |
-| Keywords match, LLM call fails (network) | Warning recorded, no crash |
-| LLM returns >5 decisions | Only first 5 created |
+| 0 keyword matches | No background process spawned |
+| Keywords match | Background worker launched via launch_worker |
+| Worker already running | Skip, no second worker |
+| CLI extract-from-session: LLM returns valid JSON | Decisions created |
+| CLI extract-from-session: LLM returns empty array | No decisions created |
+| CLI extract-from-session: LLM returns invalid JSON | Warning logged, clean exit |
+| CLI extract-from-session: LLM call fails (network) | Warning logged, clean exit |
+| CLI extract-from-session: LLM returns >5 decisions | Only first 5 created |
 
 ### Mock targets
 
@@ -225,8 +249,9 @@ def maybe_check_stale_decisions(repo_path: str) -> None:
 
 | File | Change |
 |------|--------|
-| `src/entirecontext/hooks/decision_hooks.py` | NEW — all 3 hook functions |
+| `src/entirecontext/hooks/decision_hooks.py` | NEW — all 3 hook functions (SessionStart inline, SessionEnd stale inline, SessionEnd extract launches background) |
 | `src/entirecontext/hooks/handler.py` | `_handle_session_start` prints `on_session_start_decisions()` return value to stdout when non-None |
 | `src/entirecontext/hooks/session_lifecycle.py` | Add calls to `maybe_check_stale_decisions` and `maybe_extract_decisions` at end of `on_session_end` |
 | `src/entirecontext/core/config.py` | Add `decisions` section to `DEFAULT_CONFIG` |
+| `src/entirecontext/cli/decisions_cmds.py` | Add `extract-from-session` subcommand (background worker target) |
 | `tests/test_decision_hooks.py` | NEW — test suite |

--- a/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
+++ b/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
@@ -55,7 +55,13 @@ All default **off**. Added to `DEFAULT_CONFIG` in `core/config.py`.
 
 Returns text to be included in hook stdout (agent context). Returns `None` when nothing to show.
 
-**stdout contract verification:** The hook handler (`_handle_session_start`) will `print()` the returned string. Claude Code hooks capture stdout as `additionalContext` injected into the agent's system prompt. This is the same mechanism used by the existing SessionStart hook output. For non-Claude agents (Codex, Gemini, Copilot), the hook output appears in their respective context injection paths — the Markdown format is deliberately agent-agnostic so that any agent that receives the text can parse it. A dedicated integration test will verify that the return value is correctly printed to stdout.
+**stdout contract (design assumption — to be validated):** The hook handler (`_handle_session_start`) will `print()` the returned string. The assumption is that Claude Code hooks capture stdout as `additionalContext` injected into the agent's system prompt. However, the current codebase has no prior example of SessionStart hooks producing stdout output (`handler.py:76` is a bare dispatch), and `docs/spec.md` does not formally define stdout injection semantics. This assumption MUST be validated during implementation:
+
+1. Add an integration test that verifies `_handle_session_start` prints the return value to stdout
+2. Manually verify that Claude Code surfaces the output as `additionalContext` in a real session
+3. If stdout injection does not work, fall back to writing a `.entirecontext/decisions-context.md` file that agents can read via their file-reading tools
+
+The Markdown format is deliberately agent-agnostic so that any agent receiving the text can parse it.
 
 ### Flow
 
@@ -113,24 +119,47 @@ Consider updating stale decisions or marking them as superseded.
 
 ### Function: `maybe_extract_decisions(repo_path: str, session_id: str) -> None`
 
-**Critical constraint:** SessionEnd hook timeout is **5 seconds** (`project_cmds.py:246`). LLM calls take 10-120 seconds. Therefore LLM extraction MUST run as a **background process**, following the same pattern as `_maybe_trigger_auto_sync` which uses `async_worker.launch_worker`.
+**Critical constraint:** SessionEnd hook timeout is **5 seconds** (`project_cmds.py:246`). LLM calls take 10-120 seconds. Therefore LLM extraction MUST run as a **background process**.
+
+### Worker slot contention
+
+The current `async_worker` uses a single `worker.pid` file per repo. `auto_embed` already occupies this slot (`session_lifecycle.py:458`). To avoid contention without over-engineering:
+
+- **Use a named PID file**: `decision_hooks.py` uses `.entirecontext/worker-decision.pid` instead of the shared `worker.pid`. Introduce a `pid_name` parameter to `launch_worker` (or use a thin wrapper that writes to a decision-specific PID file).
+- **Check decision-specific PID**: `worker_status` checks `.entirecontext/worker-decision.pid` only.
+- This keeps the existing `auto_embed` worker unaffected and avoids building a full queue system (YAGNI).
+
+### Idempotency
+
+To prevent duplicate decision extraction when the hook re-fires or the worker retries:
+
+- Before launching the background worker, check for an **extraction marker** in session metadata:
+  `sessions.metadata` JSON field gets `"decisions_extracted": true` after successful extraction.
+- The `extract-from-session` CLI command checks this marker at startup and exits early if already set.
+- The marker is set AFTER all decisions are created (not before), so a crashed extraction can be retried.
 
 ### Flow
 
 ```
 1. Config gate: decisions.auto_extract
-2. Collect turn summaries (inline, fast — DB query only):
+2. Idempotency check:
+   - SELECT metadata FROM sessions WHERE id = ?
+   - If metadata contains "decisions_extracted": true → early return
+3. Collect turn summaries (inline, fast — DB query only):
    SELECT assistant_summary FROM turns
    WHERE session_id = ? AND assistant_summary IS NOT NULL
    ORDER BY turn_number ASC
-3. Keyword filter (1st pass, inline):
+4. Keyword filter (1st pass, inline):
    - Compile config extract_keywords as regex pattern (OR-joined)
    - Match against each summary
    - 0 matches → early return (no background process spawned)
-4. Launch background worker:
-   - launch_worker(repo_path, [sys.executable, "-m", "entirecontext.cli",
-     "decision", "extract-from-session", session_id])
-   - Returns immediately (PID recorded in .entirecontext/worker.pid)
+5. Check decision-specific worker status:
+   - If worker-decision.pid is running → early return
+6. Launch background worker:
+   - launch to worker-decision.pid
+   - Command: [sys.executable, "-m", "entirecontext.cli",
+     "decision", "extract-from-session", session_id]
+   - Returns immediately
 ```
 
 ### New CLI command: `ec decision extract-from-session <session_id>`
@@ -139,8 +168,13 @@ Runs in background. No hook timeout constraint.
 
 ```
 1. Load config, open DB
-2. Collect matched turn summaries (same query as above)
-3. LLM extraction:
+2. Idempotency check (same as above — guard against race)
+3. Collect turn summaries with files_touched data:
+   SELECT assistant_summary, files_touched FROM turns
+   WHERE session_id = ? AND assistant_summary IS NOT NULL
+   ORDER BY turn_number ASC
+4. Keyword filter (re-run, since this is a separate process)
+5. LLM extraction:
    - Use existing futures.default_backend / futures.default_model
    - System prompt:
      "Extract architectural/technical decisions from this coding session.
@@ -149,13 +183,20 @@ Runs in background. No hook timeout constraint.
       not tasks, plans, or status updates.
       Return [] if no decisions were made."
    - Input: matched summaries joined with newlines
-4. Parse JSON response:
+6. Parse JSON response:
    - Invalid JSON → log warning, exit
-   - Empty array → exit
+   - Empty array → mark extracted, exit
    - Truncate to max 5 items
-5. For each extracted decision:
+7. For each extracted decision:
    - create_decision(conn, title=..., rationale=..., scope=...)
+   - Auto-link files: collect all files_touched from session turns,
+     call link_decision_to_file for each unique file path.
+     This ensures auto-extracted decisions are discoverable by
+     SessionStart relevance and stale checks.
    - On individual failure: skip, continue to next
+8. Set idempotency marker:
+   - UPDATE sessions SET metadata = json_set(metadata, '$.decisions_extracted', true)
+     WHERE id = ?
 ```
 
 ### Safety guards
@@ -163,11 +204,13 @@ Runs in background. No hook timeout constraint.
 - Config default off
 - Keyword gate prevents unnecessary background process spawns
 - LLM call runs in background — never blocks hook chain
+- Named PID file (`worker-decision.pid`) — no contention with auto_embed
+- Idempotency marker prevents duplicate extraction on re-fire/retry
+- Auto-linked files from `files_touched` — extracted decisions participate in lifecycle
 - Max 5 decisions per session
 - Invalid LLM response → warning, no crash
 - LLM network failure → warning, no crash
 - Each decision creation is independent — one failure doesn't block others
-- If worker is already running (`worker_status`), skip to avoid contention
 
 ## Config Integration
 
@@ -217,13 +260,18 @@ Follows TOML deep merge: defaults ← global config ← per-repo config.
 | Case | Expected |
 |------|----------|
 | 0 keyword matches | No background process spawned |
-| Keywords match | Background worker launched via launch_worker |
-| Worker already running | Skip, no second worker |
-| CLI extract-from-session: LLM returns valid JSON | Decisions created |
-| CLI extract-from-session: LLM returns empty array | No decisions created |
-| CLI extract-from-session: LLM returns invalid JSON | Warning logged, clean exit |
-| CLI extract-from-session: LLM call fails (network) | Warning logged, clean exit |
-| CLI extract-from-session: LLM returns >5 decisions | Only first 5 created |
+| Keywords match | Background worker launched to worker-decision.pid |
+| Decision worker already running | Skip, no second worker |
+| Embed worker running (different PID) | Decision worker still launches |
+| Session already has decisions_extracted marker | Early return, no worker |
+| CLI: LLM returns valid JSON | Decisions created + files auto-linked |
+| CLI: LLM returns empty array | No decisions, marker still set |
+| CLI: LLM returns invalid JSON | Warning logged, no marker set (retryable) |
+| CLI: LLM call fails (network) | Warning logged, no marker set (retryable) |
+| CLI: LLM returns >5 decisions | Only first 5 created |
+| CLI: Same session extracted twice | Second run exits early (marker check) |
+| CLI: files_touched present on turns | Linked to created decisions |
+| CLI: files_touched empty | Decisions created without file links |
 
 ### Mock targets
 
@@ -249,9 +297,10 @@ def maybe_check_stale_decisions(repo_path: str) -> None:
 
 | File | Change |
 |------|--------|
-| `src/entirecontext/hooks/decision_hooks.py` | NEW — all 3 hook functions (SessionStart inline, SessionEnd stale inline, SessionEnd extract launches background) |
+| `src/entirecontext/hooks/decision_hooks.py` | NEW — all 3 hook functions (SessionStart inline, SessionEnd stale inline, SessionEnd extract launches background via named PID) |
 | `src/entirecontext/hooks/handler.py` | `_handle_session_start` prints `on_session_start_decisions()` return value to stdout when non-None |
 | `src/entirecontext/hooks/session_lifecycle.py` | Add calls to `maybe_check_stale_decisions` and `maybe_extract_decisions` at end of `on_session_end` |
 | `src/entirecontext/core/config.py` | Add `decisions` section to `DEFAULT_CONFIG` |
-| `src/entirecontext/cli/decisions_cmds.py` | Add `extract-from-session` subcommand (background worker target) |
-| `tests/test_decision_hooks.py` | NEW — test suite |
+| `src/entirecontext/core/async_worker.py` | Add `pid_name` parameter to `launch_worker` / `worker_status` (or thin wrapper in decision_hooks.py) |
+| `src/entirecontext/cli/decisions_cmds.py` | Add `extract-from-session` subcommand with idempotency check and auto file linking |
+| `tests/test_decision_hooks.py` | NEW — test suite including idempotency, worker contention, and file linking tests |

--- a/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
+++ b/docs/superpowers/specs/2026-04-04-decision-hooks-design.md
@@ -55,13 +55,12 @@ All default **off**. Added to `DEFAULT_CONFIG` in `core/config.py`.
 
 Returns text to be included in hook stdout (agent context). Returns `None` when nothing to show.
 
-**stdout contract (design assumption — to be validated):** The hook handler (`_handle_session_start`) will `print()` the returned string. The assumption is that Claude Code hooks capture stdout as `additionalContext` injected into the agent's system prompt. However, the current codebase has no prior example of SessionStart hooks producing stdout output (`handler.py:76` is a bare dispatch), and `docs/spec.md` does not formally define stdout injection semantics. This assumption MUST be validated during implementation:
+**Dual output strategy:** The hook uses two output channels simultaneously:
 
-1. Add an integration test that verifies `_handle_session_start` prints the return value to stdout
-2. Manually verify that Claude Code surfaces the output as `additionalContext` in a real session
-3. If stdout injection does not work, fall back to writing a `.entirecontext/decisions-context.md` file that agents can read via their file-reading tools
+1. **stdout** — `_handle_session_start` prints the returned string. Claude Code hooks capture stdout as `additionalContext` injected into the agent's system prompt.
+2. **File fallback** — `.entirecontext/decisions-context.md` is always written alongside stdout. Agents that don't capture hook stdout (Codex, Gemini, Copilot) can read this file via their file-reading tools. The file is cleaned up (deleted) when there are no relevant decisions.
 
-The Markdown format is deliberately agent-agnostic so that any agent receiving the text can parse it.
+This dual approach eliminates the need for a "validate then fallback" branch — both channels are always active, and the Markdown format is agent-agnostic so any agent receiving the text can parse it.
 
 ### Flow
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -362,5 +362,137 @@ def decision_stale_all():
         console.print(f"\n[yellow]{stale_count}/{len(decisions)} decisions marked as stale.[/yellow]")
 
 
+def _get_llm_response(summaries: str, repo_path: str) -> str:
+    """Call LLM to extract decisions. Separated for testability."""
+    from ..core.config import load_config
+    from ..core.llm import get_backend
+
+    config = load_config(repo_path)
+    backend_name = config.get("futures", {}).get("default_backend", "openai")
+    model = config.get("futures", {}).get("default_model", None)
+    backend = get_backend(backend_name, model=model)
+
+    system = (
+        "Extract architectural/technical decisions from this coding session. "
+        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, "rejected_alternatives": [str]}] '
+        "Only include actual decisions (choosing one approach over another), "
+        "not tasks, plans, or status updates. "
+        "Return [] if no decisions were made."
+    )
+    return backend.complete(system, summaries)
+
+
+def _extract_from_session_impl(conn, session_id: str, repo_path: str) -> None:
+    """Core extraction logic. Used by CLI command and testable directly."""
+    import json as _json
+    import re
+
+    from ..core.config import load_config
+    from ..core.decisions import create_decision, link_decision_to_file
+
+    # Idempotency check
+    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if row and row["metadata"]:
+        try:
+            meta = _json.loads(row["metadata"])
+            if meta.get("decisions_extracted") is True:
+                return
+        except (ValueError, TypeError):
+            pass
+
+    # Collect summaries with files
+    rows = conn.execute(
+        "SELECT assistant_summary, files_touched FROM turns "
+        "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+        "ORDER BY turn_number ASC",
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return
+
+    summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+    all_files: set[str] = set()
+    for r in rows:
+        if r["files_touched"]:
+            try:
+                files = _json.loads(r["files_touched"])
+                if isinstance(files, list):
+                    all_files.update(files)
+            except (ValueError, TypeError):
+                pass
+
+    # Keyword filter
+    config = load_config(repo_path)
+    keywords = config.get("decisions", {}).get("extract_keywords", [])
+    if keywords:
+        pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
+        summaries = [s for s in summaries if pattern.search(s)]
+    if not summaries:
+        return
+
+    # LLM call
+    combined = "\n".join(summaries)
+    raw = _get_llm_response(combined, repo_path)
+
+    # Parse
+    try:
+        decisions_data = _json.loads(raw)
+    except (ValueError, TypeError):
+        console.print("[yellow]Invalid JSON from LLM, skipping extraction[/yellow]")
+        return
+
+    if not isinstance(decisions_data, list):
+        return
+
+    decisions_data = decisions_data[:5]
+
+    for item in decisions_data:
+        try:
+            if not isinstance(item, dict) or "title" not in item:
+                continue
+            d = create_decision(
+                conn,
+                title=item["title"],
+                rationale=item.get("rationale"),
+                scope=item.get("scope"),
+                rejected_alternatives=item.get("rejected_alternatives"),
+            )
+            for f in all_files:
+                try:
+                    link_decision_to_file(conn, d["id"], f)
+                except Exception:
+                    pass
+        except Exception:
+            continue
+
+    # Set idempotency marker (null-safe)
+    conn.execute(
+        "UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), '$.decisions_extracted', json('true')) WHERE id = ?",
+        (session_id,),
+    )
+    conn.commit()
+
+
+@decision_app.command("extract-from-session")
+def decision_extract_from_session(
+    session_id: str = typer.Argument(..., help="Session ID to extract decisions from"),
+):
+    """Extract decisions from a session using LLM (background worker target)."""
+    conn = _get_repo_connection()
+    try:
+        from ..core.project import find_git_root
+
+        repo_path = find_git_root()
+        if not repo_path:
+            console.print("[red]Not in a git repository.[/red]")
+            raise typer.Exit(1)
+        _extract_from_session_impl(conn, session_id, repo_path)
+    except Exception as exc:
+        console.print(f"[red]Extraction failed: {exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
+
+
 def register(app: typer.Typer) -> None:
     app.add_typer(decision_app, name="decision")

--- a/src/entirecontext/core/async_worker.py
+++ b/src/entirecontext/core/async_worker.py
@@ -19,17 +19,17 @@ import subprocess
 from pathlib import Path
 
 
-def _pid_file(repo_path: str) -> Path:
+def _pid_file(repo_path: str, pid_name: str = "worker") -> Path:
     """Return the path to the worker PID file."""
-    return Path(repo_path) / ".entirecontext" / "worker.pid"
+    return Path(repo_path) / ".entirecontext" / f"{pid_name}.pid"
 
 
-def get_worker_pid(repo_path: str) -> int | None:
+def get_worker_pid(repo_path: str, pid_name: str = "worker") -> int | None:
     """Read the worker PID from the PID file.
 
     Returns None if the file does not exist or contains invalid content.
     """
-    pid_path = _pid_file(repo_path)
+    pid_path = _pid_file(repo_path, pid_name)
     if not pid_path.exists():
         return None
     try:
@@ -57,21 +57,22 @@ def is_worker_running(pid: int) -> bool:
         return True
 
 
-def launch_worker(repo_path: str, cmd: list[str]) -> int:
+def launch_worker(repo_path: str, cmd: list[str], pid_name: str = "worker") -> int:
     """Launch *cmd* as a detached background process and record its PID.
 
     The child process is started with ``start_new_session=True`` so it is
     detached from the parent's terminal and process group.  Its PID is
-    written to ``<repo>/.entirecontext/worker.pid``.
+    written to ``<repo>/.entirecontext/<pid_name>.pid``.
 
     Args:
         repo_path: Absolute path to the git repository root.
         cmd: Command + arguments to execute (passed directly to ``Popen``).
+        pid_name: Base name for the PID file (default: ``"worker"``).
 
     Returns:
         The PID of the launched process.
     """
-    pid_path = _pid_file(repo_path)
+    pid_path = _pid_file(repo_path, pid_name)
     pid_path.parent.mkdir(parents=True, exist_ok=True)
 
     proc = subprocess.Popen(
@@ -84,7 +85,7 @@ def launch_worker(repo_path: str, cmd: list[str]) -> int:
     return proc.pid
 
 
-def stop_worker(repo_path: str) -> str:
+def stop_worker(repo_path: str, pid_name: str = "worker") -> str:
     """Send SIGTERM to the worker and remove the PID file.
 
     Returns a string indicating the outcome:
@@ -96,7 +97,7 @@ def stop_worker(repo_path: str) -> str:
         PermissionError: if the worker process exists but SIGTERM cannot be
             delivered due to OS permission restrictions.
     """
-    pid = get_worker_pid(repo_path)
+    pid = get_worker_pid(repo_path, pid_name)
     if pid is None:
         return "none"
 
@@ -108,7 +109,7 @@ def stop_worker(repo_path: str) -> str:
         outcome = "stale"
     # PermissionError propagates so the caller knows the stop failed.
 
-    pid_path = _pid_file(repo_path)
+    pid_path = _pid_file(repo_path, pid_name)
     try:
         pid_path.unlink()
     except OSError:
@@ -117,7 +118,7 @@ def stop_worker(repo_path: str) -> str:
     return outcome
 
 
-def worker_status(repo_path: str) -> dict:
+def worker_status(repo_path: str, pid_name: str = "worker") -> dict:
     """Return a dict describing the current worker state.
 
     Keys:
@@ -126,7 +127,7 @@ def worker_status(repo_path: str) -> dict:
         ``stale`` (bool, optional): Present and True when a PID file exists
             but the referenced process is no longer alive.
     """
-    pid = get_worker_pid(repo_path)
+    pid = get_worker_pid(repo_path, pid_name)
     if pid is None:
         return {"running": False, "pid": None}
 

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -66,6 +66,15 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "default_backend": "openai",
         "default_model": "gpt-4o-mini",
     },
+    "decisions": {
+        "auto_stale_check": False,
+        "auto_extract": False,
+        "show_related_on_start": False,
+        "extract_keywords": [
+            "결정", "선택", "방식으로",
+            "decided", "chose", "approach", "instead of",
+        ],
+    },
 }
 
 

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from .session_lifecycle import _find_git_root, _record_hook_warning
+from .session_lifecycle import _record_hook_warning
 
 
 def _load_decisions_config(repo_path: str) -> dict:

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -1,0 +1,37 @@
+"""Decision-related hook functions — stale detection, extraction, context surfacing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .session_lifecycle import _find_git_root, _record_hook_warning
+
+
+def _load_decisions_config(repo_path: str) -> dict:
+    from ..core.config import load_config
+
+    config = load_config(repo_path)
+    return config.get("decisions", {})
+
+
+def maybe_check_stale_decisions(repo_path: str) -> None:
+    """Auto-detect stale decisions on SessionEnd. Never raises."""
+    try:
+        config = _load_decisions_config(repo_path)
+        if not config.get("auto_stale_check", False):
+            return
+
+        from ..core.decisions import check_staleness, list_decisions, update_decision_staleness
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            decisions = list_decisions(conn, staleness_status="fresh", limit=50)
+            for d in decisions:
+                result = check_staleness(conn, d["id"], repo_path)
+                if result["stale"]:
+                    update_decision_staleness(conn, d["id"], "stale")
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "auto_stale_check", exc)

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -45,7 +45,10 @@ def _get_recently_changed_files(repo_path: str) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", "HEAD~5..HEAD"],
-            cwd=repo_path, capture_output=True, text=True, timeout=5,
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
             return [f for f in result.stdout.strip().split("\n") if f]
@@ -55,7 +58,10 @@ def _get_recently_changed_files(repo_path: str) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "log", "--name-only", "--pretty=format:", "-5"],
-            cwd=repo_path, capture_output=True, text=True, timeout=5,
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
             return list({f for f in result.stdout.strip().split("\n") if f})
@@ -121,8 +127,7 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                     entries = [_format_decision_entry(d) for d in file_related[:5]]
                     sections.append(
                         "## Related Decisions\n\n"
-                        "The following decisions are linked to recently changed files:\n\n"
-                        + "\n\n".join(entries)
+                        "The following decisions are linked to recently changed files:\n\n" + "\n\n".join(entries)
                     )
 
             # 2. Stale decisions

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -141,10 +141,23 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                     + "\n\nConsider updating stale decisions or marking them as superseded."
                 )
 
-            if not sections:
-                return None
+            # Write fallback file for agents that don't capture stdout
+            from pathlib import Path
 
-            return "\n\n".join(sections)
+            fallback_path = Path(repo_path) / ".entirecontext" / "decisions-context.md"
+            if sections:
+                output = "\n\n".join(sections)
+                fallback_path.parent.mkdir(parents=True, exist_ok=True)
+                fallback_path.write_text(output, encoding="utf-8")
+                return output
+            else:
+                # Clean up stale fallback file
+                if fallback_path.exists():
+                    try:
+                        fallback_path.unlink()
+                    except OSError:
+                        pass
+                return None
         finally:
             conn.close()
     except Exception as exc:

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from .session_lifecycle import _record_hook_warning
+import subprocess
+from typing import Any
+
+from .session_lifecycle import _find_git_root, _record_hook_warning
 
 
 def _load_decisions_config(repo_path: str) -> dict:
@@ -33,3 +36,120 @@ def maybe_check_stale_decisions(repo_path: str) -> None:
             conn.close()
     except Exception as exc:
         _record_hook_warning(repo_path, "auto_stale_check", exc)
+
+
+def _get_recently_changed_files(repo_path: str) -> list[str]:
+    """Get files changed in recent commits. Falls back to git log if both fail, records warning."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD~5..HEAD"],
+            cwd=repo_path, capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [f for f in result.stdout.strip().split("\n") if f]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["git", "log", "--name-only", "--pretty=format:", "-5"],
+            cwd=repo_path, capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return list({f for f in result.stdout.strip().split("\n") if f})
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    _record_hook_warning(repo_path, "get_recently_changed_files", RuntimeError("both git diff and git log failed"))
+    return []
+
+
+def _format_decision_entry(d: dict, stale: bool = False) -> str:
+    id_prefix = d["id"][:8]
+    title = d.get("title", "")
+    status = "STALE" if stale else d.get("staleness_status", "fresh")
+    rationale = d.get("rationale", "") or ""
+    rationale_short = rationale[:120] + "..." if len(rationale) > 120 else rationale
+    files = ", ".join(d.get("files", [])[:3])
+    parts = [f"- [{id_prefix}] {title}"]
+    parts.append(f"  Status: {status}")
+    if files:
+        parts.append(f"  Files: {files}")
+    if rationale_short:
+        parts.append(f"  Rationale: {rationale_short}")
+    return "\n".join(parts)
+
+
+def on_session_start_decisions(data: dict[str, Any]) -> str | None:
+    """Surface related and stale decisions at session start. Never raises."""
+    try:
+        cwd = data.get("cwd", ".")
+        repo_path = _find_git_root(cwd)
+        if not repo_path:
+            return None
+
+        config = _load_decisions_config(repo_path)
+        if not config.get("show_related_on_start", False):
+            return None
+
+        from ..core.decisions import get_decision, list_decisions
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            sections = []
+            seen_ids: set[str] = set()
+
+            # 1. Recently changed files → linked decisions (DB-level file_path filter)
+            changed_files = _get_recently_changed_files(repo_path)
+            file_related = []
+            if changed_files:
+                for f in changed_files:
+                    for d in list_decisions(conn, file_path=f, limit=10):
+                        if d["id"] not in seen_ids:
+                            full = get_decision(conn, d["id"]) or d
+                            file_related.append(full)
+                            seen_ids.add(d["id"])
+                        if len(seen_ids) >= 5:
+                            break
+                    if len(seen_ids) >= 5:
+                        break
+
+                if file_related:
+                    entries = [_format_decision_entry(d) for d in file_related[:5]]
+                    sections.append(
+                        "## Related Decisions\n\n"
+                        "The following decisions are linked to recently changed files:\n\n"
+                        + "\n\n".join(entries)
+                    )
+
+            # 2. Stale decisions
+            stale = list_decisions(conn, staleness_status="stale", limit=10)
+            stale_new = [d for d in stale if d["id"] not in seen_ids]
+            remaining = 5 - len(seen_ids)
+            if stale_new and remaining > 0:
+                stale_entries = []
+                for d in stale_new[:remaining]:
+                    full = get_decision(conn, d["id"]) or d
+                    stale_entries.append(_format_decision_entry(full, stale=True))
+                    seen_ids.add(d["id"])
+                sections.append(
+                    "## Stale Decisions (action needed)\n\n"
+                    + "\n\n".join(stale_entries)
+                    + "\n\nConsider updating stale decisions or marking them as superseded."
+                )
+
+            if not sections:
+                return None
+
+            return "\n\n".join(sections)
+        finally:
+            conn.close()
+    except Exception as exc:
+        try:
+            repo_path = _find_git_root(data.get("cwd", "."))
+            if repo_path:
+                _record_hook_warning(repo_path, "session_start_decisions", exc)
+        except Exception:
+            pass
+        return None

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from typing import Any
 
+from ..core.async_worker import launch_worker, worker_status
 from .session_lifecycle import _find_git_root, _record_hook_warning
 
 
@@ -153,3 +155,67 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
         except Exception:
             pass
         return None
+
+
+def _session_has_extraction_marker(conn, session_id: str) -> bool:
+    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if not row or not row["metadata"]:
+        return False
+    try:
+        import json
+
+        meta = json.loads(row["metadata"])
+        return meta.get("decisions_extracted", False) is True
+    except (ValueError, TypeError):
+        return False
+
+
+def _summaries_match_keywords(summaries: list[str], keywords: list[str]) -> bool:
+    if not keywords:
+        return False
+    pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
+    return any(pattern.search(s) for s in summaries)
+
+
+def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
+    """Launch background decision extraction if keywords match. Never raises."""
+    try:
+        config = _load_decisions_config(repo_path)
+        if not config.get("auto_extract", False):
+            return
+
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            if _session_has_extraction_marker(conn, session_id):
+                return
+
+            rows = conn.execute(
+                "SELECT assistant_summary FROM turns "
+                "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+                "ORDER BY turn_number ASC",
+                (session_id,),
+            ).fetchall()
+            summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+            if not summaries:
+                return
+
+            keywords = config.get("extract_keywords", [])
+            if not _summaries_match_keywords(summaries, keywords):
+                return
+
+            if worker_status(repo_path, pid_name="worker-decision").get("running"):
+                return
+
+            import sys
+
+            launch_worker(
+                repo_path,
+                [sys.executable, "-m", "entirecontext.cli", "decision", "extract-from-session", session_id],
+                pid_name="worker-decision",
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "auto_extract_decisions", exc)

--- a/src/entirecontext/hooks/handler.py
+++ b/src/entirecontext/hooks/handler.py
@@ -77,6 +77,15 @@ def _handle_session_start(data: dict[str, Any]) -> int:
     from .session_lifecycle import on_session_start
 
     on_session_start(data)
+
+    try:
+        from .decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions(data)
+        if result:
+            print(result)
+    except Exception:
+        pass
     return 0
 
 

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -168,9 +168,16 @@ def _populate_session_summary(conn, session_id: str) -> None:
             updates["session_summary"] = combined[:500]
 
     if updates:
-        set_clause = ", ".join(f"{k} = ?" for k in updates)
-        values = list(updates.values()) + [session_id]
-        conn.execute(f"UPDATE sessions SET {set_clause} WHERE id = ?", values)
+        if "session_title" in updates:
+            conn.execute(
+                "UPDATE sessions SET session_title = ? WHERE id = ?",
+                (updates["session_title"], session_id),
+            )
+        if "session_summary" in updates:
+            conn.execute(
+                "UPDATE sessions SET session_summary = ? WHERE id = ?",
+                (updates["session_summary"], session_id),
+            )
         conn.commit()
 
     _maybe_generate_intent_summary(conn, session_id)
@@ -278,6 +285,8 @@ def on_session_end(data: dict[str, Any]) -> None:
     _maybe_trigger_auto_sync(repo_path)
     _maybe_trigger_auto_distill(repo_path)
     _maybe_trigger_auto_embed(repo_path)
+    _maybe_check_stale_decisions(repo_path)
+    _maybe_extract_decisions(repo_path, session_id)
 
 
 def _session_has_change_signals(conn, session_id: str) -> bool:
@@ -462,6 +471,22 @@ def _maybe_trigger_auto_embed(repo_path: str) -> None:
         launch_worker(repo_path, [sys.executable, "-m", "entirecontext.cli", "index", "rebuild", "--semantic"])
     except Exception as exc:
         _record_hook_warning(repo_path, "auto_embed", exc)
+
+
+def _maybe_check_stale_decisions(repo_path: str) -> None:
+    try:
+        from .decision_hooks import maybe_check_stale_decisions
+        maybe_check_stale_decisions(repo_path)
+    except Exception as exc:
+        _record_hook_warning(repo_path, "decision_stale_dispatch", exc)
+
+
+def _maybe_extract_decisions(repo_path: str, session_id: str) -> None:
+    try:
+        from .decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(repo_path, session_id)
+    except Exception as exc:
+        _record_hook_warning(repo_path, "decision_extract_dispatch", exc)
 
 
 def _maybe_trigger_auto_distill(repo_path: str) -> None:

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -229,7 +230,7 @@ def _maybe_generate_intent_summary(conn, session_id: str) -> None:
         conn.execute("UPDATE sessions SET session_summary = ? WHERE id = ?", (summary[:500], session_id))
         conn.commit()
     except Exception as exc:
-        _record_hook_warning(repo_path, "intent_summary", exc)
+        _record_hook_warning(project["repo_path"] if project else "unknown", "intent_summary", exc)
 
 
 def on_session_end(data: dict[str, Any]) -> None:
@@ -476,6 +477,7 @@ def _maybe_trigger_auto_embed(repo_path: str) -> None:
 def _maybe_check_stale_decisions(repo_path: str) -> None:
     try:
         from .decision_hooks import maybe_check_stale_decisions
+
         maybe_check_stale_decisions(repo_path)
     except Exception as exc:
         _record_hook_warning(repo_path, "decision_stale_dispatch", exc)
@@ -484,6 +486,7 @@ def _maybe_check_stale_decisions(repo_path: str) -> None:
 def _maybe_extract_decisions(repo_path: str, session_id: str) -> None:
     try:
         from .decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(repo_path, session_id)
     except Exception as exc:
         _record_hook_warning(repo_path, "decision_extract_dispatch", exc)

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -426,3 +426,40 @@ class TestExtractFromSessionCLI:
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
         assert len(call_count) == 1
+
+
+class TestHandlerIntegration:
+    def test_session_start_prints_decisions(self, ec_repo, ec_db, monkeypatch, capsys):
+        """Verify _handle_session_start prints decision context to stdout."""
+        create_decision(ec_db, title="Integration test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+
+        from entirecontext.hooks.handler import _handle_session_start
+
+        _handle_session_start({"cwd": str(ec_repo), "session_id": "test-session"})
+        captured = capsys.readouterr()
+        assert "Integration test decision" in captured.out
+
+    def test_session_end_calls_decision_hooks(self, ec_repo, ec_db, monkeypatch, isolated_global_db):
+        from entirecontext.core.session import create_session
+
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
+        stale_called = []
+        extract_called = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.maybe_check_stale_decisions",
+            lambda rp: stale_called.append(rp),
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.maybe_extract_decisions",
+            lambda rp, sid: extract_called.append((rp, sid)),
+        )
+        from entirecontext.hooks.handler import _handle_session_end
+
+        _handle_session_end({"cwd": str(ec_repo), "session_id": session["id"]})
+        assert len(stale_called) == 1
+        assert len(extract_called) == 1

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from entirecontext.core.async_worker import _pid_file, launch_worker, worker_status
 from entirecontext.core.config import DEFAULT_CONFIG
-from entirecontext.core.decisions import create_decision, get_decision, link_decision_to_file
+from entirecontext.core.decisions import create_decision, get_decision, link_decision_to_file, list_decisions
 from entirecontext.core.session import create_session
 from entirecontext.core.turn import create_turn
 
@@ -303,3 +303,126 @@ class TestMaybeExtractDecisions:
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 0
+
+
+class TestExtractFromSessionCLI:
+    def _setup_session_with_turns(self, ec_db, turn_data):
+        """Helper: create session with turns. turn_data = [(summary, files_touched), ...]"""
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
+        for i, (summary, files) in enumerate(turn_data):
+            turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
+            ec_db.execute(
+                "UPDATE turns SET assistant_summary = ?, files_touched = ?, turn_status = 'completed' WHERE id = ?",
+                (summary, json.dumps(files) if files else None, turn["id"]),
+            )
+        ec_db.commit()
+        return session
+
+    def test_creates_decisions_from_llm_response(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided to use Redis for caching", ["src/cache.py"]),
+        ])
+        llm_response = json.dumps([
+            {"title": "Use Redis for caching", "rationale": "Fast in-memory store", "scope": "caching", "rejected_alternatives": ["memcached"]},
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        titles = [d["title"] for d in decisions]
+        assert "Use Redis for caching" in titles
+
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is True
+
+    def test_auto_links_files(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided to use Redis", ["src/cache.py", "src/config.py"]),
+        ])
+        llm_response = json.dumps([
+            {"title": "Use Redis", "rationale": "Fast", "scope": "cache", "rejected_alternatives": []},
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        d = get_decision(ec_db, decisions[0]["id"])
+        assert "src/cache.py" in d.get("files", [])
+
+    def test_empty_array_sets_marker(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided nothing", []),
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: "[]",
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is True
+
+    def test_invalid_json_no_marker(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided something", []),
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: "not json at all",
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+        meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        assert meta.get("decisions_extracted") is not True
+
+    def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("Many decisions decided", []),
+        ])
+        llm_response = json.dumps([
+            {"title": f"Decision {i}", "rationale": "r", "scope": "s", "rejected_alternatives": []}
+            for i in range(8)
+        ])
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        decisions = list_decisions(ec_db)
+        assert len(decisions) <= 5
+
+    def test_idempotency_second_run_skips(self, ec_repo, ec_db, monkeypatch):
+        session = self._setup_session_with_turns(ec_db, [
+            ("We decided X", []),
+        ])
+        call_count = []
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: (call_count.append(1), "[]")[1],
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        assert len(call_count) == 1

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -52,3 +52,66 @@ class TestNamedWorker:
         ec_dir.mkdir()
         status = worker_status(str(tmp_path), pid_name="worker-decision")
         assert status["running"] is False
+
+
+from entirecontext.core.decisions import create_decision, link_decision_to_file, get_decision
+
+
+class TestMaybeCheckStaleDecisions:
+    def test_disabled_by_config(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": False},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))
+
+    def test_no_decisions_early_return(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))
+
+    def test_stale_detection_updates_status(self, ec_repo, ec_db, monkeypatch):
+        import subprocess
+
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
+        )
+        d = create_decision(ec_db, title="Test decision")
+        test_file = ec_repo / "src" / "app.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("x = 1")
+        link_decision_to_file(ec_db, d["id"], "src/app.py")
+
+        subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(ec_repo), "commit", "-m", "change app"],
+            check=True, capture_output=True,
+        )
+
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))
+
+        updated = get_decision(ec_db, d["id"])
+        assert updated["staleness_status"] == "stale"
+
+    def test_exception_does_not_propagate(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_stale_check": True},
+        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("entirecontext.core.decisions.list_decisions", _boom)
+        from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
+
+        maybe_check_stale_decisions(str(ec_repo))

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -463,3 +463,55 @@ class TestHandlerIntegration:
         _handle_session_end({"cwd": str(ec_repo), "session_id": session["id"]})
         assert len(stale_called) == 1
         assert len(extract_called) == 1
+
+
+class TestStdoutContract:
+    def test_handler_prints_decision_context(self, ec_repo, ec_db, monkeypatch, capsys):
+        """Verify _handle_session_start actually prints decision text to stdout."""
+        create_decision(ec_db, title="Stdout test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.handler import _handle_session_start
+
+        _handle_session_start({"cwd": str(ec_repo), "session_id": "stdout-test"})
+        captured = capsys.readouterr()
+        assert "Stdout test decision" in captured.out
+
+    def test_fallback_file_written(self, ec_repo, ec_db, monkeypatch):
+        """Verify fallback file is written alongside stdout."""
+        create_decision(ec_db, title="Fallback test decision", staleness_status="stale")
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "fb-test"})
+        assert result is not None
+
+        from pathlib import Path
+
+        fallback_path = Path(str(ec_repo)) / ".entirecontext" / "decisions-context.md"
+        assert fallback_path.exists()
+        content = fallback_path.read_text(encoding="utf-8")
+        assert "Fallback test decision" in content
+
+    def test_fallback_file_cleaned_when_no_decisions(self, ec_repo, ec_db, monkeypatch):
+        """Verify fallback file is removed when there are no decisions to show."""
+        from pathlib import Path
+
+        fallback_path = Path(str(ec_repo)) / ".entirecontext" / "decisions-context.md"
+        fallback_path.parent.mkdir(parents=True, exist_ok=True)
+        fallback_path.write_text("old content")
+
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "cleanup-test"})
+        assert result is None
+        assert not fallback_path.exists()

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from entirecontext.core.config import DEFAULT_CONFIG
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from entirecontext.core.async_worker import launch_worker, worker_status, _pid_file
 
 
 class TestDecisionConfig:
@@ -20,3 +23,33 @@ class TestDecisionConfig:
         assert isinstance(keywords, list)
         assert len(keywords) > 0
         assert "decided" in keywords
+
+
+class TestNamedWorker:
+    def test_pid_file_default_name(self, tmp_path):
+        result = _pid_file(str(tmp_path))
+        assert result == tmp_path / ".entirecontext" / "worker.pid"
+
+    def test_pid_file_custom_name(self, tmp_path):
+        result = _pid_file(str(tmp_path), pid_name="worker-decision")
+        assert result == tmp_path / ".entirecontext" / "worker-decision.pid"
+
+    def test_launch_worker_custom_pid(self, tmp_path):
+        ec_dir = tmp_path / ".entirecontext"
+        ec_dir.mkdir()
+        with patch("entirecontext.core.async_worker.subprocess.Popen") as mock_popen:
+            mock_proc = MagicMock()
+            mock_proc.pid = 12345
+            mock_popen.return_value = mock_proc
+            pid = launch_worker(str(tmp_path), ["echo", "test"], pid_name="worker-decision")
+            assert pid == 12345
+            pid_path = ec_dir / "worker-decision.pid"
+            assert pid_path.exists()
+            assert pid_path.read_text().strip() == "12345"
+            assert not (ec_dir / "worker.pid").exists()
+
+    def test_worker_status_custom_pid(self, tmp_path):
+        ec_dir = tmp_path / ".entirecontext"
+        ec_dir.mkdir()
+        status = worker_status(str(tmp_path), pid_name="worker-decision")
+        assert status["running"] is False

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import subprocess as _subprocess
 from unittest.mock import MagicMock, patch
 
 from entirecontext.core.async_worker import _pid_file, launch_worker, worker_status
 from entirecontext.core.config import DEFAULT_CONFIG
 from entirecontext.core.decisions import create_decision, get_decision, link_decision_to_file
+from entirecontext.core.session import create_session
+from entirecontext.core.turn import create_turn
 
 
 class TestDecisionConfig:
@@ -205,3 +208,98 @@ class TestOnSessionStartDecisions:
 
         result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
         assert result is None
+
+
+class TestMaybeExtractDecisions:
+    def _setup_session_with_summaries(self, ec_db, summaries):
+        project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+        session = create_session(ec_db, project_id)
+        for i, summary in enumerate(summaries):
+            turn = create_turn(ec_db, session["id"], i + 1, user_message=f"msg {i}")
+            ec_db.execute(
+                "UPDATE turns SET assistant_summary = ?, turn_status = 'completed' WHERE id = ?",
+                (summary, turn["id"]),
+            )
+        ec_db.commit()
+        return session
+
+    def test_disabled_by_config(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": False, "extract_keywords": ["decided"]},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(str(ec_repo), "fake-session-id")
+
+    def test_no_keyword_matches_no_worker(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["just a normal conversation"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+
+    def test_keyword_match_launches_worker(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(kw) or 0,
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.worker_status",
+            lambda *a, **kw: {"running": False, "pid": None},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 1
+
+    def test_worker_already_running_skips(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.worker_status",
+            lambda *a, **kw: {"running": True, "pid": 999},
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+
+    def test_idempotency_marker_skips(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"auto_extract": True, "extract_keywords": ["decided"]},
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        ec_db.execute(
+            "UPDATE sessions SET metadata = ? WHERE id = ?",
+            (json.dumps({"decisions_extracted": True}), session["id"]),
+        )
+        ec_db.commit()
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from entirecontext.core.config import DEFAULT_CONFIG
 from unittest.mock import patch, MagicMock
 from entirecontext.core.async_worker import launch_worker, worker_status, _pid_file
+from entirecontext.core.decisions import create_decision, link_decision_to_file, get_decision
 
 
 class TestDecisionConfig:
@@ -52,9 +53,6 @@ class TestNamedWorker:
         ec_dir.mkdir()
         status = worker_status(str(tmp_path), pid_name="worker-decision")
         assert status["running"] is False
-
-
-from entirecontext.core.decisions import create_decision, link_decision_to_file, get_decision
 
 
 class TestMaybeCheckStaleDecisions:

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from entirecontext.core.config import DEFAULT_CONFIG
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 from entirecontext.core.async_worker import launch_worker, worker_status, _pid_file
 

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -1,0 +1,22 @@
+"""Tests for decision hooks."""
+
+from __future__ import annotations
+
+from entirecontext.core.config import DEFAULT_CONFIG
+
+
+class TestDecisionConfig:
+    def test_decisions_section_exists(self):
+        assert "decisions" in DEFAULT_CONFIG
+
+    def test_decisions_defaults_all_off(self):
+        decisions = DEFAULT_CONFIG["decisions"]
+        assert decisions["auto_stale_check"] is False
+        assert decisions["auto_extract"] is False
+        assert decisions["show_related_on_start"] is False
+
+    def test_extract_keywords_present(self):
+        keywords = DEFAULT_CONFIG["decisions"]["extract_keywords"]
+        assert isinstance(keywords, list)
+        assert len(keywords) > 0
+        assert "decided" in keywords

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess as _subprocess
+from unittest.mock import MagicMock, patch
+
+from entirecontext.core.async_worker import _pid_file, launch_worker, worker_status
 from entirecontext.core.config import DEFAULT_CONFIG
-from unittest.mock import patch, MagicMock
-from entirecontext.core.async_worker import launch_worker, worker_status, _pid_file
-from entirecontext.core.decisions import create_decision, link_decision_to_file, get_decision
+from entirecontext.core.decisions import create_decision, get_decision, link_decision_to_file
 
 
 class TestDecisionConfig:
@@ -113,3 +115,93 @@ class TestMaybeCheckStaleDecisions:
         from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
 
         maybe_check_stale_decisions(str(ec_repo))
+
+
+class TestOnSessionStartDecisions:
+    def test_disabled_by_config(self, ec_repo, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": False},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None
+
+    def test_no_related_decisions_returns_none(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None
+
+    def test_related_decisions_shown(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        d = create_decision(ec_db, title="Arch decision")
+        link_decision_to_file(ec_db, d["id"], "src/app.py")
+
+        test_file = ec_repo / "src" / "app.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("x = 1")
+        _subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
+        _subprocess.run(
+            ["git", "-C", str(ec_repo), "commit", "-m", "add app"],
+            check=True, capture_output=True,
+        )
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        assert "Arch decision" in result
+        assert "Related Decisions" in result
+
+    def test_stale_decisions_shown(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        create_decision(ec_db, title="Stale one", staleness_status="stale")
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        assert "Stale Decisions" in result
+        assert "Stale one" in result
+
+    def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        for i in range(8):
+            create_decision(ec_db, title=f"Stale {i}", staleness_status="stale")
+
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is not None
+        entries = [line for line in result.split("\n") if line.strip().startswith("- [")]
+        assert len(entries) <= 5
+
+    def test_git_failure_returns_none(self, ec_repo, ec_db, monkeypatch):
+        from unittest.mock import MagicMock
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {"show_related_on_start": True},
+        )
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.subprocess.run",
+            lambda *a, **kw: MagicMock(returncode=1, stdout=""),
+        )
+        from entirecontext.hooks.decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        assert result is None

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -95,7 +95,8 @@ class TestMaybeCheckStaleDecisions:
         subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
         subprocess.run(
             ["git", "-C", str(ec_repo), "commit", "-m", "change app"],
-            check=True, capture_output=True,
+            check=True,
+            capture_output=True,
         )
 
         from entirecontext.hooks.decision_hooks import maybe_check_stale_decisions
@@ -155,7 +156,8 @@ class TestOnSessionStartDecisions:
         _subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
         _subprocess.run(
             ["git", "-C", str(ec_repo), "commit", "-m", "add app"],
-            check=True, capture_output=True,
+            check=True,
+            capture_output=True,
         )
 
         from entirecontext.hooks.decision_hooks import on_session_start_decisions
@@ -196,6 +198,7 @@ class TestOnSessionStartDecisions:
 
     def test_git_failure_returns_none(self, ec_repo, ec_db, monkeypatch):
         from unittest.mock import MagicMock
+
         monkeypatch.setattr(
             "entirecontext.hooks.decision_hooks._load_decisions_config",
             lambda _: {"show_related_on_start": True},
@@ -229,6 +232,7 @@ class TestMaybeExtractDecisions:
             lambda _: {"auto_extract": False, "extract_keywords": ["decided"]},
         )
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(str(ec_repo), "fake-session-id")
 
     def test_no_keyword_matches_no_worker(self, ec_repo, ec_db, monkeypatch):
@@ -243,6 +247,7 @@ class TestMaybeExtractDecisions:
             lambda *a, **kw: launched.append(1) or 0,
         )
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 0
 
@@ -262,6 +267,7 @@ class TestMaybeExtractDecisions:
             lambda *a, **kw: {"running": False, "pid": None},
         )
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 1
 
@@ -281,6 +287,7 @@ class TestMaybeExtractDecisions:
             lambda *a, **kw: {"running": True, "pid": 999},
         )
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 0
 
@@ -301,6 +308,7 @@ class TestMaybeExtractDecisions:
             lambda *a, **kw: launched.append(1) or 0,
         )
         from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 0
 
@@ -320,12 +328,22 @@ class TestExtractFromSessionCLI:
         return session
 
     def test_creates_decisions_from_llm_response(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("We decided to use Redis for caching", ["src/cache.py"]),
-        ])
-        llm_response = json.dumps([
-            {"title": "Use Redis for caching", "rationale": "Fast in-memory store", "scope": "caching", "rejected_alternatives": ["memcached"]},
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided to use Redis for caching", ["src/cache.py"]),
+            ],
+        )
+        llm_response = json.dumps(
+            [
+                {
+                    "title": "Use Redis for caching",
+                    "rationale": "Fast in-memory store",
+                    "scope": "caching",
+                    "rejected_alternatives": ["memcached"],
+                },
+            ]
+        )
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",
             lambda *a, **kw: llm_response,
@@ -343,12 +361,17 @@ class TestExtractFromSessionCLI:
         assert meta.get("decisions_extracted") is True
 
     def test_auto_links_files(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("We decided to use Redis", ["src/cache.py", "src/config.py"]),
-        ])
-        llm_response = json.dumps([
-            {"title": "Use Redis", "rationale": "Fast", "scope": "cache", "rejected_alternatives": []},
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided to use Redis", ["src/cache.py", "src/config.py"]),
+            ],
+        )
+        llm_response = json.dumps(
+            [
+                {"title": "Use Redis", "rationale": "Fast", "scope": "cache", "rejected_alternatives": []},
+            ]
+        )
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",
             lambda *a, **kw: llm_response,
@@ -362,9 +385,12 @@ class TestExtractFromSessionCLI:
         assert "src/cache.py" in d.get("files", [])
 
     def test_empty_array_sets_marker(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("We decided nothing", []),
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided nothing", []),
+            ],
+        )
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",
             lambda *a, **kw: "[]",
@@ -378,9 +404,12 @@ class TestExtractFromSessionCLI:
         assert meta.get("decisions_extracted") is True
 
     def test_invalid_json_no_marker(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("We decided something", []),
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided something", []),
+            ],
+        )
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",
             lambda *a, **kw: "not json at all",
@@ -394,13 +423,15 @@ class TestExtractFromSessionCLI:
         assert meta.get("decisions_extracted") is not True
 
     def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("Many decisions decided", []),
-        ])
-        llm_response = json.dumps([
-            {"title": f"Decision {i}", "rationale": "r", "scope": "s", "rejected_alternatives": []}
-            for i in range(8)
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("Many decisions decided", []),
+            ],
+        )
+        llm_response = json.dumps(
+            [{"title": f"Decision {i}", "rationale": "r", "scope": "s", "rejected_alternatives": []} for i in range(8)]
+        )
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",
             lambda *a, **kw: llm_response,
@@ -413,9 +444,12 @@ class TestExtractFromSessionCLI:
         assert len(decisions) <= 5
 
     def test_idempotency_second_run_skips(self, ec_repo, ec_db, monkeypatch):
-        session = self._setup_session_with_turns(ec_db, [
-            ("We decided X", []),
-        ])
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided X", []),
+            ],
+        )
         call_count = []
         monkeypatch.setattr(
             "entirecontext.cli.decisions_cmds._get_llm_response",


### PR DESCRIPTION
## Summary

- Add 3 decision-related hooks that automate the decision lifecycle:
  - **SessionStart**: Surface related and stale decisions as agent context (stdout + file fallback)
  - **SessionEnd (stale)**: Auto-detect stale decisions via git diff on linked files
  - **SessionEnd (extract)**: Hybrid keyword + LLM extraction of decisions from session turns (background worker)
- All hooks are config-gated (default off), exception-safe, and follow existing `_maybe_*` patterns
- Add `pid_name` parameter to `async_worker` for named worker slots (avoids contention with `auto_embed`)

## Changed files

| File | Change |
|------|--------|
| `src/entirecontext/hooks/decision_hooks.py` | NEW — 3 hook functions + helpers |
| `src/entirecontext/hooks/handler.py` | Print decision context on SessionStart |
| `src/entirecontext/hooks/session_lifecycle.py` | Call decision hooks at end of SessionEnd chain |
| `src/entirecontext/core/async_worker.py` | Add `pid_name` parameter (backwards-compatible) |
| `src/entirecontext/core/config.py` | Add `decisions` config section |
| `src/entirecontext/cli/decisions_cmds.py` | Add `extract-from-session` CLI command |
| `tests/test_decision_hooks.py` | NEW — 33 tests |
| `docs/superpowers/specs/` | Design spec |
| `docs/superpowers/plans/` | Implementation plan |

## Config

```toml
[decisions]
auto_stale_check = true      # SessionEnd stale detection
auto_extract = true           # SessionEnd LLM extraction
show_related_on_start = true  # SessionStart context surfacing
```

## Test plan

- [x] 33 decision hook tests pass
- [x] 1136 total tests pass (no regressions)
- [x] ruff lint/format clean
- [ ] Manual validation: enable `show_related_on_start` and verify stdout appears as `additionalContext`