### PR TITLE
feat: Add lesson retrieval guidance and decision keyword search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ The EntireContext MCP server is registered in Claude Code and provides these too
 | `ec_rewind` | Time-travel to past states | View code at a specific checkpoint |
 | `ec_assess` / `ec_assess_create` | Evaluating changes against roadmap | Assess current diff before committing |
 | `ec_assess_trends` | Cross-session trend analysis | Review verdict distribution over time |
-| `ec_lessons` | Learning from past assessments | Check distilled lessons before new work |
+| `ec_lessons` | Retrieving distilled guidance from past assessed changes | Scan lessons before work in areas with prior narrow verdicts |
+| `ec_feedback` | Providing assessment feedback for lesson accumulation | Record agree/disagree with reason after assessed work completes |
 
 ### CLI Commands for Development Workflow
 
@@ -122,7 +123,7 @@ auto_distill = true              # Auto-distill lessons from assessments
 Before implementing a feature, search for related past work:
 1. Use `ec_search` or `ec search --fts` to find relevant past turns
 2. Use `ec_related` with file paths being modified
-3. Review `ec_lessons` for applicable learnings
+3. Review `ec_lessons` for applicable learnings, especially when touching areas with prior narrow verdicts, debugging regressions, revisiting subsystems with existing feedback, or making structurally similar changes to previously assessed work
 4. Create checkpoints at meaningful milestones
 
 #### Pattern: Assessment-Driven Development
@@ -138,33 +139,47 @@ When resuming work across sessions:
 3. `ec_session_context` to get the last session's summary
 4. `ec search "specific topic"` to find exact implementation details
 
-## Decision Reuse Policy
+## Decision and Lesson Reuse Policy
 
-This repository is building decision memory for coding agents. Agents working in this repository must use stored decisions as part of the development workflow instead of treating them as optional background context.
+This repository is building decision and lesson memory for coding agents. Agents working in this repository must use stored decisions and lessons as part of the development workflow instead of treating them as optional background context.
 
-### When to check decisions
-Check for relevant prior decisions before non-trivial analysis or implementation when the task:
+### When to check decisions and lessons
+Check for relevant prior decisions and lessons before non-trivial analysis or implementation when the task:
 - changes behavior, policy, schema, or interfaces
 - touches retrieval, ranking, sync, session lifecycle, hooks, dashboard, assessments, telemetry, or decision memory
 - implements or reinterprets a roadmap item
 - revisits an area with repeated bugs, repeated refactors, or prior design discussion
 - asks why something was implemented a certain way
+- involves debugging a regression, repeated failure, or issue structurally similar to a previously assessed change
 
 ### Required workflow
 1. Retrieve relevant decisions before implementation.
 2. Read the selected decisions before proposing or applying changes.
-3. Prefer fresh decisions by default.
-4. Do not silently apply stale, contradicted, or superseded decisions.
-5. If decisions conflict, surface the conflict explicitly.
-6. If no relevant decision exists, say that clearly before proceeding.
-7. If a decision materially informed the work, record that usage.
-8. After the work completes, record whether the result confirmed, contradicted, refined, or replaced the decision.
-9. If the work creates a stable new policy or architectural judgment, create or update a decision record.
+3. Scan lessons for applicable guidance from past assessed changes, especially when the task involves debugging, regressions, repeated subsystem work, or areas with prior narrow verdicts.
+4. Prefer fresh decisions by default.
+5. Do not silently apply stale, contradicted, or superseded decisions.
+6. If decisions conflict, surface the conflict explicitly.
+7. If no relevant decision exists, say that clearly before proceeding.
+8. If a decision materially informed the work, record that usage.
+9. After the work completes, record whether the result confirmed, contradicted, refined, or replaced the decision.
+10. If the work creates a stable new policy or architectural judgment, create or update a decision record.
+11. If the completed work was previously assessed, provide agree/disagree feedback with a reason so lessons can accumulate.
 
 ### Repository-specific retrieval path
 Prefer the strongest decision-aware path available in the current environment:
 - MCP: `ec_decision_related`, `ec_decision_get`, `ec_decision_list`
 - CLI fallback: `ec decision list`, `ec decision show`, plus targeted `ec search` if needed
+
+### Lesson retrieval path
+Scan lessons before non-trivial work, especially when debugging regressions, working in areas with prior narrow verdicts, making structurally similar changes to previously assessed work, or revisiting a subsystem with existing assessment feedback.
+- MCP: `ec_lessons`
+- CLI fallback: `ec futures lessons`
+
+Lesson retrieval is a quick scan, not a targeted lookup. Review recent lessons for relevance and proceed if none apply.
+
+When providing assessment feedback after assessed work completes:
+- MCP: `ec_feedback(assessment_id, feedback, reason)`
+- CLI fallback: `ec futures feedback ASSESSMENT_ID FEEDBACK --reason REASON`
 
 ### MCP Call Discipline
 When using EntireContext MCP tools, treat the tool schema as strict and do not infer argument shapes from natural-language descriptions alone.
@@ -184,16 +199,18 @@ When the task outcome validates or invalidates a decision, record a decision out
 - CLI fallback: use the corresponding decision outcome command if available in the current installed version
 
 ### Minimum behavior
-For non-trivial tasks, do not move directly from request to implementation without a decision check unless the user explicitly asks to skip it.
+For non-trivial tasks, do not move directly from request to implementation without a decision and lesson check unless the user explicitly asks to skip it.
 
-If the agent skips the decision check, it must state that it skipped it and why.
+If the agent skips the decision and lesson check, it must state that it skipped it and why.
 
 ### Final reporting
-When decisions were relevant, the final response must include:
+When decisions or lessons were relevant, the final response must include:
 - which decisions were considered
 - which decision was applied, if any
 - which decisions were rejected or treated as stale, if any
 - whether the completed work confirmed, contradicted, superseded, or extended prior guidance
+- which lessons were reviewed, if any, and whether any influenced the approach
+- which assessments received feedback during this task, if any
 
 ### Interpretation rule
 Stored decisions are inputs to judgment, not blind rules. Follow relevant fresh decisions by default, but still verify fit against the current code, current task, and current user intent.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Scenarios to proactively use EntireContext:
 Preferred retrieval order:
 1. Decision-specific lookup (`ec_decision_related`, `ec_decision_list`, `ec_decision_get`)
 2. Broader repo memory lookup (`ec_related`, `ec_search`, `ec_session_context`)
-3. Deep inspection (`ec_turn_content`, `ec_checkpoint_list`, `ec_attribution`, `ec_lessons`, `ec_assess_trends`)
+3. Lesson retrieval (`ec_lessons`) — especially when debugging regressions, working in areas with prior narrow verdicts, or making structurally similar changes to previously assessed work
+4. Deep inspection (`ec_turn_content`, `ec_checkpoint_list`, `ec_attribution`, `ec_assess_trends`)
 
 If no relevant EntireContext records exist, state that explicitly before proceeding
 with new reasoning.
@@ -111,6 +112,20 @@ Capture timing:
 - Record **during** the session as decisions happen — do not defer to SessionEnd
 - SessionEnd auto-extraction (`maybe_extract_decisions`) is a fallback, not the primary path
 - If you realize a past session made an unrecorded decision, record it retroactively
+
+### Lesson Feedback — Building Lessons from Assessed Work
+
+Lessons accumulate from assessment feedback. Proactively provide feedback on
+assessed changes so the lesson pipeline has material to distill.
+
+When to provide feedback (`ec_feedback`):
+- Completed work was previously assessed and you can confirm or dispute the verdict
+- You observe that a past assessment's prediction was correct or incorrect
+- A debugging session reveals that a prior assessed change caused the issue
+
+Feedback timing:
+- Provide feedback as soon as you have evidence — do not defer to session end
+- Include a reason so the distilled lesson captures the context
 <!-- ENTIRECONTEXT:END -->
 ```
 

--- a/docs/templates/entirecontext-maintainer-decision-reuse-template.md
+++ b/docs/templates/entirecontext-maintainer-decision-reuse-template.md
@@ -1,4 +1,4 @@
-# EntireContext Maintainer Template: Decision Reuse Policy
+# EntireContext Maintainer Template: Decision and Lesson Reuse Policy
 
 Use this template in `AGENTS.md` for work inside the `entirecontext` repository itself.
 
@@ -7,28 +7,31 @@ It is process-neutral by design. It does not assume TDD, PR review, trunk-based 
 ## Suggested Insertion
 
 ```md
-## Decision Reuse Policy
+## Decision and Lesson Reuse Policy
 
-This repository is building decision memory for coding agents. Agents working in this repository must use stored decisions as part of the development workflow instead of treating them as optional background context.
+This repository is building decision and lesson memory for coding agents. Agents working in this repository must use stored decisions and lessons as part of the development workflow instead of treating them as optional background context.
 
-### When to check decisions
-Check for relevant prior decisions before non-trivial analysis or implementation when the task:
+### When to check decisions and lessons
+Check for relevant prior decisions and lessons before non-trivial analysis or implementation when the task:
 - changes behavior, policy, schema, or interfaces
 - touches retrieval, ranking, sync, session lifecycle, hooks, dashboard, assessments, telemetry, or decision memory
 - implements or reinterprets a roadmap item
 - revisits an area with repeated bugs, repeated refactors, or prior design discussion
 - asks why something was implemented a certain way
+- involves debugging a regression, repeated failure, or issue structurally similar to a previously assessed change
 
 ### Required workflow
 1. Retrieve relevant decisions before implementation.
 2. Read the selected decisions before proposing or applying changes.
-3. Prefer fresh decisions by default.
-4. Do not silently apply stale, contradicted, or superseded decisions.
-5. If decisions conflict, surface the conflict explicitly.
-6. If no relevant decision exists, say that clearly before proceeding.
-7. If a decision materially informed the work, record that usage.
-8. After the work completes, record whether the result confirmed, contradicted, refined, or replaced the decision.
-9. If the work creates a stable new policy or architectural judgment, create or update a decision record.
+3. Scan lessons for applicable guidance from past assessed changes, especially when the task involves debugging, regressions, repeated subsystem work, or areas with prior narrow verdicts.
+4. Prefer fresh decisions by default.
+5. Do not silently apply stale, contradicted, or superseded decisions.
+6. If decisions conflict, surface the conflict explicitly.
+7. If no relevant decision exists, say that clearly before proceeding.
+8. If a decision materially informed the work, record that usage.
+9. After the work completes, record whether the result confirmed, contradicted, refined, or replaced the decision.
+10. If the work creates a stable new policy or architectural judgment, create or update a decision record.
+11. If the completed work was previously assessed, provide agree/disagree feedback with a reason so lessons can accumulate.
 
 ### Repository-specific retrieval path
 Prefer the strongest decision-aware path available in the current environment:
@@ -43,17 +46,30 @@ When the task outcome validates or invalidates a decision, record a decision out
 - MCP: `ec_decision_outcome(...)`
 - CLI fallback: use the corresponding decision outcome command if available in the current installed version
 
-### Minimum behavior
-For non-trivial tasks, do not move directly from request to implementation without a decision check unless the user explicitly asks to skip it.
+### Lesson retrieval path
+Scan lessons before non-trivial work, especially when debugging regressions, working in areas with prior narrow verdicts, making structurally similar changes to previously assessed work, or revisiting a subsystem with existing assessment feedback.
+- MCP: `ec_lessons`
+- CLI fallback: `ec futures lessons`
 
-If the agent skips the decision check, it must state that it skipped it and why.
+Lesson retrieval is a quick scan, not a targeted lookup. Review recent lessons for relevance and proceed if none apply.
+
+When providing assessment feedback after assessed work completes:
+- MCP: `ec_feedback(assessment_id, feedback, reason)`
+- CLI fallback: `ec futures feedback ASSESSMENT_ID FEEDBACK --reason REASON`
+
+### Minimum behavior
+For non-trivial tasks, do not move directly from request to implementation without a decision and lesson check unless the user explicitly asks to skip it.
+
+If the agent skips the decision and lesson check, it must state that it skipped it and why.
 
 ### Final reporting
-When decisions were relevant, the final response must include:
+When decisions or lessons were relevant, the final response must include:
 - which decisions were considered
 - which decision was applied, if any
 - which decisions were rejected or treated as stale, if any
 - whether the completed work confirmed, contradicted, superseded, or extended prior guidance
+- which lessons were reviewed, if any, and whether any influenced the approach
+- which assessments received feedback during this task, if any
 
 ### Interpretation rule
 Stored decisions are inputs to judgment, not blind rules. Follow relevant fresh decisions by default, but still verify fit against the current code, current task, and current user intent.

--- a/docs/templates/entirecontext-user-decision-reuse-template.md
+++ b/docs/templates/entirecontext-user-decision-reuse-template.md
@@ -1,15 +1,15 @@
-# EntireContext User Template: AGENTS.md Decision Reuse Policy
+# EntireContext User Template: AGENTS.md Decision and Lesson Reuse Policy
 
-Use this template in projects that have installed and enabled EntireContext and want coding agents to reuse stored decisions consistently.
+Use this template in projects that have installed and enabled EntireContext and want coding agents to reuse stored decisions and lessons consistently.
 
 It is intentionally workflow-neutral. It works for solo repositories, small teams, PR-based workflows, direct-to-main workflows, TDD, and non-TDD processes.
 
 ## Suggested Insertion
 
 ```md
-## Decision Reuse Policy
+## Decision and Lesson Reuse Policy
 
-This project uses EntireContext to preserve engineering decisions over time. Agents must check for relevant prior decisions before making non-trivial changes so the project does not repeatedly rediscover the same judgment.
+This project uses EntireContext to preserve engineering decisions and lessons over time. Agents must check for relevant prior decisions and lessons before making non-trivial changes so the project does not repeatedly rediscover the same judgment or repeat the same mistakes.
 
 ### When this policy applies
 Use this workflow when the task materially affects behavior, architecture, policy, interfaces, data shape, or long-term maintenance cost.
@@ -22,17 +22,20 @@ Common examples:
 - repeated work in the same subsystem
 - roadmap-driven work
 - tasks where the user asks why something was done a certain way
+- debugging a regression, repeated failure, or issue similar to a previously assessed change
 
 ### Required workflow
 1. Before implementation, check whether relevant prior decisions already exist.
 2. Read relevant decisions before making or proposing non-trivial changes.
-3. Prefer fresh decisions by default.
-4. Do not silently apply stale, contradicted, or superseded decisions.
-5. If multiple decisions conflict, surface that conflict explicitly.
-6. If no relevant decision exists, say so before proceeding with new reasoning.
-7. If a prior decision materially informed the work, record that it was applied.
-8. After completing the task, record whether the result confirmed, contradicted, refined, or replaced prior guidance.
-9. If the task produces a stable new rule, policy, or architectural judgment, create or update a decision record.
+3. Scan lessons for applicable guidance from past assessed changes, especially when the task involves debugging, regressions, repeated subsystem work, or areas with prior narrow verdicts.
+4. Prefer fresh decisions by default.
+5. Do not silently apply stale, contradicted, or superseded decisions.
+6. If multiple decisions conflict, surface that conflict explicitly.
+7. If no relevant decision exists, say so before proceeding with new reasoning.
+8. If a prior decision materially informed the work, record that it was applied.
+9. After completing the task, record whether the result confirmed, contradicted, refined, or replaced prior guidance.
+10. If the task produces a stable new rule, policy, or architectural judgment, create or update a decision record.
+11. If the completed work was previously assessed, provide agree/disagree feedback with a reason so lessons can accumulate.
 
 ### Retrieval path
 Prefer decision-specific retrieval first, then broader history search only if needed.
@@ -42,17 +45,24 @@ Recommended order:
 - file- or subsystem-scoped decision listing
 - broader search across prior sessions or assessments
 
-### Minimum behavior
-For non-trivial tasks, do not jump directly from user request to implementation without first checking for relevant decisions unless the user explicitly asks to skip that step.
+### Lesson retrieval
+Scan lessons before non-trivial work, especially when debugging regressions, working in areas with prior narrow verdicts, making structurally similar changes to previously assessed work, or revisiting a subsystem with existing assessment feedback.
 
-If the agent skips the decision check, it must state that it skipped it and why.
+Lesson retrieval is a quick scan, not a targeted lookup. Review recent lessons for relevance to the current task. If no lessons exist or none are relevant, proceed without further delay.
+
+### Minimum behavior
+For non-trivial tasks, do not jump directly from user request to implementation without first checking for relevant decisions and lessons unless the user explicitly asks to skip that step.
+
+If the agent skips the decision and lesson check, it must state that it skipped it and why.
 
 ### Final reporting
-When decisions were relevant, final reporting must include:
+When decisions or lessons were relevant, final reporting must include:
 - which decisions were considered
 - which decision was applied, if any
 - which decisions were rejected or treated as stale, if any
 - whether the completed work confirmed, contradicted, superseded, or extended prior guidance
+- which lessons were reviewed, if any, and whether any influenced the approach
+- which assessments received feedback during this task, if any
 
 ### Interpretation rule
 Stored decisions are inputs to judgment, not blind rules. Agents should follow relevant fresh decisions by default, while still checking that they fit the current code, current task, and current user intent.
@@ -66,6 +76,7 @@ Teams adopting this template should adjust:
 - Which command or MCP path is preferred in their environment
 - Whether decision usage is required for medium-risk tasks or only high-risk tasks
 - Whether final reporting must always mention decision checks or only when decisions were found
+- Whether lesson checks are expected for medium-risk tasks or only high-risk tasks
 
 ## Minimal Adoption Guidance
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -305,6 +305,51 @@ def decision_unlink(
         console.print("[yellow]Link not found.[/yellow]")
 
 
+@decision_app.command("search")
+def decision_search(
+    query: str = typer.Argument(..., help='FTS5 search query (supports AND, OR, NOT, prefix*, "phrase")'),
+    search_type: str = typer.Option("fts", "--search-type", "-t", help="fts|hybrid"),
+    since: Optional[str] = typer.Option(None, "--since", help="Only decisions updated after this ISO date"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+):
+    """Search decisions by keyword."""
+    if search_type not in ("fts", "hybrid"):
+        console.print(f"[red]Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.[/red]")
+        raise typer.Exit(1)
+
+    from ..core.decisions import fts_search_decisions, hybrid_search_decisions
+
+    conn, _ = get_repo_connection()
+    try:
+        if search_type == "hybrid":
+            decisions = hybrid_search_decisions(conn, query, since=since, limit=limit)
+        else:
+            decisions = fts_search_decisions(conn, query, since=since, limit=limit)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
+
+    if not decisions:
+        console.print("[dim]No decisions found.[/dim]")
+        return
+
+    table = Table(title=f"Decision Search: '{query}' ({len(decisions)} results)")
+    table.add_column("ID", style="dim", max_width=12)
+    table.add_column("Title")
+    table.add_column("Status")
+    table.add_column("Updated")
+    if search_type == "hybrid":
+        table.add_column("Score", justify="right")
+    for d in decisions:
+        row = [d["id"][:12], d.get("title", ""), d.get("staleness_status", ""), d.get("updated_at", "")]
+        if search_type == "hybrid":
+            row.append(f"{d.get('hybrid_score', 0):.4f}")
+        table.add_row(*row)
+    console.print(table)
+
+
 @decision_app.command("stale-all")
 def decision_stale_all():
     """Check staleness for all fresh decisions and persist results."""

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -682,3 +682,70 @@ def check_staleness(conn, decision_id: str, repo_path: str) -> dict:
 
     changed_in_scope = sorted(set(linked_files) & recently_changed)
     return {"stale": len(changed_in_scope) > 0, "changed_files": changed_in_scope, "decision_id": full_id}
+
+
+# ---------------------------------------------------------------------------
+# FTS / Hybrid keyword search for decisions
+# ---------------------------------------------------------------------------
+
+
+def fts_search_decisions(
+    conn,
+    query: str,
+    *,
+    since: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """FTS5 full-text search over decision title and rationale."""
+    sql = """
+        SELECT d.id, d.title, d.rationale, d.scope, d.staleness_status,
+               d.updated_at, d.created_at, rank
+        FROM fts_decisions fd
+        JOIN decisions d ON fd.rowid = d.rowid
+        WHERE fts_decisions MATCH ?
+        AND (? IS NULL OR d.updated_at >= ?)
+        ORDER BY rank LIMIT ?
+    """
+    params: list[Any] = [query, since, since, limit]
+
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    except Exception as exc:
+        msg = str(exc)
+        if "fts5: syntax error" in msg or "parse error" in msg.lower():
+            raise ValueError(f"Invalid FTS5 query syntax: {msg}") from exc
+        raise
+
+    return [dict(r) for r in rows]
+
+
+def hybrid_search_decisions(
+    conn,
+    query: str,
+    *,
+    since: str | None = None,
+    limit: int = 20,
+    k: int = 60,
+) -> list[dict]:
+    """Hybrid search combining FTS5 relevance and recency via RRF."""
+    from .search import rrf_fuse
+
+    fts_results = fts_search_decisions(conn, query, since=since, limit=limit * 3)
+    if not fts_results:
+        return []
+
+    fts_rank_list = [r["id"] for r in fts_results]
+    id_to_ts = {r["id"]: (r.get("updated_at") or "") for r in fts_results}
+    recency_rank_list = sorted(fts_rank_list, key=lambda rid: id_to_ts.get(rid, ""), reverse=True)
+
+    scores = rrf_fuse([fts_rank_list, recency_rank_list], k=k)
+    sorted_ids = sorted(scores, key=scores.__getitem__, reverse=True)[:limit]
+
+    id_to_doc = {r["id"]: r for r in fts_results}
+    results: list[dict] = []
+    for rid in sorted_ids:
+        if rid in id_to_doc:
+            doc = dict(id_to_doc[rid])
+            doc["hybrid_score"] = round(scores[rid], 6)
+            results.append(doc)
+    return results

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -699,7 +699,7 @@ def fts_search_decisions(
     """FTS5 full-text search over decision title and rationale."""
     sql = """
         SELECT d.id, d.title, d.rationale, d.scope, d.staleness_status,
-               d.updated_at, d.created_at, rank
+               d.updated_at, d.created_at, rank, -rank AS relevance_score
         FROM fts_decisions fd
         JOIN decisions d ON fd.rowid = d.rowid
         WHERE fts_decisions MATCH ?

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -84,7 +84,15 @@ def _record_selection(
 
 
 from .tools.checkpoint import ec_checkpoint_list, ec_rewind  # noqa: E402
-from .tools.decisions import ec_decision_create, ec_decision_get, ec_decision_list, ec_decision_outcome, ec_decision_related, ec_decision_stale  # noqa: E402
+from .tools.decisions import (
+    ec_decision_create,
+    ec_decision_get,
+    ec_decision_list,
+    ec_decision_outcome,
+    ec_decision_related,
+    ec_decision_search,
+    ec_decision_stale,
+)  # noqa: E402
 from .tools.futures import ec_assess, ec_assess_create, ec_assess_trends, ec_feedback, ec_lessons  # noqa: E402
 from .tools.misc import ec_dashboard, ec_graph  # noqa: E402
 from .tools.search import ec_activate, ec_ast_search, ec_related, ec_search  # noqa: E402
@@ -130,6 +138,7 @@ __all__ = [
     "ec_decision_list",
     "ec_decision_outcome",
     "ec_decision_related",
+    "ec_decision_search",
     "ec_decision_stale",
     "run_server",
 ]

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -203,6 +203,112 @@ async def ec_decision_stale(decision_id: str) -> str:
         conn.close()
 
 
+async def ec_decision_search(
+    query: str,
+    search_type: str = "fts",
+    since: str | None = None,
+    limit: int = 20,
+    repos: list[str] | None = None,
+) -> str:
+    """Search decisions by keyword using FTS5 full-text search.
+
+    Searches decision title and rationale fields. Use this when you need to find
+    decisions by keyword rather than by file/assessment context.
+
+    Args:
+        query: FTS5 search query (supports AND, OR, NOT, prefix*, "phrase")
+        search_type: "fts" for relevance-ranked or "hybrid" for relevance+recency
+        since: ISO date filter — only return decisions updated after this date
+        limit: Maximum results (default 20)
+        repos: Repo filter — null for current repo, ["*"] for all repos
+    """
+    if search_type not in ("fts", "hybrid"):
+        return runtime.error_payload(f"Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.")
+
+    is_cross_repo = repos is not None
+    if is_cross_repo:
+        repo_names = runtime.normalize_repo_names(repos)
+        from ...core.cross_repo import _for_each_repo
+        from ...core.decisions import fts_search_decisions, hybrid_search_decisions
+
+        def _query(conn, _repo):
+            if search_type == "hybrid":
+                return hybrid_search_decisions(conn, query, since=since, limit=limit)
+            return fts_search_decisions(conn, query, since=since, limit=limit)
+
+        cross_sort_key = "hybrid_score" if search_type == "hybrid" else None
+        all_results, _warnings = _for_each_repo(_query, repos=repo_names, sort_key=cross_sort_key, limit=limit)
+        formatted = _format_decision_results(all_results)
+        return json.dumps({"decisions": formatted, "count": len(formatted), "retrieval_event_id": None})
+
+    (conn, _), error = runtime.resolve_repo()
+    if error:
+        return error
+    try:
+        from ...core.decisions import fts_search_decisions, hybrid_search_decisions
+
+        started_at = time.perf_counter()
+        if search_type == "hybrid":
+            results = hybrid_search_decisions(conn, query, since=since, limit=limit)
+        else:
+            results = fts_search_decisions(conn, query, since=since, limit=limit)
+
+        tracked_event_id = runtime.record_search_event(
+            conn,
+            query=query,
+            search_type=f"decision_{search_type}",
+            target="decision",
+            result_count=len(results),
+            latency_ms=int((time.perf_counter() - started_at) * 1000),
+            since=since,
+        )
+        for idx, item in enumerate(results, start=1):
+            runtime.record_selection(
+                conn,
+                retrieval_event_id=tracked_event_id,
+                result_type="decision",
+                result_id=item["id"],
+                rank=idx,
+            )
+        formatted = _format_decision_results(results)
+        return json.dumps(
+            {
+                "decisions": formatted,
+                "count": len(formatted),
+                "retrieval_event_id": tracked_event_id,
+            }
+        )
+    except Exception as exc:
+        return runtime.error_payload(str(exc))
+    finally:
+        conn.close()
+
+
+def _truncate(text: str, max_len: int) -> str:
+    return text if len(text) <= max_len else text[:max_len] + "…"
+
+
+def _format_decision_results(results: list[dict]) -> list[dict]:
+    formatted = []
+    for r in results:
+        entry: dict = {
+            "id": r.get("id", ""),
+            "title": r.get("title", ""),
+            "rationale_excerpt": _truncate(r.get("rationale") or "", 200),
+            "scope": r.get("scope", ""),
+            "staleness_status": r.get("staleness_status", ""),
+            "updated_at": r.get("updated_at", ""),
+        }
+        if "hybrid_score" in r:
+            entry["hybrid_score"] = r["hybrid_score"]
+        if "rank" in r:
+            entry["rank"] = r["rank"]
+        if "repo_name" in r:
+            entry["repo_name"] = r["repo_name"]
+        formatted.append(entry)
+    return formatted
+
+
 def register_tools(mcp, services=None) -> None:
     for tool in (
         ec_decision_get,
@@ -211,5 +317,6 @@ def register_tools(mcp, services=None) -> None:
         ec_decision_create,
         ec_decision_list,
         ec_decision_stale,
+        ec_decision_search,
     ):
         mcp.tool()(tool)

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -236,7 +236,7 @@ async def ec_decision_search(
                 return hybrid_search_decisions(conn, query, since=since, limit=limit)
             return fts_search_decisions(conn, query, since=since, limit=limit)
 
-        cross_sort_key = "hybrid_score" if search_type == "hybrid" else None
+        cross_sort_key = "hybrid_score" if search_type == "hybrid" else "relevance_score"
         all_results, _warnings = _for_each_repo(_query, repos=repo_names, sort_key=cross_sort_key, limit=limit)
         formatted = _format_decision_results(all_results)
         return json.dumps({"decisions": formatted, "count": len(formatted), "retrieval_event_id": None})

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -7,8 +7,10 @@ import pytest
 from entirecontext.core.decisions import (
     check_staleness,
     create_decision,
+    fts_search_decisions,
     get_decision,
     get_decision_quality_summary,
+    hybrid_search_decisions,
     link_decision_to_assessment,
     link_decision_to_checkpoint,
     link_decision_to_commit,
@@ -555,3 +557,52 @@ class TestDecisionsCoreExtended:
         matching_item = next(item for item in ranked if item["id"] == matching["id"])
         other_item = next(item for item in ranked if item["id"] == other["id"])
         assert matching_item["base_score"] > other_item["base_score"]
+
+
+class TestDecisionFTSSearch:
+    def test_fts_search_by_title(self, ec_db):
+        create_decision(ec_db, title="Use queue based webhook retries", rationale="Prevent retry storms")
+        create_decision(ec_db, title="Cache invalidation strategy", rationale="TTL-based approach")
+
+        results = fts_search_decisions(ec_db, "webhook")
+        assert len(results) == 1
+        assert results[0]["title"] == "Use queue based webhook retries"
+
+    def test_fts_search_by_rationale(self, ec_db):
+        create_decision(ec_db, title="Caching approach", rationale="Use TTL-based cache invalidation")
+
+        results = fts_search_decisions(ec_db, "invalidation")
+        assert len(results) == 1
+        assert results[0]["title"] == "Caching approach"
+
+    def test_fts_search_no_match(self, ec_db):
+        create_decision(ec_db, title="Some decision", rationale="Some rationale")
+
+        results = fts_search_decisions(ec_db, "nonexistent")
+        assert results == []
+
+    def test_fts_search_since_filter(self, ec_db):
+        create_decision(ec_db, title="Old decision", rationale="Old rationale")
+        results = fts_search_decisions(ec_db, "decision", since="2099-01-01")
+        assert results == []
+
+    def test_fts_search_limit(self, ec_db):
+        for i in range(5):
+            create_decision(ec_db, title=f"Architecture decision {i}", rationale=f"Rationale {i}")
+
+        results = fts_search_decisions(ec_db, "Architecture", limit=3)
+        assert len(results) == 3
+
+    def test_fts_search_bad_query_raises_error(self, ec_db):
+        create_decision(ec_db, title="Some decision", rationale="Some rationale")
+        with pytest.raises(ValueError, match="Invalid FTS5 query syntax"):
+            fts_search_decisions(ec_db, "AND OR NOT")
+
+    def test_hybrid_search_returns_scores(self, ec_db):
+        create_decision(ec_db, title="Migration safety", rationale="Always use reversible migrations")
+        create_decision(ec_db, title="Migration strategy", rationale="Blue-green deployment for migrations")
+
+        results = hybrid_search_decisions(ec_db, "migration")
+        assert len(results) == 2
+        assert all("hybrid_score" in r for r in results)
+        assert results[0]["hybrid_score"] >= results[1]["hybrid_score"]

--- a/tests/test_mcp_registration.py
+++ b/tests/test_mcp_registration.py
@@ -38,6 +38,7 @@ def test_register_tools_exports_expected_public_tool_names():
         "ec_decision_list",
         "ec_decision_outcome",
         "ec_decision_related",
+        "ec_decision_search",
         "ec_decision_stale",
         "ec_feedback",
         "ec_graph",


### PR DESCRIPTION
## Summary

- **Lesson retrieval guidance**: Integrate lesson retrieval into existing Decision Reuse Policy templates, README, and AGENTS.md — agents now know when to check `ec_lessons` and when to provide `ec_feedback`
- **`ec_decision_search`**: Wire existing `fts_decisions` FTS5 table into new MCP tool + CLI command for keyword-based decision search, preparatory work for #42

## Changes

### Commit 1: docs(agents) — Lesson retrieval guidance
- Rename sections to "Decision and Lesson Reuse Policy" across 4 files
- Add workflow steps 3 (scan lessons) and 11 (assessment feedback)
- Add Lesson retrieval subsections with trigger conditions
- Promote `ec_lessons` to tier 3 in README retrieval order
- Add `ec_feedback` to AGENTS.md MCP tool table

### Commit 2: feat(decisions) — `ec_decision_search`
- Core: `fts_search_decisions()` + `hybrid_search_decisions()` with RRF fusion
- MCP: `ec_decision_search` with search_type validation, cross-repo support, telemetry
- CLI: `ec decision search QUERY --search-type fts|hybrid --since DATE`
- Tests: 7 new tests (title/rationale match, no match, since filter, limit, bad query error, hybrid scores)

## Reviewed by
- Codex: plan peer review + implementation review (2 bugs fixed, 3 concerns addressed)
- Advisor: cross-repo `get_all_connections` import bug caught and fixed

## Test plan
- [x] `uv run pytest` — 1178 passed, 0 failed
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ec decision search "architecture"` — 5 results returned
- [ ] Manual MCP tool test: `ec_decision_search` via Claude Code session
- [ ] Verify lesson guidance wording consistency across all 4 doc files

Refs #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)