### PR TITLE
docs: Add Codex-derived code review principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,37 @@ Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `securit
 - ruff formatter, line-length 120, target Python 3.12
 - Type hints throughout (`from __future__ import annotations`)
 - SQLite pragmas: WAL, foreign_keys=ON, busy_timeout=5000
+
+## Code Review Principles
+
+Principles for automated code review (CI and agent review alike). These guide the reviewer, not the code author.
+
+### Grounding
+- Every finding must cite specific code location (file:line)
+- Do not present inferences as facts; label hypotheses clearly
+- Ground claims in repository context or tool outputs, not assumptions
+
+### Confidence Threshold
+- Only submit a finding if you can point to a specific code path that causes the issue
+- Do not submit findings based on pattern-matching alone without tracing the actual call or data flow
+- If confidence is low, omit the finding rather than labeling it a "suggestion"
+
+### Severity
+- Categorize findings: Critical (must fix) / Important (should fix) / Suggestion
+- Critical: correctness bugs, data loss, security vulnerabilities
+- Important: missing error handling, contract mismatches between docs and code, edge cases
+- Suggestion: readability, naming, minor optimization
+
+### Depth
+- After first plausible issue, check second-order failures: empty-state handling, retries, stale state, rollback paths
+- Verify contract consistency: if CLAUDE.md, docstrings, or specs state X, code must match
+
+### False Positive Avoidance
+- Do not flag pre-existing issues unrelated to the change
+- Do not flag issues ruff, pytest, or other configured CI steps already enforce
+- Do not flag intentional behavior changes that align with the PR's stated purpose
+- Do not flag style preferences not codified in this file or ruff config
+
+### Scope
+- Review only the changed code and its immediate blast radius
+- Do not suggest unrelated refactors or cleanup


### PR DESCRIPTION
## Summary
- Add `## Code Review Principles` section to CLAUDE.md, adapted from Codex review methodology
- Principles cover: grounding (evidence-based findings), confidence thresholds, severity categorization, depth checks (second-order failures), false positive avoidance, and scope limits
- Reviewed by Codex: removed mypy reference (not configured in this repo), added Confidence Threshold section

## Test plan
- [ ] Verify `Code Review Principles` section exists in CLAUDE.md
- [ ] Open a code PR to confirm Claude Code Review CI picks up the new principles
- [ ] Check that review comments follow grounding and confidence threshold rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)