### PR TITLE
feat(retrieval): Rank decisions by current-change relevance

### DIFF
--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -594,7 +594,6 @@ _CODE_STOPWORDS: frozenset[str] = frozenset(
     }
 )
 
-_PER_SOURCE_CAP = 100
 _FALLBACK_RECENT_COUNT = 20
 _MIN_CANDIDATE_THRESHOLD = 5
 
@@ -721,7 +720,8 @@ def _fts_rank_decisions_from_diff(conn, diff_text: str, limit: int = 50) -> dict
         for rowid, raw in raw_scores.items():
             did = rowid_to_id.get(rowid)
             if did:
-                result[did] = 4.0 * (raw - min_score) / score_range
+                # Floor at 0.5 so the weakest FTS hit still contributes signal
+                result[did] = 0.5 + 3.5 * (raw - min_score) / score_range
     return result
 
 
@@ -737,8 +737,8 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
     placeholders = ",".join("?" for _ in normalized)
     rows = conn.execute(
         f"SELECT DISTINCT decision_id FROM decision_files"  # noqa: S608
-        f" WHERE REPLACE(CASE WHEN file_path LIKE './%' THEN SUBSTR(file_path, 3) ELSE file_path END, '\\', '/') IN ({placeholders}) LIMIT ?",
-        [*normalized, _PER_SOURCE_CAP],
+        f" WHERE REPLACE(CASE WHEN file_path LIKE './%' THEN SUBSTR(file_path, 3) ELSE file_path END, '\\', '/') IN ({placeholders})",
+        normalized,
     ).fetchall()
     candidates.update(r["decision_id"] for r in rows)
 
@@ -758,8 +758,8 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
         rows = conn.execute(
             "SELECT DISTINCT decision_id FROM decision_files"
             " WHERE REPLACE(CASE WHEN file_path LIKE './%' THEN SUBSTR(file_path, 3)"
-            " ELSE file_path END, '\\', '/') LIKE ? ESCAPE '\\' LIMIT ?",
-            (f"{escaped}/%", _PER_SOURCE_CAP),
+            " ELSE file_path END, '\\', '/') LIKE ? ESCAPE '\\'",
+            (f"{escaped}/%",),
         ).fetchall()
         candidates.update(r["decision_id"] for r in rows)
     return candidates
@@ -771,8 +771,8 @@ def _gather_candidates_by_commits(conn, commit_shas: list[str]) -> set[str]:
         return set()
     placeholders = ",".join("?" for _ in commit_shas)
     rows = conn.execute(
-        f"SELECT DISTINCT decision_id FROM decision_commits WHERE commit_sha IN ({placeholders}) LIMIT ?",  # noqa: S608
-        [*commit_shas, _PER_SOURCE_CAP],
+        f"SELECT DISTINCT decision_id FROM decision_commits WHERE commit_sha IN ({placeholders})",  # noqa: S608
+        commit_shas,
     ).fetchall()
     return {r["decision_id"] for r in rows}
 
@@ -819,8 +819,8 @@ def rank_related_decisions(
     if resolved_assessment_ids:
         placeholders = ",".join("?" for _ in resolved_assessment_ids)
         rows = conn.execute(
-            f"SELECT DISTINCT decision_id FROM decision_assessments WHERE assessment_id IN ({placeholders}) LIMIT ?",  # noqa: S608
-            [*resolved_assessment_ids, _PER_SOURCE_CAP],
+            f"SELECT DISTINCT decision_id FROM decision_assessments WHERE assessment_id IN ({placeholders})",  # noqa: S608
+            list(resolved_assessment_ids),
         ).fetchall()
         candidate_ids.update(r["decision_id"] for r in rows)
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -748,7 +748,7 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
     ancestor_dirs: set[str] = set()
     for p in normalized:
         parts = PurePosixPath(p).parts[:-1]  # directory components, excluding filename
-        for depth in range(min(len(parts), 3)):
+        for depth in range(min(len(parts), 4)):
             ancestor_parts = parts[: len(parts) - depth]
             ancestor = str(PurePosixPath(*ancestor_parts))
             if ancestor and ancestor != ".":

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import re
 import json
 import subprocess
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from typing import Any
 from uuid import uuid4
 
@@ -537,107 +539,420 @@ def unlink_decision_from_checkpoint(conn, decision_id: str, checkpoint_id: str) 
     return cursor.rowcount > 0
 
 
+# ---------------------------------------------------------------------------
+# Ranking helpers
+# ---------------------------------------------------------------------------
+
+_STALENESS_FACTORS: dict[str, float] = {
+    "fresh": 1.0,
+    "stale": 0.85,
+    "superseded": 0.5,
+    "contradicted": 0.25,
+}
+
+_ASSESSMENT_RELATION_WEIGHTS: dict[str, float] = {
+    "supports": 4.0,
+    "informed_by": 4.0,
+    "contradicts": 5.0,
+    "supersedes": 3.0,
+}
+
+_CODE_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "function",
+        "return",
+        "class",
+        "import",
+        "const",
+        "null",
+        "true",
+        "false",
+        "test",
+        "self",
+        "def",
+        "var",
+        "let",
+        "src",
+        "none",
+        "this",
+        "from",
+        "async",
+        "await",
+        "yield",
+        "with",
+        "elif",
+        "else",
+        "pass",
+        "raise",
+        "except",
+        "finally",
+        "try",
+        "for",
+        "while",
+        "break",
+        "continue",
+    }
+)
+
+_PER_SOURCE_CAP = 100
+_FALLBACK_RECENT_COUNT = 20
+_MIN_CANDIDATE_THRESHOLD = 5
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize a file path for consistent matching."""
+    p = path.replace("\\", "/")
+    if p.startswith("./"):
+        p = p[2:]
+    return p
+
+
+def _directory_proximity_score(path_a: str, path_b: str) -> float:
+    """Score directory proximity between two file paths.
+
+    Same directory = 1.5, parent = 0.75, grandparent = 0.375 (halves per level, cap 3).
+    Returns 0.0 if paths share no directory components.
+    """
+    parts_a = PurePosixPath(_normalize_path(path_a)).parts[:-1]
+    parts_b = PurePosixPath(_normalize_path(path_b)).parts[:-1]
+    if not parts_a or not parts_b:
+        return 0.0
+    shared = 0
+    for a, b in zip(parts_a, parts_b):
+        if a != b:
+            break
+        shared += 1
+    if shared == 0:
+        return 0.0
+    depth_from_match = max(len(parts_a), len(parts_b)) - shared
+    if depth_from_match > 3:
+        return 0.0
+    return 1.5 * (0.5**depth_from_match)
+
+
+def _tokenize_diff_for_fts(diff_text: str, max_tokens: int = 30) -> str | None:
+    """Extract meaningful tokens from diff text for FTS5 query.
+
+    Only processes added/removed lines. Filters code stopwords,
+    numeric-only tokens, and short tokens. Returns an FTS5 OR query
+    or None if too few tokens remain.
+    """
+    if not diff_text:
+        return None
+    text = diff_text[:5000]
+    tokens: dict[str, int] = {}
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        # Skip diff metadata
+        if stripped.startswith(("@@", "---", "+++", "diff --git")):
+            continue
+        # Only process added/removed lines
+        if not stripped.startswith(("+", "-")):
+            continue
+        content = stripped[1:].strip()
+        # Split camelCase and snake_case
+        parts = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\b)|[a-z]+", content)
+        words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{2,}", content)
+        all_tokens = {t.lower() for t in parts + words}
+        for t in all_tokens:
+            if len(t) < 3:
+                continue
+            if t in _CODE_STOPWORDS:
+                continue
+            if re.fullmatch(r"[0-9a-f]+", t):
+                continue
+            tokens[t] = tokens.get(t, 0) + 1
+
+    if len(tokens) < 2:
+        return None
+    sorted_tokens = sorted(tokens, key=tokens.__getitem__, reverse=True)[:max_tokens]
+    # Quote tokens that could conflict with FTS5 syntax
+    safe = []
+    for t in sorted_tokens:
+        if t.upper() in ("AND", "OR", "NOT", "NEAR"):
+            safe.append(f'"{t}"')
+        else:
+            safe.append(t)
+    return " OR ".join(safe)
+
+
+def _fts_rank_decisions_from_diff(conn, diff_text: str, limit: int = 50) -> dict[str, float]:
+    """Search fts_decisions with tokenized diff text and return normalized relevance scores.
+
+    Returns {decision_id: score} where score is in [0.0, 4.0].
+    """
+    fts_query = _tokenize_diff_for_fts(diff_text)
+    if fts_query is None:
+        return {}
+    try:
+        rows = conn.execute(
+            "SELECT rowid, rank FROM fts_decisions WHERE fts_decisions MATCH ? ORDER BY rank LIMIT ?",
+            (fts_query, limit),
+        ).fetchall()
+    except Exception:
+        return {}
+    if not rows:
+        return {}
+    # Map rowid back to decision id
+    rowids = [r["rowid"] for r in rows]
+    placeholders = ",".join("?" for _ in rowids)
+    id_rows = conn.execute(
+        f"SELECT rowid, id FROM decisions WHERE rowid IN ({placeholders})",  # noqa: S608
+        rowids,
+    ).fetchall()
+    rowid_to_id = {r["rowid"]: r["id"] for r in id_rows}
+
+    # FTS5 rank is negative (more negative = better match); normalize to [0, 4]
+    raw_scores = {r["rowid"]: -r["rank"] for r in rows}
+    max_score = max(raw_scores.values()) if raw_scores else 1.0
+    min_score = min(raw_scores.values()) if raw_scores else 0.0
+
+    result: dict[str, float] = {}
+    if max_score == min_score:
+        for rowid in raw_scores:
+            did = rowid_to_id.get(rowid)
+            if did:
+                result[did] = 2.0
+    else:
+        score_range = max_score - min_score
+        for rowid, raw in raw_scores.items():
+            did = rowid_to_id.get(rowid)
+            if did:
+                result[did] = 4.0 * (raw - min_score) / score_range
+    return result
+
+
+def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
+    """Find decision IDs linked to the given files or sharing a parent directory."""
+    if not file_paths:
+        return set()
+    candidates: set[str] = set()
+    normalized = [_normalize_path(p) for p in file_paths]
+
+    # Exact file matches
+    placeholders = ",".join("?" for _ in normalized)
+    rows = conn.execute(
+        f"SELECT DISTINCT decision_id FROM decision_files WHERE file_path IN ({placeholders}) LIMIT ?",  # noqa: S608
+        [*normalized, _PER_SOURCE_CAP],
+    ).fetchall()
+    candidates.update(r["decision_id"] for r in rows)
+
+    # Parent directory matches (for proximity scoring)
+    parent_dirs: set[str] = set()
+    for p in normalized:
+        parent = str(PurePosixPath(p).parent)
+        if parent and parent != ".":
+            parent_dirs.add(parent)
+    for parent_dir in parent_dirs:
+        escaped = _escape_like(parent_dir)
+        rows = conn.execute(
+            "SELECT DISTINCT decision_id FROM decision_files WHERE file_path LIKE ? ESCAPE '\\' LIMIT ?",
+            (f"{escaped}/%", _PER_SOURCE_CAP),
+        ).fetchall()
+        candidates.update(r["decision_id"] for r in rows)
+    return candidates
+
+
+def _gather_candidates_by_commits(conn, commit_shas: list[str]) -> set[str]:
+    """Find decision IDs linked to the given commit SHAs."""
+    if not commit_shas:
+        return set()
+    placeholders = ",".join("?" for _ in commit_shas)
+    rows = conn.execute(
+        f"SELECT DISTINCT decision_id FROM decision_commits WHERE commit_sha IN ({placeholders}) LIMIT ?",  # noqa: S608
+        [*commit_shas, _PER_SOURCE_CAP],
+    ).fetchall()
+    return {r["decision_id"] for r in rows}
+
+
 def rank_related_decisions(
     conn,
     *,
     file_paths: list[str] | None = None,
     assessment_ids: list[str] | None = None,
     diff_text: str | None = None,
+    commit_shas: list[str] | None = None,
     limit: int = 10,
 ) -> list[dict]:
-    """Rank decisions by file overlap, assessment links, and recency.
+    """Rank decisions by current-change relevance using multi-signal scoring.
 
-    Scoring rules:
-    - +4 per linked assessment match
-    - +2 per linked file path match
-    - +1 if title/rationale appears in diff text
-    - quality score adjustment from tracked outcomes, capped to [-4, +4]
+    Candidate-first architecture: gathers candidate decisions from each signal
+    source (files, assessments, diff FTS5, commits), then scores the union.
+
+    Signals:
+    - file_exact: +3.0 per exact file match
+    - file_proximity: +1.5/0.75/0.375 for directory proximity (same/parent/grandparent)
+    - assessment: +3.0 to +5.0 per assessment match (max weight per assessment_id)
+    - diff_relevance: 0.0-4.0 from FTS5 match of diff text against title/rationale
+    - git_commit: +3.0 per matching commit SHA
+    - quality: from outcome tracking (accepted/ignored/contradicted), capped [-4, +4]
+    - staleness_factor: multiplicative on base_score only (fresh=1.0, stale=0.85, etc.)
+
+    Score formula: score = base_score * staleness_factor + quality_score
     """
-    file_paths = file_paths or []
+    file_paths = [_normalize_path(p) for p in (file_paths or [])]
     assessment_ids = assessment_ids or []
-    diff_text_lc = (diff_text or "").lower()
+    commit_shas = commit_shas or []
 
-    decisions = [dict(r) for r in conn.execute("SELECT * FROM decisions ORDER BY updated_at DESC LIMIT 200").fetchall()]
+    # --- 1. Gather candidates from each signal source ---
+    candidate_ids: set[str] = set()
+    candidate_ids |= _gather_candidates_by_files(conn, file_paths)
+    candidate_ids |= _gather_candidates_by_commits(conn, commit_shas)
+
+    resolved_assessment_ids: set[str] = set()
+    for aid in assessment_ids:
+        full_id = _resolve_assessment_id(conn, aid)
+        if full_id:
+            resolved_assessment_ids.add(full_id)
+    if resolved_assessment_ids:
+        placeholders = ",".join("?" for _ in resolved_assessment_ids)
+        rows = conn.execute(
+            f"SELECT DISTINCT decision_id FROM decision_assessments WHERE assessment_id IN ({placeholders}) LIMIT ?",  # noqa: S608
+            [*resolved_assessment_ids, _PER_SOURCE_CAP],
+        ).fetchall()
+        candidate_ids.update(r["decision_id"] for r in rows)
+
+    diff_fts_scores: dict[str, float] = {}
+    if diff_text:
+        diff_fts_scores = _fts_rank_decisions_from_diff(conn, diff_text)
+        candidate_ids.update(diff_fts_scores.keys())
+
+    # Fallback: if too few candidates, pad with recent decisions
+    if len(candidate_ids) < _MIN_CANDIDATE_THRESHOLD:
+        recent = conn.execute(
+            "SELECT id FROM decisions ORDER BY updated_at DESC LIMIT ?",
+            (_FALLBACK_RECENT_COUNT,),
+        ).fetchall()
+        candidate_ids.update(r["id"] for r in recent)
+
+    if not candidate_ids:
+        return []
+
+    # --- 2. Bulk-fetch decision data ---
+    id_list = list(candidate_ids)
+    placeholders = ",".join("?" for _ in id_list)
+    decisions = [
+        dict(r)
+        for r in conn.execute(
+            f"SELECT * FROM decisions WHERE id IN ({placeholders})",  # noqa: S608
+            id_list,
+        ).fetchall()
+    ]
     if not decisions:
         return []
 
-    resolved_assessment_ids: set[str] = set()
-    for assessment_id in assessment_ids:
-        full_assessment_id = _resolve_assessment_id(conn, assessment_id)
-        if full_assessment_id:
-            resolved_assessment_ids.add(full_assessment_id)
-
-    scored: list[dict] = []
     decision_ids = [d["id"] for d in decisions]
-    file_links_by_decision: dict[str, set[str]] = {decision_id: set() for decision_id in decision_ids}
-    assessment_links_by_decision: dict[str, set[str]] = {decision_id: set() for decision_id in decision_ids}
-    outcome_counts_by_decision: dict[str, dict[str, int]] = {decision_id: {} for decision_id in decision_ids}
+    ph = ",".join("?" for _ in decision_ids)
 
-    if decision_ids:
-        placeholders = ",".join("?" for _ in decision_ids)
-        file_rows = conn.execute(
-            f"SELECT decision_id, file_path FROM decision_files WHERE decision_id IN ({placeholders})",
+    # File links
+    file_links_by_decision: dict[str, set[str]] = {did: set() for did in decision_ids}
+    for row in conn.execute(
+        f"SELECT decision_id, file_path FROM decision_files WHERE decision_id IN ({ph})",  # noqa: S608
+        decision_ids,
+    ).fetchall():
+        file_links_by_decision[row["decision_id"]].add(row["file_path"])
+
+    # Assessment links (with relation_type for weighted scoring)
+    assessment_links_by_decision: dict[str, dict[str, str]] = {did: {} for did in decision_ids}
+    for row in conn.execute(
+        f"SELECT decision_id, assessment_id, relation_type FROM decision_assessments WHERE decision_id IN ({ph})",  # noqa: S608
+        decision_ids,
+    ).fetchall():
+        existing = assessment_links_by_decision[row["decision_id"]]
+        aid = row["assessment_id"]
+        rtype = row["relation_type"]
+        # Keep max weight per assessment_id
+        if aid not in existing or _ASSESSMENT_RELATION_WEIGHTS.get(rtype, 0) > _ASSESSMENT_RELATION_WEIGHTS.get(
+            existing[aid], 0
+        ):
+            existing[aid] = rtype
+
+    # Commit links
+    commit_links_by_decision: dict[str, set[str]] = {did: set() for did in decision_ids}
+    if commit_shas:
+        for row in conn.execute(
+            f"SELECT decision_id, commit_sha FROM decision_commits WHERE decision_id IN ({ph})",  # noqa: S608
             decision_ids,
-        ).fetchall()
-        for row in file_rows:
-            file_links_by_decision[row["decision_id"]].add(row["file_path"])
+        ).fetchall():
+            commit_links_by_decision[row["decision_id"]].add(row["commit_sha"])
 
-        assessment_rows = conn.execute(
-            f"SELECT decision_id, assessment_id FROM decision_assessments WHERE decision_id IN ({placeholders})",
-            decision_ids,
-        ).fetchall()
-        for row in assessment_rows:
-            assessment_links_by_decision[row["decision_id"]].add(row["assessment_id"])
+    # Outcome counts
+    outcome_counts_by_decision: dict[str, dict[str, int]] = {did: {} for did in decision_ids}
+    for row in conn.execute(
+        f"SELECT decision_id, outcome_type, COUNT(*) AS total FROM decision_outcomes WHERE decision_id IN ({ph}) GROUP BY decision_id, outcome_type",  # noqa: S608
+        decision_ids,
+    ).fetchall():
+        outcome_counts_by_decision.setdefault(row["decision_id"], {})[row["outcome_type"]] = row["total"] or 0
 
-        outcome_rows = conn.execute(
-            (
-                "SELECT decision_id, outcome_type, COUNT(*) AS total "
-                f"FROM decision_outcomes WHERE decision_id IN ({placeholders}) "
-                "GROUP BY decision_id, outcome_type"
-            ),
-            decision_ids,
-        ).fetchall()
-        for row in outcome_rows:
-            counts = outcome_counts_by_decision.setdefault(row["decision_id"], {})
-            counts[row["outcome_type"]] = row["total"] or 0
-
+    # --- 3. Score each candidate ---
+    commit_set = set(commit_shas)
+    scored: list[dict] = []
     for d in decisions:
-        decision_id = d["id"]
-        base_score = 0.0
+        did = d["id"]
+        file_exact = 0.0
+        file_proximity = 0.0
+        assessment_score = 0.0
+        diff_relevance = diff_fts_scores.get(did, 0.0)
+        git_commit = 0.0
 
+        # File signals
         if file_paths:
-            linked_files = file_links_by_decision.get(decision_id, set())
-            for file_path in file_paths:
-                if any(file_path in linked or linked in file_path for linked in linked_files):
-                    base_score += 2
+            linked_files = file_links_by_decision.get(did, set())
+            for fp in file_paths:
+                exact_matched = False
+                for linked in linked_files:
+                    if _normalize_path(linked) == fp:
+                        file_exact += 3.0
+                        exact_matched = True
+                        break
+                if not exact_matched:
+                    best_prox = 0.0
+                    for linked in linked_files:
+                        prox = _directory_proximity_score(fp, linked)
+                        if prox > best_prox:
+                            best_prox = prox
+                    file_proximity += best_prox
 
+        # Assessment signal (deduplicated by assessment_id, max weight)
         if resolved_assessment_ids:
-            linked_assessment_ids = assessment_links_by_decision.get(decision_id, set())
-            base_score += 4 * len(linked_assessment_ids & resolved_assessment_ids)
+            links = assessment_links_by_decision.get(did, {})
+            for aid, rtype in links.items():
+                if aid in resolved_assessment_ids:
+                    assessment_score += _ASSESSMENT_RELATION_WEIGHTS.get(rtype, 4.0)
 
-        if diff_text_lc:
-            title = (d.get("title") or "").lower()
-            rationale = (d.get("rationale") or "").lower()
-            if title and title in diff_text_lc:
-                base_score += 1
-            elif rationale and rationale[:80] and rationale[:80] in diff_text_lc:
-                base_score += 1
+        # Git commit signal
+        if commit_set:
+            linked_commits = commit_links_by_decision.get(did, set())
+            git_commit = 3.0 * len(linked_commits & commit_set)
 
-        if base_score == 0:
+        base_score = file_exact + file_proximity + assessment_score + diff_relevance + git_commit
+        if base_score <= 0:
             continue
 
-        quality_score = calculate_decision_quality_score(outcome_counts_by_decision.get(decision_id, {}))
-        score = base_score + quality_score
+        quality_score = calculate_decision_quality_score(outcome_counts_by_decision.get(did, {}))
+        staleness_factor = _STALENESS_FACTORS.get(d.get("staleness_status", "fresh"), 1.0)
+        score = base_score * staleness_factor + quality_score
 
         scored.append(
             {
-                "id": decision_id,
+                "id": did,
                 "title": d.get("title"),
                 "staleness_status": d.get("staleness_status"),
                 "updated_at": d.get("updated_at"),
                 "base_score": round(base_score, 3),
                 "quality_score": round(quality_score, 3),
                 "score": round(score, 3),
+                "score_breakdown": {
+                    "file_exact": round(file_exact, 3),
+                    "file_proximity": round(file_proximity, 3),
+                    "assessment": round(assessment_score, 3),
+                    "diff_relevance": round(diff_relevance, 3),
+                    "git_commit": round(git_commit, 3),
+                    "quality": round(quality_score, 3),
+                    "staleness_factor": round(staleness_factor, 3),
+                },
             }
         )
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -648,10 +648,11 @@ def _tokenize_diff_for_fts(diff_text: str, max_tokens: int = 30) -> str | None:
         # Skip diff metadata
         if stripped.startswith(("@@", "---", "+++", "diff --git")):
             continue
-        # Only process added/removed lines
-        if not stripped.startswith(("+", "-")):
-            continue
-        content = stripped[1:].strip()
+        # Prefer added/removed lines; fall back to all lines for plain-text input
+        if stripped.startswith(("+", "-")):
+            content = stripped[1:].strip()
+        else:
+            content = stripped
         # Split camelCase and snake_case
         parts = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\b)|[a-z]+", content)
         words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{2,}", content)
@@ -755,7 +756,9 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
     for ancestor_dir in ancestor_dirs:
         escaped = _escape_like(ancestor_dir)
         rows = conn.execute(
-            "SELECT DISTINCT decision_id FROM decision_files WHERE file_path LIKE ? ESCAPE '\\' LIMIT ?",
+            "SELECT DISTINCT decision_id FROM decision_files"
+            " WHERE REPLACE(CASE WHEN file_path LIKE './%' THEN SUBSTR(file_path, 3)"
+            " ELSE file_path END, '\\', '/') LIKE ? ESCAPE '\\' LIMIT ?",
             (f"{escaped}/%", _PER_SOURCE_CAP),
         ).fetchall()
         candidates.update(r["decision_id"] for r in rows)

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -731,22 +731,29 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
     candidates: set[str] = set()
     normalized = [_normalize_path(p) for p in file_paths]
 
-    # Exact file matches
+    # Exact file matches — normalize stored paths at query time to handle ./prefix and backslashes
+    # so stored values like "./src/foo.py" or "src\foo.py" match normalized inputs.
     placeholders = ",".join("?" for _ in normalized)
     rows = conn.execute(
-        f"SELECT DISTINCT decision_id FROM decision_files WHERE file_path IN ({placeholders}) LIMIT ?",  # noqa: S608
+        f"SELECT DISTINCT decision_id FROM decision_files"  # noqa: S608
+        f" WHERE REPLACE(CASE WHEN file_path LIKE './%' THEN SUBSTR(file_path, 3) ELSE file_path END, '\\', '/') IN ({placeholders}) LIMIT ?",
         [*normalized, _PER_SOURCE_CAP],
     ).fetchall()
     candidates.update(r["decision_id"] for r in rows)
 
-    # Parent directory matches (for proximity scoring)
-    parent_dirs: set[str] = set()
+    # Ancestor directory matches (for proximity scoring up to 3 levels).
+    # _directory_proximity_score returns non-zero for depth_from_match <= 3, so we must gather
+    # candidates from ancestor dirs at each level to avoid silently excluding sibling/cousin files.
+    ancestor_dirs: set[str] = set()
     for p in normalized:
-        parent = str(PurePosixPath(p).parent)
-        if parent and parent != ".":
-            parent_dirs.add(parent)
-    for parent_dir in parent_dirs:
-        escaped = _escape_like(parent_dir)
+        parts = PurePosixPath(p).parts[:-1]  # directory components, excluding filename
+        for depth in range(min(len(parts), 3)):
+            ancestor_parts = parts[: len(parts) - depth]
+            ancestor = str(PurePosixPath(*ancestor_parts))
+            if ancestor and ancestor != ".":
+                ancestor_dirs.add(ancestor)
+    for ancestor_dir in ancestor_dirs:
+        escaped = _escape_like(ancestor_dir)
         rows = conn.execute(
             "SELECT DISTINCT decision_id FROM decision_files WHERE file_path LIKE ? ESCAPE '\\' LIMIT ?",
             (f"{escaped}/%", _PER_SOURCE_CAP),

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -84,7 +84,7 @@ def _record_selection(
 
 
 from .tools.checkpoint import ec_checkpoint_list, ec_rewind  # noqa: E402
-from .tools.decisions import (
+from .tools.decisions import (  # noqa: E402
     ec_decision_create,
     ec_decision_get,
     ec_decision_list,
@@ -92,7 +92,7 @@ from .tools.decisions import (
     ec_decision_related,
     ec_decision_search,
     ec_decision_stale,
-)  # noqa: E402
+)
 from .tools.futures import ec_assess, ec_assess_create, ec_assess_trends, ec_feedback, ec_lessons  # noqa: E402
 from .tools.misc import ec_dashboard, ec_graph  # noqa: E402
 from .tools.search import ec_activate, ec_ast_search, ec_related, ec_search  # noqa: E402

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -27,6 +27,7 @@ async def ec_decision_related(
     files: list[str] | None = None,
     assessment_ids: list[str] | None = None,
     diff_text: str | None = None,
+    commit_shas: list[str] | None = None,
     limit: int = 10,
     retrieval_event_id: str | None = None,
 ) -> str:
@@ -42,6 +43,7 @@ async def ec_decision_related(
             file_paths=files or [],
             assessment_ids=assessment_ids or [],
             diff_text=diff_text,
+            commit_shas=commit_shas or [],
             limit=limit,
         )
         tracked_event_id = runtime.record_search_event(

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -338,7 +338,7 @@ class TestDecisionsCore:
 
         assert [item["id"] for item in ranked[:2]] == [promoted["id"], demoted["id"]]
         assert ranked[0]["quality_score"] > ranked[1]["quality_score"]
-        assert ranked[0]["base_score"] == ranked[1]["base_score"] == 2.0
+        assert ranked[0]["base_score"] == ranked[1]["base_score"] == 3.0
 
 
 class TestUpdateDecision:
@@ -519,7 +519,7 @@ class TestDecisionsCoreExtended:
     def test_unlink_from_checkpoint_decision_not_found(self, ec_db):
         assert unlink_decision_from_checkpoint(ec_db, "nonexistent-decision-id", "nonexistent-checkpoint-id") is False
 
-    def test_rank_decisions_diff_text_title_scoring(self, ec_db):
+    def test_rank_decisions_diff_fts_title_scoring(self, ec_db):
         matching = create_decision(ec_db, title="Adopt queue retries")
         other = create_decision(ec_db, title="Use monolith pattern")
         link_decision_to_file(ec_db, matching["id"], "src/retry.py")
@@ -528,7 +528,7 @@ class TestDecisionsCoreExtended:
         ranked = rank_related_decisions(
             ec_db,
             file_paths=["src/retry.py"],
-            diff_text="this change is about adopt queue retries in the service layer",
+            diff_text="+adopt queue retries in the service layer\n+retry handler setup",
         )
 
         ids = [item["id"] for item in ranked]
@@ -536,9 +536,9 @@ class TestDecisionsCoreExtended:
         assert other["id"] in ids
         matching_item = next(item for item in ranked if item["id"] == matching["id"])
         other_item = next(item for item in ranked if item["id"] == other["id"])
-        assert matching_item["base_score"] > other_item["base_score"]
+        assert matching_item["score"] > other_item["score"]
 
-    def test_rank_decisions_diff_text_rationale_scoring(self, ec_db):
+    def test_rank_decisions_diff_fts_rationale_scoring(self, ec_db):
         matching = create_decision(
             ec_db,
             title="Unique unrelated title xyz",
@@ -551,12 +551,12 @@ class TestDecisionsCoreExtended:
         ranked = rank_related_decisions(
             ec_db,
             file_paths=["src/service.py"],
-            diff_text="this diff prevents retry storms in production environment and adds resilience",
+            diff_text="+prevents retry storms in production environment\n+adds resilience layer",
         )
 
         matching_item = next(item for item in ranked if item["id"] == matching["id"])
         other_item = next(item for item in ranked if item["id"] == other["id"])
-        assert matching_item["base_score"] > other_item["base_score"]
+        assert matching_item["score"] > other_item["score"]
 
 
 class TestDecisionFTSSearch:
@@ -606,3 +606,235 @@ class TestDecisionFTSSearch:
         assert len(results) == 2
         assert all("hybrid_score" in r for r in results)
         assert results[0]["hybrid_score"] >= results[1]["hybrid_score"]
+
+
+class TestRankingSignals:
+    """Tests for multi-signal decision ranking (issue #40)."""
+
+    # --- Signal isolation ---
+
+    def test_file_exact_match(self, ec_db):
+        d = create_decision(ec_db, title="Exact file decision")
+        link_decision_to_file(ec_db, d["id"], "src/auth.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/auth.py"])
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["file_exact"] == 3.0
+        assert item["score_breakdown"]["file_proximity"] == 0.0
+
+    def test_file_proximity_same_directory(self, ec_db):
+        d = create_decision(ec_db, title="Nearby file decision")
+        link_decision_to_file(ec_db, d["id"], "src/service/handler.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/service/router.py"])
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["file_exact"] == 0.0
+        assert item["score_breakdown"]["file_proximity"] == 1.5
+
+    def test_file_proximity_parent_directory(self, ec_db):
+        d = create_decision(ec_db, title="Parent dir decision")
+        link_decision_to_file(ec_db, d["id"], "src/service/sub/deep.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/service/other.py"])
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["file_proximity"] == 0.75
+
+    def test_file_proximity_different_tree(self, ec_db):
+        d = create_decision(ec_db, title="Unrelated dir")
+        link_decision_to_file(ec_db, d["id"], "tests/unit/test_auth.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/service/auth.py"])
+        found = [r for r in ranked if r["id"] == d["id"]]
+        if found:
+            assert found[0]["score_breakdown"]["file_proximity"] == 0.0
+            assert found[0]["score_breakdown"]["file_exact"] == 0.0
+
+    def test_assessment_match(self, ec_db):
+        assessment = create_assessment(ec_db, verdict="expand", impact_summary="assessment signal test")
+        d = create_decision(ec_db, title="Assessment linked")
+        link_decision_to_assessment(ec_db, d["id"], assessment["id"])
+
+        ranked = rank_related_decisions(ec_db, assessment_ids=[assessment["id"]])
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["assessment"] == 4.0
+
+    def test_assessment_contradicts_weight(self, ec_db):
+        assessment = create_assessment(ec_db, verdict="narrow", impact_summary="contradicts test")
+        d = create_decision(ec_db, title="Contradicted decision")
+        link_decision_to_assessment(ec_db, d["id"], assessment["id"], relation_type="contradicts")
+
+        ranked = rank_related_decisions(ec_db, assessment_ids=[assessment["id"]])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["assessment"] == 5.0
+
+    def test_assessment_dedupe_max_weight(self, ec_db):
+        assessment = create_assessment(ec_db, verdict="expand", impact_summary="dedupe test")
+        d = create_decision(ec_db, title="Multi-relation")
+        link_decision_to_assessment(ec_db, d["id"], assessment["id"], relation_type="supports")
+        link_decision_to_assessment(ec_db, d["id"], assessment["id"], relation_type="contradicts")
+
+        ranked = rank_related_decisions(ec_db, assessment_ids=[assessment["id"]])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        # Should use max weight (contradicts=5.0), not sum (4.0+5.0)
+        assert item["score_breakdown"]["assessment"] == 5.0
+
+    def test_diff_fts_match(self, ec_db):
+        d = create_decision(ec_db, title="Queue retry backoff strategy")
+
+        ranked = rank_related_decisions(
+            ec_db,
+            diff_text="+implement queue retry backoff\n+exponential delay strategy",
+        )
+        found = [r for r in ranked if r["id"] == d["id"]]
+        assert len(found) >= 1
+        assert found[0]["score_breakdown"]["diff_relevance"] > 0
+
+    def test_diff_fts_no_match(self, ec_db):
+        create_decision(ec_db, title="Cache invalidation policy")
+
+        ranked = rank_related_decisions(
+            ec_db,
+            diff_text="+authentication middleware refactor\n+jwt token validation",
+        )
+        found = [r for r in ranked if r["title"] == "Cache invalidation policy"]
+        if found:
+            assert found[0]["score_breakdown"]["diff_relevance"] == 0.0
+
+    def test_commit_match(self, ec_db):
+        d = create_decision(ec_db, title="Commit-linked decision")
+        link_decision_to_commit(ec_db, d["id"], "abc123def")
+
+        ranked = rank_related_decisions(ec_db, commit_shas=["abc123def"])
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["git_commit"] == 3.0
+
+    # --- Staleness penalty ---
+
+    def test_stale_penalty(self, ec_db):
+        fresh = create_decision(ec_db, title="Fresh decision")
+        stale = create_decision(ec_db, title="Stale decision")
+        update_decision_staleness(ec_db, stale["id"], "stale")
+        link_decision_to_file(ec_db, fresh["id"], "src/api.py")
+        link_decision_to_file(ec_db, stale["id"], "src/api.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/api.py"])
+        ids = [r["id"] for r in ranked]
+        assert ids.index(fresh["id"]) < ids.index(stale["id"])
+        fresh_item = next(r for r in ranked if r["id"] == fresh["id"])
+        stale_item = next(r for r in ranked if r["id"] == stale["id"])
+        assert fresh_item["score_breakdown"]["staleness_factor"] == 1.0
+        assert stale_item["score_breakdown"]["staleness_factor"] == 0.85
+
+    def test_superseded_penalty(self, ec_db):
+        fresh = create_decision(ec_db, title="Fresh")
+        superseded = create_decision(ec_db, title="Superseded")
+        update_decision_staleness(ec_db, superseded["id"], "superseded")
+        link_decision_to_file(ec_db, fresh["id"], "src/core.py")
+        link_decision_to_file(ec_db, superseded["id"], "src/core.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/core.py"])
+        fresh_item = next(r for r in ranked if r["id"] == fresh["id"])
+        sup_item = next(r for r in ranked if r["id"] == superseded["id"])
+        assert fresh_item["score"] > sup_item["score"]
+        assert sup_item["score_breakdown"]["staleness_factor"] == 0.5
+
+    # --- Scenario tests ---
+
+    def test_repeated_task_scenario(self, ec_db):
+        """Simulates revisiting the same files — decision should surface."""
+        d = create_decision(ec_db, title="Retry strategy for webhook service")
+        link_decision_to_file(ec_db, d["id"], "src/webhook/handler.py")
+        link_decision_to_file(ec_db, d["id"], "src/webhook/retry.py")
+
+        ranked = rank_related_decisions(
+            ec_db,
+            file_paths=["src/webhook/handler.py", "src/webhook/retry.py"],
+        )
+        assert len(ranked) >= 1
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["file_exact"] == 6.0  # 3.0 * 2 files
+
+    def test_regression_fix_scenario(self, ec_db):
+        """Simulates fixing regression in area covered by a prior decision."""
+        d = create_decision(ec_db, title="Connection pool sizing")
+        link_decision_to_file(ec_db, d["id"], "src/db/pool.py")
+        link_decision_to_commit(ec_db, d["id"], "fix123abc")
+
+        ranked = rank_related_decisions(
+            ec_db,
+            file_paths=["src/db/pool.py"],
+            commit_shas=["fix123abc"],
+        )
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["file_exact"] == 3.0
+        assert item["score_breakdown"]["git_commit"] == 3.0
+        assert item["base_score"] >= 6.0
+
+    def test_candidate_beyond_200_recency(self, ec_db):
+        """Old decision linked to a specific file must surface (no 200-row ceiling)."""
+        old = create_decision(ec_db, title="Ancient decision")
+        link_decision_to_file(ec_db, old["id"], "src/legacy/ancient.py")
+
+        # Create 201 newer decisions to push `old` beyond old 200-row limit
+        for i in range(201):
+            create_decision(ec_db, title=f"Padding decision {i}")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/legacy/ancient.py"])
+        ids = [r["id"] for r in ranked]
+        assert old["id"] in ids
+
+    def test_no_signals_returns_empty(self, ec_db):
+        create_decision(ec_db, title="Some decision")
+        ranked = rank_related_decisions(ec_db)
+        # With no signals, only fallback candidates exist but all score 0 → filtered
+        assert ranked == []
+
+    # --- Observability ---
+
+    def test_score_breakdown_keys_present(self, ec_db):
+        d = create_decision(ec_db, title="Breakdown test")
+        link_decision_to_file(ec_db, d["id"], "src/test.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/test.py"])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        expected_keys = {
+            "file_exact",
+            "file_proximity",
+            "assessment",
+            "diff_relevance",
+            "git_commit",
+            "quality",
+            "staleness_factor",
+        }
+        assert set(item["score_breakdown"].keys()) == expected_keys
+
+    def test_score_breakdown_sums_correctly(self, ec_db):
+        d = create_decision(ec_db, title="Sum test")
+        link_decision_to_file(ec_db, d["id"], "src/sum.py")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/sum.py"])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        bd = item["score_breakdown"]
+        expected_base = (
+            bd["file_exact"] + bd["file_proximity"] + bd["assessment"] + bd["diff_relevance"] + bd["git_commit"]
+        )
+        assert abs(item["base_score"] - round(expected_base, 3)) < 0.01
+        expected_score = expected_base * bd["staleness_factor"] + bd["quality"]
+        assert abs(item["score"] - round(expected_score, 3)) < 0.01
+
+    # --- Backward compatibility ---
+
+    def test_return_format_backward_compat(self, ec_db):
+        d = create_decision(ec_db, title="Compat test")
+        link_decision_to_file(ec_db, d["id"], "src/compat.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/compat.py"])
+        item = ranked[0]
+        for key in ("id", "title", "staleness_status", "updated_at", "base_score", "quality_score", "score"):
+            assert key in item

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -652,6 +652,31 @@ class TestRankingSignals:
             assert found[0]["score_breakdown"]["file_proximity"] == 0.0
             assert found[0]["score_breakdown"]["file_exact"] == 0.0
 
+    def test_file_exact_match_dotslash_stored_path(self, ec_db):
+        """Exact match must work when the stored path has a ./ prefix."""
+        d = create_decision(ec_db, title="Dotslash stored path")
+        # Simulate a path stored with ./ prefix (as some tooling produces)
+        link_decision_to_file(ec_db, d["id"], "./src/auth.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/auth.py"])
+        assert len(ranked) >= 1
+        item = next((r for r in ranked if r["id"] == d["id"]), None)
+        assert item is not None, "Decision with ./src/auth.py should match query for src/auth.py"
+        assert item["score_breakdown"]["file_exact"] == 3.0
+
+    def test_file_proximity_sibling_directory(self, ec_db):
+        """Decision in a sibling directory must be a candidate for proximity scoring."""
+        d = create_decision(ec_db, title="Sibling dir decision")
+        # Decision linked to src/service/y.py (sibling of src/service/sub/)
+        link_decision_to_file(ec_db, d["id"], "src/service/y.py")
+
+        # Changed file is src/service/sub/x.py — sibling should have proximity 0.75
+        ranked = rank_related_decisions(ec_db, file_paths=["src/service/sub/x.py"])
+        assert len(ranked) >= 1
+        item = next((r for r in ranked if r["id"] == d["id"]), None)
+        assert item is not None, "Decision in sibling dir should be a candidate"
+        assert item["score_breakdown"]["file_proximity"] == 0.75
+
     def test_assessment_match(self, ec_db):
         assessment = create_assessment(ec_db, verdict="expand", impact_summary="assessment signal test")
         d = create_decision(ec_db, title="Assessment linked")


### PR DESCRIPTION
## Summary

- Replace 200-row recency-based scoring with candidate-first architecture that gathers candidates from signal sources (files, assessments, FTS5 diff, commits) then scores the union
- Add 5 ranking signals: file exact/proximity, assessment with relation-type weighting, FTS5 diff matching, git commit SHA, and staleness penalty
- Return `score_breakdown` in every result for retrieval observability and debugging
- Add `commit_shas` parameter to `ec_decision_related` MCP tool

## Test plan

- [x] `uv run pytest tests/test_decisions_core.py -v` — 76 tests pass (18 new in `TestRankingSignals`)
- [x] Verify signal isolation: file exact, file proximity (same/parent/different), assessment, diff FTS5, commit match
- [x] Verify staleness penalty: fresh > stale > superseded
- [x] Verify scenario tests: repeated-task (same files), regression-fix (files + commits), beyond-200-recency ceiling
- [x] Verify `score_breakdown` keys present and sums correctly
- [x] Verify backward compatibility: existing API keys (id, title, base_score, quality_score, score) preserved
- [x] `uv run ruff check && uv run ruff format --check .` — lint/format clean

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)