### PR TITLE
fix(mcp): normalize common input shapes and return friendlier query errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ uv run pytest --cov=entirecontext # coverage
 
 Tests use real git repos via fixtures (`git_repo`, `ec_repo`, `ec_db`, `isolated_global_db`). External deps are isolated with `monkeypatch`. See `tests/conftest.py`.
 
+When modifying a source module, always run the existing tests for that module before committing — not just newly written tests. Test verification scope must match the change scope.
+
 ## Lint & Format
 
 ```bash

--- a/src/entirecontext/cli/search_cmds.py
+++ b/src/entirecontext/cli/search_cmds.py
@@ -12,6 +12,7 @@ from rich.table import Table
 
 console = Console()
 
+
 def search(
     query: str = typer.Argument(..., help="Search query"),
     fts: bool = typer.Option(False, "--fts", help="Use FTS5 full-text search"),
@@ -40,17 +41,21 @@ def search(
         if hybrid:
             console.print("[yellow]--hybrid is not supported for cross-repo search; falling back to FTS5.[/yellow]")
         search_type = "semantic" if semantic else ("fts" if fts or hybrid else "regex")
-        results = cross_repo_search(
-            query,
-            search_type=search_type,
-            target=target,
-            repos=repo,
-            file_filter=file,
-            commit_filter=commit,
-            agent_filter=agent,
-            since=since,
-            limit=limit,
-        )
+        try:
+            results = cross_repo_search(
+                query,
+                search_type=search_type,
+                target=target,
+                repos=repo,
+                file_filter=file,
+                commit_filter=commit,
+                agent_filter=agent,
+                since=since,
+                limit=limit,
+            )
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1)
     else:
         from ..core.project import find_git_root
         from ..core.telemetry import detect_current_context, record_retrieval_event

--- a/src/entirecontext/core/cross_repo.py
+++ b/src/entirecontext/core/cross_repo.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .context import GlobalContext
+from .search import FTSQueryError
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class RepoExecutor:
                     result["repo_name"] = repo["repo_name"]
                     result["repo_path"] = repo["repo_path"]
                 all_results.extend(results)
-            except ValueError:
+            except FTSQueryError:
                 raise
             except Exception as exc:
                 warnings.append(self.policy.warning(repo, "query", exc))
@@ -141,7 +142,7 @@ class RepoExecutor:
                     result["repo_name"] = repo["repo_name"]
                     result["repo_path"] = repo["repo_path"]
                     return result, warnings
-            except ValueError:
+            except FTSQueryError:
                 raise
             except Exception as exc:
                 warnings.append(self.policy.warning(repo, "query", exc))

--- a/src/entirecontext/core/cross_repo.py
+++ b/src/entirecontext/core/cross_repo.py
@@ -106,6 +106,8 @@ class RepoExecutor:
                     result["repo_name"] = repo["repo_name"]
                     result["repo_path"] = repo["repo_path"]
                 all_results.extend(results)
+            except ValueError:
+                raise
             except Exception as exc:
                 warnings.append(self.policy.warning(repo, "query", exc))
                 logger.debug("Skipping repo %s", repo.get("repo_path"), exc_info=True)
@@ -139,6 +141,8 @@ class RepoExecutor:
                     result["repo_name"] = repo["repo_name"]
                     result["repo_path"] = repo["repo_path"]
                     return result, warnings
+            except ValueError:
+                raise
             except Exception as exc:
                 warnings.append(self.policy.warning(repo, "query", exc))
                 logger.debug("Skipping repo %s", repo.get("repo_path"), exc_info=True)
@@ -348,7 +352,9 @@ def cross_repo_related(
             results.extend(fts_search(conn, query, target="turn", limit=limit * 2))
         if files:
             for file_pattern in files:
-                results.extend(regex_search(conn, file_pattern, target="turn", file_filter=file_pattern, limit=limit * 2))
+                results.extend(
+                    regex_search(conn, file_pattern, target="turn", file_filter=file_pattern, limit=limit * 2)
+                )
         return results
 
     results, warnings = RepoExecutor().execute(fn, repos=repos, sort_key="timestamp", limit=limit)

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -1036,9 +1036,9 @@ def fts_search_decisions(
     try:
         rows = conn.execute(sql, params).fetchall()
     except Exception as exc:
-        msg = str(exc)
-        if "fts5: syntax error" in msg or "parse error" in msg.lower():
-            raise ValueError(f"Invalid FTS5 query syntax: {msg}") from exc
+        from .search import _raise_fts_query_error
+
+        _raise_fts_query_error(exc)
         raise
 
     return [dict(r) for r in rows]

--- a/src/entirecontext/core/search.py
+++ b/src/entirecontext/core/search.py
@@ -182,14 +182,20 @@ def _regex_search_content(conn, pattern: str, limit: int) -> list[dict]:
     return results
 
 
+class FTSQueryError(ValueError):
+    """Raised when an FTS5 query has invalid syntax."""
+
+
 _FTS5_ERROR_PATTERNS = ("fts5: syntax error", "no such column", "unterminated string", "parse error")
 
 
 def _raise_fts_query_error(exc: sqlite3.OperationalError) -> None:
-    """Convert FTS5 query-related OperationalError to a ValueError with actionable message."""
+    """Convert FTS5 query-related OperationalError to FTSQueryError with actionable message."""
     msg = str(exc).lower()
     if any(p in msg for p in _FTS5_ERROR_PATTERNS):
-        raise ValueError(f"Invalid FTS query: {exc}. Wrap punctuation in double-quotes or simplify the query.") from exc
+        raise FTSQueryError(
+            f"Invalid FTS query: {exc}. Wrap punctuation in double-quotes or simplify the query."
+        ) from exc
 
 
 def fts_search(

--- a/src/entirecontext/core/search.py
+++ b/src/entirecontext/core/search.py
@@ -182,6 +182,16 @@ def _regex_search_content(conn, pattern: str, limit: int) -> list[dict]:
     return results
 
 
+_FTS5_ERROR_PATTERNS = ("fts5: syntax error", "no such column", "unterminated string", "parse error")
+
+
+def _raise_fts_query_error(exc: sqlite3.OperationalError) -> None:
+    """Convert FTS5 query-related OperationalError to a ValueError with actionable message."""
+    msg = str(exc).lower()
+    if any(p in msg for p in _FTS5_ERROR_PATTERNS):
+        raise ValueError(f"Invalid FTS query: {exc}. Wrap punctuation in double-quotes or simplify the query.") from exc
+
+
 def fts_search(
     conn,
     query: str,
@@ -230,7 +240,11 @@ def _fts_search_turns(conn, query, file_filter, commit_filter, agent_filter, sin
     sql += " ORDER BY rank LIMIT ?"
     params.append(limit)
 
-    rows = conn.execute(sql, params).fetchall()
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        _raise_fts_query_error(exc)
+        raise
     results = [dict(r) for r in rows]
 
     if file_filter:
@@ -247,7 +261,12 @@ def _fts_search_sessions(conn, query, since, limit) -> list[dict]:
         params.append(since)
     sql += " ORDER BY rank LIMIT ?"
     params.append(limit)
-    return [dict(r) for r in conn.execute(sql, params).fetchall()]
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        _raise_fts_query_error(exc)
+        raise
+    return [dict(r) for r in rows]
 
 
 def _fts_search_events(conn, query, since, limit) -> list[dict]:
@@ -258,7 +277,12 @@ def _fts_search_events(conn, query, since, limit) -> list[dict]:
         params.append(since)
     sql += " ORDER BY rank LIMIT ?"
     params.append(limit)
-    return [dict(r) for r in conn.execute(sql, params).fetchall()]
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as exc:
+        _raise_fts_query_error(exc)
+        raise
+    return [dict(r) for r in rows]
 
 
 # ---------------------------------------------------------------------------

--- a/src/entirecontext/core/search.py
+++ b/src/entirecontext/core/search.py
@@ -189,8 +189,8 @@ class FTSQueryError(ValueError):
 _FTS5_ERROR_PATTERNS = ("fts5: syntax error", "no such column", "unterminated string", "parse error")
 
 
-def _raise_fts_query_error(exc: sqlite3.OperationalError) -> None:
-    """Convert FTS5 query-related OperationalError to FTSQueryError with actionable message."""
+def _raise_fts_query_error(exc: Exception) -> None:
+    """Convert FTS5 query-related exceptions to FTSQueryError with actionable message."""
     msg = str(exc).lower()
     if any(p in msg for p in _FTS5_ERROR_PATTERNS):
         raise FTSQueryError(

--- a/src/entirecontext/mcp/runtime.py
+++ b/src/entirecontext/mcp/runtime.py
@@ -27,7 +27,9 @@ def _resolve_explicit_repo(repo_path: str, *, source_label: str) -> tuple[sqlite
     if context.project is None:
         resolved_path = context.repo_path
         context.close()
-        raise RepoResolutionError(f"{source_label}={repo_path} points to a repo at {resolved_path} that is not initialized. Run 'ec init'.")
+        raise RepoResolutionError(
+            f"{source_label}={repo_path} points to a repo at {resolved_path} that is not initialized. Run 'ec init'."
+        )
     # Caller takes ownership of conn; context is intentionally not closed here
     return context.conn, context.repo_path
 
@@ -120,7 +122,9 @@ def record_selection(conn, **kwargs):
     return server._record_selection(conn, **kwargs)
 
 
-def normalize_repo_names(repos: list[str] | None) -> list[str] | None:
+def normalize_repo_names(repos: str | list[str] | None) -> list[str] | None:
+    if isinstance(repos, str):
+        repos = [repos] if repos else []
     return None if not repos or repos == ["*"] else repos
 
 

--- a/src/entirecontext/mcp/tools/checkpoint.py
+++ b/src/entirecontext/mcp/tools/checkpoint.py
@@ -15,7 +15,7 @@ async def ec_checkpoint_list(
     retrieval_event_id: str | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_checkpoints
 
         results, warnings = cross_repo_checkpoints(
@@ -98,7 +98,7 @@ async def ec_checkpoint_list(
 
 async def ec_rewind(checkpoint_id: str, repos: str | list[str] | None = None) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_rewind
 
         result, warnings = cross_repo_rewind(checkpoint_id, repos=repo_names, include_warnings=True)

--- a/src/entirecontext/mcp/tools/checkpoint.py
+++ b/src/entirecontext/mcp/tools/checkpoint.py
@@ -11,14 +11,15 @@ async def ec_checkpoint_list(
     session_id: str | None = None,
     limit: int = 20,
     since: str | None = None,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
     retrieval_event_id: str | None = None,
 ) -> str:
-    if repos is not None:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_checkpoints
 
         results, warnings = cross_repo_checkpoints(
-            repos=runtime.normalize_repo_names(repos),
+            repos=repo_names,
             session_id=session_id,
             since=since,
             limit=limit,
@@ -95,11 +96,12 @@ async def ec_checkpoint_list(
         conn.close()
 
 
-async def ec_rewind(checkpoint_id: str, repos: list[str] | None = None) -> str:
-    if repos is not None:
+async def ec_rewind(checkpoint_id: str, repos: str | list[str] | None = None) -> str:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_rewind
 
-        result, warnings = cross_repo_rewind(checkpoint_id, repos=runtime.normalize_repo_names(repos), include_warnings=True)
+        result, warnings = cross_repo_rewind(checkpoint_id, repos=repo_names, include_warnings=True)
         if not result:
             return runtime.error_payload(f"Checkpoint not found: {checkpoint_id}", warnings=warnings)
         return json.dumps(

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -238,7 +238,8 @@ async def ec_decision_search(
         search_type: "fts" for relevance-ranked or "hybrid" for relevance+recency
         since: ISO date filter — only return decisions updated after this date
         limit: Maximum results (default 20)
-        repos: Repo filter — null for current repo, ["*"] for all repos
+        repos: Repo filter — null for current repo, "*" or ["*"] for all repos,
+               or a plain repo name string (coerced to a single-element list)
     """
     if search_type not in ("fts", "hybrid"):
         return runtime.error_payload(f"Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.")

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -8,7 +8,7 @@ import time
 from .. import runtime
 
 
-def _ensure_list(value, field_name: str) -> list | None:
+def _ensure_list(value: str | dict | list | None, field_name: str) -> list | None:
     """Coerce common agent input shapes for list fields into proper lists."""
     if value is None:
         return None

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -244,7 +244,7 @@ async def ec_decision_search(
         return runtime.error_payload(f"Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.")
 
     repo_names = runtime.normalize_repo_names(repos)
-    is_cross_repo = bool(repos)
+    is_cross_repo = repos is not None and repos != ""
     if is_cross_repo:
         from ...core.cross_repo import _for_each_repo
         from ...core.decisions import fts_search_decisions, hybrid_search_decisions

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -8,6 +8,19 @@ import time
 from .. import runtime
 
 
+def _ensure_list(value, field_name: str) -> list | None:
+    """Coerce common agent input shapes for list fields into proper lists."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list):
+        return value
+    raise ValueError(f"'{field_name}' must be a list, string, or null. Got {type(value).__name__}.")
+
+
 async def ec_decision_get(decision_id: str) -> str:
     (conn, _), error = runtime.resolve_repo()
     if error:
@@ -123,8 +136,8 @@ async def ec_decision_create(
     title: str,
     rationale: str | None = None,
     scope: str | None = None,
-    rejected_alternatives: list[str] | None = None,
-    supporting_evidence: list | None = None,
+    rejected_alternatives: list[str] | str | None = None,
+    supporting_evidence: list | str | dict | None = None,
 ) -> str:
     """Create a new decision record.
 
@@ -139,6 +152,9 @@ async def ec_decision_create(
     if error:
         return error
     try:
+        rejected_alternatives = _ensure_list(rejected_alternatives, "rejected_alternatives")
+        supporting_evidence = _ensure_list(supporting_evidence, "supporting_evidence")
+
         from ...core.decisions import create_decision
 
         d = create_decision(
@@ -210,7 +226,7 @@ async def ec_decision_search(
     search_type: str = "fts",
     since: str | None = None,
     limit: int = 20,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
 ) -> str:
     """Search decisions by keyword using FTS5 full-text search.
 
@@ -227,9 +243,9 @@ async def ec_decision_search(
     if search_type not in ("fts", "hybrid"):
         return runtime.error_payload(f"Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.")
 
-    is_cross_repo = repos is not None
+    repo_names = runtime.normalize_repo_names(repos)
+    is_cross_repo = bool(repos)
     if is_cross_repo:
-        repo_names = runtime.normalize_repo_names(repos)
         from ...core.cross_repo import _for_each_repo
         from ...core.decisions import fts_search_decisions, hybrid_search_decisions
 
@@ -239,7 +255,10 @@ async def ec_decision_search(
             return fts_search_decisions(conn, query, since=since, limit=limit)
 
         cross_sort_key = "hybrid_score" if search_type == "hybrid" else "relevance_score"
-        all_results, _warnings = _for_each_repo(_query, repos=repo_names, sort_key=cross_sort_key, limit=limit)
+        try:
+            all_results, _warnings = _for_each_repo(_query, repos=repo_names, sort_key=cross_sort_key, limit=limit)
+        except ValueError as exc:
+            return runtime.error_payload(str(exc))
         formatted = _format_decision_results(all_results)
         return json.dumps({"decisions": formatted, "count": len(formatted), "retrieval_event_id": None})
 

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -136,7 +136,7 @@ async def ec_decision_create(
     title: str,
     rationale: str | None = None,
     scope: str | None = None,
-    rejected_alternatives: list[str] | str | None = None,
+    rejected_alternatives: list[str] | str | dict | None = None,
     supporting_evidence: list | str | dict | None = None,
 ) -> str:
     """Create a new decision record.

--- a/src/entirecontext/mcp/tools/futures.py
+++ b/src/entirecontext/mcp/tools/futures.py
@@ -165,11 +165,12 @@ async def ec_lessons(limit: int = 50) -> str:
         conn.close()
 
 
-async def ec_assess_trends(repos: list[str] | None = None, since: str | None = None) -> str:
+async def ec_assess_trends(repos: str | list[str] | None = None, since: str | None = None) -> str:
     from ...core.cross_repo import cross_repo_assessment_trends
 
+    repo_names = runtime.normalize_repo_names(repos)
     trends, warnings = cross_repo_assessment_trends(
-        repos=runtime.normalize_repo_names(repos),
+        repos=repo_names,
         since=since,
         include_warnings=True,
     )

--- a/src/entirecontext/mcp/tools/search.py
+++ b/src/entirecontext/mcp/tools/search.py
@@ -16,24 +16,27 @@ async def ec_search(
     agent_filter: str | None = None,
     since: str | None = None,
     limit: int = 20,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
 ) -> str:
-    is_cross_repo = repos is not None
     repo_names = runtime.normalize_repo_names(repos)
+    is_cross_repo = bool(repos)
 
     if is_cross_repo:
         from ...core.cross_repo import cross_repo_search
 
-        results = cross_repo_search(
-            query,
-            search_type=search_type,
-            repos=repo_names,
-            file_filter=file_filter,
-            commit_filter=commit_filter,
-            agent_filter=agent_filter,
-            since=since,
-            limit=limit,
-        )
+        try:
+            results = cross_repo_search(
+                query,
+                search_type=search_type,
+                repos=repo_names,
+                file_filter=file_filter,
+                commit_filter=commit_filter,
+                agent_filter=agent_filter,
+                since=since,
+                limit=limit,
+            )
+        except ValueError as exc:
+            return runtime.error_payload(str(exc))
         retrieval_event_id = None
     else:
         (conn, repo_path), error = runtime.resolve_repo()
@@ -114,6 +117,8 @@ async def ec_search(
                 agent_filter=agent_filter,
                 since=since,
             )
+        except ValueError as exc:
+            return runtime.error_payload(str(exc))
         finally:
             conn.close()
 
@@ -141,18 +146,22 @@ async def ec_related(
     query: str | None = None,
     files: list[str] | None = None,
     limit: int = 20,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
 ) -> str:
-    if repos is not None:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_related
 
-        results, warnings = cross_repo_related(
-            query=query,
-            files=files,
-            repos=runtime.normalize_repo_names(repos),
-            limit=limit,
-            include_warnings=True,
-        )
+        try:
+            results, warnings = cross_repo_related(
+                query=query,
+                files=files,
+                repos=repo_names,
+                limit=limit,
+                include_warnings=True,
+            )
+        except ValueError as exc:
+            return runtime.error_payload(str(exc))
         related = [
             {
                 "type": "turn",

--- a/src/entirecontext/mcp/tools/search.py
+++ b/src/entirecontext/mcp/tools/search.py
@@ -19,7 +19,7 @@ async def ec_search(
     repos: str | list[str] | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    is_cross_repo = bool(repos)
+    is_cross_repo = repos is not None and repos != ""
 
     if is_cross_repo:
         from ...core.cross_repo import cross_repo_search
@@ -149,7 +149,7 @@ async def ec_related(
     repos: str | list[str] | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_related
 
         try:

--- a/src/entirecontext/mcp/tools/session.py
+++ b/src/entirecontext/mcp/tools/session.py
@@ -13,7 +13,7 @@ async def ec_session_context(
     retrieval_event_id: str | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_session_detail
 
         if not session_id:
@@ -108,7 +108,7 @@ async def ec_attribution(
     repos: str | list[str] | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_attribution
 
         results, warnings = cross_repo_attribution(
@@ -178,7 +178,7 @@ async def ec_turn_content(
     retrieval_event_id: str | None = None,
 ) -> str:
     repo_names = runtime.normalize_repo_names(repos)
-    if bool(repos):
+    if repos is not None and repos != "":
         from ...core.cross_repo import cross_repo_turn_content
 
         result, warnings = cross_repo_turn_content(turn_id, repos=repo_names, include_warnings=True)

--- a/src/entirecontext/mcp/tools/session.py
+++ b/src/entirecontext/mcp/tools/session.py
@@ -9,15 +9,16 @@ from .. import runtime
 
 async def ec_session_context(
     session_id: str | None = None,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
     retrieval_event_id: str | None = None,
 ) -> str:
-    if repos is not None:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_session_detail
 
         if not session_id:
             return runtime.error_payload("session_id is required for cross-repo session context")
-        result, warnings = cross_repo_session_detail(session_id, repos=runtime.normalize_repo_names(repos), include_warnings=True)
+        result, warnings = cross_repo_session_detail(session_id, repos=repo_names, include_warnings=True)
         if not result:
             return runtime.error_payload(f"Session not found: {session_id}", warnings=warnings)
         turns = result.get("turns", [])
@@ -104,16 +105,17 @@ async def ec_attribution(
     file_path: str,
     start_line: int | None = None,
     end_line: int | None = None,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
 ) -> str:
-    if repos is not None:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_attribution
 
         results, warnings = cross_repo_attribution(
             file_path,
             start_line,
             end_line,
-            repos=runtime.normalize_repo_names(repos),
+            repos=repo_names,
             include_warnings=True,
         )
         attributions = [
@@ -172,13 +174,14 @@ async def ec_attribution(
 
 async def ec_turn_content(
     turn_id: str,
-    repos: list[str] | None = None,
+    repos: str | list[str] | None = None,
     retrieval_event_id: str | None = None,
 ) -> str:
-    if repos is not None:
+    repo_names = runtime.normalize_repo_names(repos)
+    if bool(repos):
         from ...core.cross_repo import cross_repo_turn_content
 
-        result, warnings = cross_repo_turn_content(turn_id, repos=runtime.normalize_repo_names(repos), include_warnings=True)
+        result, warnings = cross_repo_turn_content(turn_id, repos=repo_names, include_warnings=True)
         if not result:
             return runtime.error_payload(f"Turn not found: {turn_id}", warnings=warnings)
         return json.dumps(

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -595,7 +595,7 @@ class TestDecisionFTSSearch:
 
     def test_fts_search_bad_query_raises_error(self, ec_db):
         create_decision(ec_db, title="Some decision", rationale="Some rationale")
-        with pytest.raises(ValueError, match="Invalid FTS5 query syntax"):
+        with pytest.raises(ValueError, match="Invalid FTS query"):
             fts_search_decisions(ec_db, "AND OR NOT")
 
     def test_hybrid_search_returns_scores(self, ec_db):

--- a/tests/test_mcp_input_normalization.py
+++ b/tests/test_mcp_input_normalization.py
@@ -144,6 +144,14 @@ class TestFtsQueryErrorHandling:
         assert "error" in result
         assert "Invalid FTS query" in result["error"]
 
+    def test_ec_search_foo_colon_bar_returns_error_payload(self, mock_repo_db):
+        """Matches PR test plan: ec_search(query='foo:bar', search_type='fts')."""
+        from entirecontext.mcp.tools.search import ec_search
+
+        result = json.loads(asyncio.run(ec_search("foo:bar", search_type="fts")))
+        assert "error" in result
+        assert "Invalid FTS query" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # Part 3: Decision field coercion
@@ -208,3 +216,17 @@ class TestDecisionCreateCoercion:
         )
         assert "error" in result
         assert "rejected_alternatives" in result["error"]
+
+    def test_plain_single_string_coerced(self, mock_repo_db):
+        """Matches PR test plan: rejected_alternatives='single string' -> ['single string']."""
+        from entirecontext.mcp.tools.decisions import ec_decision_create
+
+        result = json.loads(
+            asyncio.run(
+                ec_decision_create(
+                    title="Test decision",
+                    rejected_alternatives="single string",
+                )
+            )
+        )
+        assert result["rejected_alternatives"] == ["single string"]

--- a/tests/test_mcp_input_normalization.py
+++ b/tests/test_mcp_input_normalization.py
@@ -1,0 +1,210 @@
+"""Regression tests for issue #44: normalize common input shapes and friendlier query errors."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from entirecontext.db.connection import get_memory_db
+from entirecontext.db.migration import init_schema
+from entirecontext.mcp import runtime
+from entirecontext.mcp.tools.decisions import _ensure_list
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db():
+    conn = get_memory_db()
+    init_schema(conn)
+    conn.execute("INSERT INTO projects (id, name, repo_path) VALUES ('p1', 'test', '/tmp/test')")
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, started_at, last_activity_at, session_title, session_summary, total_turns) "
+        "VALUES ('s1', 'p1', 'claude', '2025-01-01', '2025-01-01', 'Test Session', 'A test session', 3)"
+    )
+    conn.execute(
+        "INSERT INTO turns (id, session_id, turn_number, user_message, assistant_summary, content_hash, timestamp) "
+        "VALUES ('t1', 's1', 1, 'fix auth bug', 'Fixed authentication', 'hash1', '2025-01-01')"
+    )
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def mock_repo_db(db, monkeypatch):
+    class _NoCloseConn:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+
+        def close(self):
+            pass
+
+        def __getattr__(self, name):
+            return getattr(object.__getattribute__(self, "_conn"), name)
+
+    wrapper = _NoCloseConn(db)
+    monkeypatch.setattr("entirecontext.mcp.runtime.get_repo_db", lambda repo_hint=None: (wrapper, "/tmp/test"))
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Part 1: normalize_repo_names
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRepoNames:
+    def test_string_coerced_to_list(self):
+        assert runtime.normalize_repo_names("myrepo") == ["myrepo"]
+
+    def test_string_star_returns_none(self):
+        assert runtime.normalize_repo_names("*") is None
+
+    def test_list_unchanged(self):
+        assert runtime.normalize_repo_names(["a", "b"]) == ["a", "b"]
+
+    def test_list_star_returns_none(self):
+        assert runtime.normalize_repo_names(["*"]) is None
+
+    def test_none_returns_none(self):
+        assert runtime.normalize_repo_names(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert runtime.normalize_repo_names("") is None
+
+    def test_empty_list_returns_none(self):
+        assert runtime.normalize_repo_names([]) is None
+
+    def test_wildcard_star_triggers_cross_repo(self):
+        """repos=["*"] should still trigger cross-repo mode (bool(repos) is True)
+        even though normalize returns None (meaning 'all repos')."""
+        repos_input = ["*"]
+        assert bool(repos_input) is True
+        assert runtime.normalize_repo_names(repos_input) is None
+
+    def test_scalar_star_triggers_cross_repo(self):
+        """repos="*" should trigger cross-repo mode."""
+        repos_input = "*"
+        assert bool(repos_input) is True
+        assert runtime.normalize_repo_names(repos_input) is None
+
+
+# ---------------------------------------------------------------------------
+# Part 2: FTS query error handling
+# ---------------------------------------------------------------------------
+
+
+class TestFtsQueryErrorHandling:
+    def test_fts_turns_bad_syntax_raises_valueerror(self, db):
+        from entirecontext.core.search import _fts_search_turns
+
+        with pytest.raises(ValueError, match="Invalid FTS query"):
+            _fts_search_turns(db, "AND OR NOT", None, None, None, None, 10)
+
+    def test_fts_sessions_bad_syntax_raises_valueerror(self, db):
+        from entirecontext.core.search import _fts_search_sessions
+
+        with pytest.raises(ValueError, match="Invalid FTS query"):
+            _fts_search_sessions(db, "AND OR NOT", None, 10)
+
+    def test_fts_events_bad_syntax_raises_valueerror(self, db):
+        from entirecontext.core.search import _fts_search_events
+
+        with pytest.raises(ValueError, match="Invalid FTS query"):
+            _fts_search_events(db, "AND OR NOT", None, 10)
+
+    def test_fts_colon_punctuation_raises_valueerror(self, db):
+        from entirecontext.core.search import _fts_search_turns
+
+        with pytest.raises(ValueError, match="Invalid FTS query"):
+            _fts_search_turns(db, "foo:bar", None, None, None, None, 10)
+
+    def test_fts_valid_query_still_works(self, db):
+        from entirecontext.core.search import _fts_search_turns
+
+        results = _fts_search_turns(db, "auth", None, None, None, None, 10)
+        assert isinstance(results, list)
+
+    def test_ec_search_fts_bad_syntax_returns_error_payload(self, mock_repo_db):
+        from entirecontext.mcp.tools.search import ec_search
+
+        result = json.loads(asyncio.run(ec_search("AND OR NOT", search_type="fts")))
+        assert "error" in result
+        assert "Invalid FTS query" in result["error"]
+
+    def test_ec_search_hybrid_bad_syntax_returns_error_payload(self, mock_repo_db):
+        from entirecontext.mcp.tools.search import ec_search
+
+        result = json.loads(asyncio.run(ec_search("AND OR NOT", search_type="hybrid")))
+        assert "error" in result
+        assert "Invalid FTS query" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Part 3: Decision field coercion
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureList:
+    def test_none_passthrough(self):
+        assert _ensure_list(None, "f") is None
+
+    def test_string_to_list(self):
+        assert _ensure_list("a", "f") == ["a"]
+
+    def test_dict_to_list(self):
+        assert _ensure_list({"k": "v"}, "f") == [{"k": "v"}]
+
+    def test_list_passthrough(self):
+        assert _ensure_list(["a", "b"], "f") == ["a", "b"]
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match="must be a list, string, or null"):
+            _ensure_list(42, "field_name")
+
+
+class TestDecisionCreateCoercion:
+    def test_string_alternatives_coerced(self, mock_repo_db):
+        from entirecontext.mcp.tools.decisions import ec_decision_create
+
+        result = json.loads(
+            asyncio.run(
+                ec_decision_create(
+                    title="Test decision",
+                    rejected_alternatives="single alternative",
+                )
+            )
+        )
+        assert result["rejected_alternatives"] == ["single alternative"]
+
+    def test_dict_evidence_coerced(self, mock_repo_db):
+        from entirecontext.mcp.tools.decisions import ec_decision_create
+
+        result = json.loads(
+            asyncio.run(
+                ec_decision_create(
+                    title="Test decision",
+                    supporting_evidence={"source": "benchmark", "result": "fast"},
+                )
+            )
+        )
+        assert result["supporting_evidence"] == [{"source": "benchmark", "result": "fast"}]
+
+    def test_invalid_type_returns_error_payload(self, mock_repo_db):
+        from entirecontext.mcp.tools.decisions import ec_decision_create
+
+        result = json.loads(
+            asyncio.run(
+                ec_decision_create(
+                    title="Test decision",
+                    rejected_alternatives=42,
+                )
+            )
+        )
+        assert "error" in result
+        assert "rejected_alternatives" in result["error"]


### PR DESCRIPTION
## Summary
- Coerce scalar `repos` string to list; widen all MCP tool `repos` signatures to `str | list[str] | None`
- Add FTS5 query error handling with broader pattern matching (`fts5: syntax error`, `no such column`, `unterminated string`, `parse error`) → actionable JSON error payloads
- Add `_ensure_list` coercion for `rejected_alternatives` / `supporting_evidence` in `ec_decision_create`
- Preserve `repos=["*"]` wildcard contract for cross-repo queries while rejecting empty inputs

## Test plan
- [x] 26 regression tests in `tests/test_mcp_input_normalization.py`
- [x] Existing `tests/test_mcp.py` search/decision tests pass (5 pre-existing env failures unrelated)
- [x] `ruff check` and `ruff format` clean
- [x] `ec_search(query="foo:bar", search_type="fts")` → error payload (`test_ec_search_foo_colon_bar_returns_error_payload`)
- [x] `ec_decision_create(rejected_alternatives="single string")` → stored as `["single string"]` (`test_plain_single_string_coerced`)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)