### PR TITLE
fix(tests): correct MCP repo fixture patch target in decision/assessment suites

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1281,7 +1281,7 @@ class TestMCPDecisionToolsExtended:
 
     @pytest.fixture
     def mock_repo_db(self, db, monkeypatch):
-        monkeypatch.setattr("entirecontext.mcp.server._get_repo_db", lambda: (db, "/tmp/test"))
+        monkeypatch.setattr("entirecontext.mcp.runtime.get_repo_db", lambda repo_hint=None: (db, "/tmp/test"))
         return db
 
     def test_ec_decision_related_with_files(self, mock_repo_db):
@@ -1820,7 +1820,7 @@ class TestMCPAssessTrends:
 
     @pytest.fixture
     def mock_repo_db(self, db, monkeypatch):
-        monkeypatch.setattr("entirecontext.mcp.server._get_repo_db", lambda: (db, "/tmp/test"))
+        monkeypatch.setattr("entirecontext.mcp.runtime.get_repo_db", lambda repo_hint=None: (db, "/tmp/test"))
         return db
 
     def _seed_assessments(self, conn, count=3, verdict="expand", created_at="2025-06-01", feedback=None):


### PR DESCRIPTION
### Motivation
- Tests in `TestMCPDecisionToolsExtended` and `TestMCPAssessTrends` could fail on developer machines with multiple registered repos due to fixtures patching a stale symbol, causing `RepoResolutionError: Multiple repos registered` during repo resolution. 
- The project uses `runtime.resolve_repo()` / `runtime.get_repo_db()` as the active path for MCP repo resolution, so fixtures must intercept `entirecontext.mcp.runtime.get_repo_db` to reliably isolate test DBs.

### Description
- Updated two `mock_repo_db` fixtures in `tests/test_mcp.py` to patch `entirecontext.mcp.runtime.get_repo_db` with `lambda repo_hint=None: (db, "/tmp/test")` instead of the old `entirecontext.mcp.server._get_repo_db` target. 
- Changes align these fixtures with the pattern used by other working fixtures in the same file and with the current MCP runtime code path. 
- Commit message: `fix(tests): patch MCP fixtures to runtime get_repo_db` and PR titled `fix(tests): correct MCP repo fixture patch target in decision/assessment suites` were created.

### Testing
- Ran `uv run ec decision list --limit 5` and confirmed no stored decisions were found, so no decision-driven change was applied. 
- Ran targeted pytest without `PYTHONPATH` which failed import due to environment, then ran `PYTHONPATH=src uv run pytest tests/test_mcp.py::TestMCPDecisionToolsExtended tests/test_mcp.py::TestMCPAssessTrends -q` and observed successful collection with all tests skipped due to the optional `mcp` dependency (9 skipped), indicating the fixture import/collection succeeds in this environment. 
- No test failures were introduced by these changes in the test runs performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def6dc0490832390895d649ef990aa)