### PR TITLE
feat(decisions): candidate extraction pipeline with confirmation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,11 +63,11 @@ cli/             business    SQLite     Claude Code   shadow branch
 
 **Per-repo DB**: `.entirecontext/db/local.db`
 **Global DB**: `~/.entirecontext/db/ec.db`
-**Schema version**: 12
+**Schema version**: 13
 
-Key tables: `projects`, `sessions`, `turns`, `turn_content`, `checkpoints`, `agents`, `events`, `assessments`, `assessment_relationships`, `attributions`, `embeddings`, `ast_symbols`, `sync_metadata`
+Key tables: `projects`, `sessions`, `turns`, `turn_content`, `checkpoints`, `agents`, `events`, `assessments`, `assessment_relationships`, `attributions`, `embeddings`, `ast_symbols`, `sync_metadata`, `decisions`, `decision_candidates`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`
 
-FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols` (auto-synced via triggers)
+FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols`, `fts_decisions`, `fts_decision_candidates` (auto-synced via triggers)
 
 Hybrid storage: SQLite for metadata/search, JSONL content files referenced by `turn_content.content_path`.
 

--- a/scripts/generate_noisy_candidate_fixtures.py
+++ b/scripts/generate_noisy_candidate_fixtures.py
@@ -1,0 +1,161 @@
+"""Tier 2 noisy candidate fixture generator (manual, one-shot).
+
+Samples N real sessions from the dev .entirecontext/db/local.db, redacts every
+text field via core.content_filter.redact_content, and writes static JSON
+fixtures under tests/fixtures/noisy_candidates/real/.
+
+This script is checked in for reproducibility. The test suite does NOT invoke
+it at collection time — tier 2 fixture tests skip cleanly when the output
+files are absent, so a fresh clone still passes the full suite.
+
+Usage (from the repo root, inside `uv run`):
+
+    uv run python scripts/generate_noisy_candidate_fixtures.py \
+        --out tests/fixtures/noisy_candidates/real \
+        --count 5
+
+The generator intentionally avoids calling any LLM. Recording the model
+response for each fixture is a follow-up step done by hand after review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _ensure_ec_db_path(repo_root: Path) -> Path:
+    path = repo_root / ".entirecontext" / "db" / "local.db"
+    if not path.exists():
+        raise FileNotFoundError(f"dev DB not found at {path}. Run ec commands in this repo first.")
+    return path
+
+
+def _sample_sessions(conn, count: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT s.id, s.session_title, s.session_summary, s.total_turns,
+               (SELECT COUNT(*) FROM checkpoints WHERE session_id = s.id) AS checkpoint_count
+        FROM sessions s
+        WHERE s.total_turns >= 3
+          AND s.ended_at IS NOT NULL
+        ORDER BY RANDOM()
+        LIMIT ?
+        """,
+        (count,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _collect_session_payload(conn, session_id: str) -> dict:
+    from entirecontext.core.content_filter import redact_content
+
+    session_row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if not session_row:
+        return {}
+    turns = conn.execute(
+        "SELECT id, turn_number, user_message, assistant_summary, files_touched "
+        "FROM turns WHERE session_id = ? ORDER BY turn_number ASC",
+        (session_id,),
+    ).fetchall()
+    checkpoints = conn.execute(
+        "SELECT id, created_at, diff_summary, files_snapshot "
+        "FROM checkpoints WHERE session_id = ? ORDER BY created_at ASC",
+        (session_id,),
+    ).fetchall()
+    assessments = conn.execute(
+        "SELECT a.id, a.checkpoint_id, a.verdict, a.impact_summary, "
+        "       a.roadmap_alignment, a.tidy_suggestion, a.diff_summary "
+        "FROM assessments a JOIN checkpoints c ON a.checkpoint_id = c.id "
+        "WHERE c.session_id = ?",
+        (session_id,),
+    ).fetchall()
+
+    def _redact(value):
+        if value is None:
+            return None
+        return redact_content(str(value))
+
+    return {
+        "session": {
+            "id": session_row["id"],
+            "session_title": _redact(session_row["session_title"]),
+            "session_summary": _redact(session_row["session_summary"]),
+        },
+        "turns": [
+            {
+                "id": t["id"],
+                "turn_number": t["turn_number"],
+                "user_message": _redact(t["user_message"]),
+                "assistant_summary": _redact(t["assistant_summary"]),
+                "files_touched": t["files_touched"],
+            }
+            for t in turns
+        ],
+        "checkpoints": [
+            {
+                "id": c["id"],
+                "created_at": c["created_at"],
+                "diff_summary": _redact(c["diff_summary"]),
+                "files_snapshot": c["files_snapshot"],
+            }
+            for c in checkpoints
+        ],
+        "assessments": [
+            {
+                "id": a["id"],
+                "checkpoint_id": a["checkpoint_id"],
+                "verdict": a["verdict"],
+                "impact_summary": _redact(a["impact_summary"]),
+                "roadmap_alignment": _redact(a["roadmap_alignment"]),
+                "tidy_suggestion": _redact(a["tidy_suggestion"]),
+                "diff_summary": _redact(a["diff_summary"]),
+            }
+            for a in assessments
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Repository root")
+    parser.add_argument("--out", required=True, help="Output directory for fixtures")
+    parser.add_argument("--count", type=int, default=5, help="Number of sessions to sample")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo).resolve()
+    out_dir = Path(args.out).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fail fast if the dev DB is missing; the script is intentionally
+    # a manual one-shot and should not invent an empty DB.
+    _ensure_ec_db_path(repo_root)
+
+    # Import after path adjustments
+    sys.path.insert(0, str(repo_root / "src"))
+    from entirecontext.db import get_db
+
+    conn = get_db(str(repo_root))
+    try:
+        sessions = _sample_sessions(conn, args.count)
+        if not sessions:
+            print("No eligible sessions found (need ≥3 turns, ended).", file=sys.stderr)
+            return 1
+        for idx, meta in enumerate(sessions, start=1):
+            payload = _collect_session_payload(conn, meta["id"])
+            if not payload:
+                continue
+            out_file = out_dir / f"real_{idx:02d}_{meta['id'][:8]}.json"
+            out_file.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+            print(f"wrote {out_file}")
+    finally:
+        conn.close()
+
+    print(f"generated {len(sessions)} fixtures under {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -457,7 +457,7 @@ def decision_stale_all():
         console.print(f"\n[yellow]{stale_count}/{len(decisions)} decisions marked as stale.[/yellow]")
 
 
-def _get_llm_response(summaries: str, repo_path: str) -> str:
+def _get_llm_response(summaries: str, repo_path: str, source_type: str = "session") -> str:
     """LLM call shim preserved at current module path for monkeypatch-based tests.
 
     The shim body below (_extract_from_session_impl) must always call this
@@ -465,10 +465,37 @@ def _get_llm_response(summaries: str, repo_path: str) -> str:
     `entirecontext.cli.decisions_cmds._get_llm_response` remain effective.
     The production hook/worker path invokes
     `core.decision_extraction.call_extraction_llm` directly instead.
+
+    `source_type` is a keyword with default so that legacy tests that
+    monkeypatch this function with a 2-arg lambda (no source_type) still
+    work — the shim calls through `_invoke_get_llm_response` which falls
+    back to the 2-arg signature when the bound symbol does not accept
+    `source_type`.
     """
     from ..core.decision_extraction import call_extraction_llm
 
-    return call_extraction_llm(summaries, repo_path, source_type="session")
+    return call_extraction_llm(summaries, repo_path, source_type=source_type)
+
+
+def _invoke_get_llm_response(summaries: str, repo_path: str, source_type: str) -> str:
+    """Dispatch through the module-level _get_llm_response symbol while
+    staying compatible with pre-existing 2-arg monkeypatches.
+
+    Production callers (and tests that use `lambda *a, **kw: ...`) get
+    the correct per-source system prompt via the `source_type` kwarg.
+    Legacy tests that monkeypatch with `lambda summaries, repo_path: ...`
+    are detected via inspect.signature and called without the kwarg.
+    """
+    import inspect
+
+    try:
+        params = inspect.signature(_get_llm_response).parameters
+    except (TypeError, ValueError):
+        return _get_llm_response(summaries, repo_path)
+    accepts_source = "source_type" in params or any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+    if accepts_source:
+        return _get_llm_response(summaries, repo_path, source_type=source_type)
+    return _get_llm_response(summaries, repo_path)
 
 
 def _extract_from_session_impl(conn, session_id: str, repo_path: str) -> None:
@@ -493,7 +520,7 @@ def _extract_from_session_impl(conn, session_id: str, repo_path: str) -> None:
             continue
         redacted = ex.apply_redaction(prompt_text, repo_path)
         try:
-            raw = _get_llm_response(redacted, repo_path)
+            raw = _invoke_get_llm_response(redacted, repo_path, bundle.source_type)
         except ex.DecisionExtractionError:
             continue
         except Exception as exc:

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -458,121 +458,94 @@ def decision_stale_all():
 
 
 def _get_llm_response(summaries: str, repo_path: str) -> str:
-    """Call LLM to extract decisions. Separated for testability."""
-    from ..core.config import load_config
-    from ..core.llm import get_backend
+    """LLM call shim preserved at current module path for monkeypatch-based tests.
 
-    config = load_config(repo_path)
-    backend_name = config.get("futures", {}).get("default_backend", "openai")
-    model = config.get("futures", {}).get("default_model", None)
-    backend = get_backend(backend_name, model=model)
+    The shim body below (_extract_from_session_impl) must always call this
+    module-level function so that test monkeypatches on
+    `entirecontext.cli.decisions_cmds._get_llm_response` remain effective.
+    The production hook/worker path invokes
+    `core.decision_extraction.call_extraction_llm` directly instead.
+    """
+    from ..core.decision_extraction import call_extraction_llm
 
-    system = (
-        "Extract architectural/technical decisions from this coding session. "
-        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, "rejected_alternatives": [str]}] '
-        "Only include actual decisions (choosing one approach over another), "
-        "not tasks, plans, or status updates. "
-        "Return [] if no decisions were made."
-    )
-    return backend.complete(system, summaries)
+    return call_extraction_llm(summaries, repo_path, source_type="session")
 
 
 def _extract_from_session_impl(conn, session_id: str, repo_path: str) -> None:
-    """Core extraction logic. Used by CLI command and testable directly."""
-    import json as _json
-    import re
+    """Back-compat shim that drives the candidate pipeline while keeping
+    monkeypatches on _get_llm_response effective. Writes into
+    decision_candidates, NOT decisions — legacy tests were migrated."""
+    from ..core import decision_extraction as ex
 
-    from ..core.config import load_config
-    from ..core.decisions import create_decision, link_decision_to_file
-
-    # Idempotency check
-    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
-    if row and row["metadata"]:
-        try:
-            meta = _json.loads(row["metadata"])
-            if meta.get("decisions_extracted") is True:
-                return
-        except (ValueError, TypeError):
-            pass
-
-    # Collect summaries with files
-    rows = conn.execute(
-        "SELECT assistant_summary, files_touched FROM turns "
-        "WHERE session_id = ? AND assistant_summary IS NOT NULL "
-        "ORDER BY turn_number ASC",
-        (session_id,),
-    ).fetchall()
-    if not rows:
+    if ex.is_session_extracted(conn, session_id):
         return
 
-    summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
-    all_files: set[str] = set()
-    for r in rows:
-        if r["files_touched"]:
-            try:
-                files = _json.loads(r["files_touched"])
-                if isinstance(files, list):
-                    all_files.update(files)
-            except (ValueError, TypeError):
-                pass
-
-    # Keyword filter
-    config = load_config(repo_path)
-    keywords = config.get("decisions", {}).get("extract_keywords", [])
-    if keywords:
-        pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
-        summaries = [s for s in summaries if pattern.search(s)]
-    if not summaries:
+    bundles = ex.collect_signals(conn, session_id, repo_path)
+    if not bundles:
+        # Intentionally NOT marking as extracted — future collector rules or
+        # new source types must be able to rediscover these sessions.
         return
 
-    # LLM call
-    combined = "\n".join(summaries)
-    raw = _get_llm_response(combined, repo_path)
-
-    # Parse
-    try:
-        decisions_data = _json.loads(raw)
-    except (ValueError, TypeError):
-        console.print("[yellow]Invalid JSON from LLM, skipping extraction[/yellow]")
-        return
-
-    if not isinstance(decisions_data, list):
-        return
-
-    decisions_data = decisions_data[:5]
-
-    for item in decisions_data:
-        try:
-            if not isinstance(item, dict) or "title" not in item:
-                continue
-            d = create_decision(
-                conn,
-                title=item["title"],
-                rationale=item.get("rationale"),
-                scope=item.get("scope"),
-                rejected_alternatives=item.get("rejected_alternatives"),
-            )
-            for f in all_files:
-                try:
-                    link_decision_to_file(conn, d["id"], f)
-                except Exception:
-                    pass
-        except Exception:
+    parsed_ok = False
+    for bundle in bundles:
+        prompt_text = ex.assemble_prompt(bundle)
+        if not prompt_text.strip():
             continue
+        redacted = ex.apply_redaction(prompt_text, repo_path)
+        try:
+            raw = _get_llm_response(redacted, repo_path)
+        except ex.DecisionExtractionError:
+            continue
+        except Exception as exc:
+            console.print(f"[yellow]LLM call failed for {bundle.source_type}: {exc}[/yellow]")
+            continue
+        try:
+            drafts = ex.parse_llm_response(raw, bundle)
+        except ex.DecisionExtractionError:
+            # Parse failure intentionally does NOT mark the session, so that
+            # the next SessionEnd re-runs extraction once the upstream noise
+            # has been resolved. Matches test_extract_from_session_invalid_llm_json.
+            continue
+        parsed_ok = True
+        for draft in drafts:
+            dedup_result = ex.dedup(conn, draft)
+            score, breakdown = ex.score_confidence(draft, dedup_result)
+            ex.persist_candidate(conn, draft, score, breakdown, dedup_result)
 
-    # Set idempotency marker (null-safe)
-    conn.execute(
-        "UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), '$.decisions_extracted', json('true')) WHERE id = ?",
-        (session_id,),
-    )
-    conn.commit()
+    if parsed_ok:
+        ex.mark_session_extracted(conn, session_id)
+
+
+@decision_app.command("extract-candidates")
+def decision_extract_candidates(
+    session_id: str = typer.Option(..., "--session", help="Session ID to extract candidates from"),
+):
+    """Extract candidate decisions from a session (background worker target)."""
+    conn, repo_path = get_repo_connection()
+    try:
+        from ..core.decision_extraction import run_extraction
+
+        outcome = run_extraction(conn, session_id, repo_path)
+        console.print(
+            f"[green]Extraction complete[/green] — bundles={outcome.bundles_collected} "
+            f"drafts={outcome.drafts_parsed} inserted={outcome.candidates_inserted} "
+            f"duplicates={outcome.duplicates_skipped}"
+        )
+        if outcome.warnings:
+            for warning in outcome.warnings:
+                console.print(f"[yellow]warning:[/yellow] {warning}")
+    except Exception as exc:
+        console.print(f"[red]Extraction failed: {exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
 
 
 @decision_app.command("extract-from-session")
 def decision_extract_from_session(
-    session_id: str = typer.Argument(..., help="Session ID to extract decisions from"),
+    session_id: str = typer.Argument(..., help="Session ID to extract candidates from"),
 ):
-    """Extract decisions from a session using LLM (background worker target)."""
+    """Back-compat alias for the candidate extraction pipeline."""
     conn, repo_path = get_repo_connection()
     try:
         _extract_from_session_impl(conn, session_id, repo_path)
@@ -581,6 +554,138 @@ def decision_extract_from_session(
         raise typer.Exit(1)
     finally:
         conn.close()
+
+
+candidates_app = typer.Typer(help="Candidate decision review flow")
+
+
+@candidates_app.command("list")
+def candidates_list(
+    session_id: Optional[str] = typer.Option(None, "--session", help="Filter by session id"),
+    status: Optional[str] = typer.Option(None, "--status", help="pending|confirmed|rejected"),
+    min_confidence: float = typer.Option(0.0, "--min-confidence", help="Minimum confidence"),
+    source: Optional[str] = typer.Option(None, "--source", help="session|checkpoint|assessment"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+):
+    from ..core.decision_candidates import list_candidates
+
+    conn, _ = get_repo_connection()
+    try:
+        rows = list_candidates(
+            conn,
+            session_id=session_id,
+            status=status,
+            min_confidence=min_confidence,
+            source_type=source,
+            limit=limit,
+        )
+    finally:
+        conn.close()
+
+    if not rows:
+        console.print("[dim]No candidates found.[/dim]")
+        return
+
+    table = Table(title=f"Decision Candidates ({len(rows)})")
+    table.add_column("ID", style="dim", max_width=12)
+    table.add_column("Title")
+    table.add_column("Source")
+    table.add_column("Status")
+    table.add_column("Conf", justify="right")
+    for r in rows:
+        table.add_row(
+            r["id"][:12],
+            (r.get("title") or "")[:60],
+            r.get("source_type", ""),
+            r.get("review_status", ""),
+            f"{r.get('confidence', 0.0):.2f}",
+        )
+    console.print(table)
+
+
+@candidates_app.command("show")
+def candidates_show(candidate_id: str = typer.Argument(..., help="Candidate ID")):
+    import json as _json
+
+    from ..core.decision_candidates import get_candidate
+
+    conn, _ = get_repo_connection()
+    try:
+        candidate = get_candidate(conn, candidate_id)
+    finally:
+        conn.close()
+
+    if not candidate:
+        console.print(f"[red]Candidate not found:[/red] {candidate_id}")
+        raise typer.Exit(1)
+
+    console.print(f"[bold]Candidate:[/bold] {candidate['id']}")
+    console.print(f"  Title: {candidate.get('title', '')}")
+    console.print(f"  Source: {candidate.get('source_type', '')} / {candidate.get('source_id', '')}")
+    console.print(f"  Status: {candidate.get('review_status', '')}")
+    console.print(f"  Confidence: {candidate.get('confidence', 0.0):.3f}")
+    if candidate.get("rationale"):
+        console.print(f"  Rationale: {candidate['rationale']}")
+    if candidate.get("scope"):
+        console.print(f"  Scope: {candidate['scope']}")
+    alts = candidate.get("rejected_alternatives") or []
+    if alts:
+        console.print(f"  Rejected alternatives: {alts}")
+    files = candidate.get("files") or []
+    if files:
+        console.print(f"  Files: {files}")
+    breakdown = candidate.get("confidence_breakdown") or {}
+    if breakdown:
+        console.print("  Breakdown:")
+        console.print(_json.dumps(breakdown, indent=2, ensure_ascii=False))
+
+
+@candidates_app.command("confirm")
+def candidates_confirm(
+    candidate_id: str = typer.Argument(..., help="Candidate ID"),
+    scope: Optional[str] = typer.Option(None, "--scope", help="Override scope on promotion"),
+    note: Optional[str] = typer.Option(None, "--note", help="Reviewer note"),
+):
+    from ..core.decision_candidates import confirm_candidate
+
+    conn, _ = get_repo_connection()
+    try:
+        result = confirm_candidate(
+            conn,
+            candidate_id,
+            scope_override=scope,
+            reviewer="cli",
+            note=note,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
+    console.print(
+        f"[green]Confirmed[/green] candidate {result['candidate_id'][:12]} → decision {result['decision_id']}"
+    )
+
+
+@candidates_app.command("reject")
+def candidates_reject(
+    candidate_id: str = typer.Argument(..., help="Candidate ID"),
+    reason: Optional[str] = typer.Option(None, "--reason", help="Reviewer reason"),
+):
+    from ..core.decision_candidates import reject_candidate
+
+    conn, _ = get_repo_connection()
+    try:
+        result = reject_candidate(conn, candidate_id, reason=reason, reviewer="cli")
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+    finally:
+        conn.close()
+    console.print(f"[yellow]Rejected[/yellow] candidate {result['candidate_id'][:12]}")
+
+
+decision_app.add_typer(candidates_app, name="candidates")
 
 
 def register(app: typer.Typer) -> None:

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -83,6 +83,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "approach",
             "instead of",
         ],
+        "extract_sources": ["session", "checkpoint", "assessment"],
+        "candidate_min_confidence": 0.0,
+        "candidate_dedup_similarity_threshold": 0.5,
+        "candidate_redact_secrets": True,
     },
 }
 

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -74,10 +74,9 @@ def list_candidates(
     # (e.g. "session_id = ?"). All user-supplied values flow through params
     # via ? bindings, never into the SQL text.
     where_clause = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    query = (  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
-        f"SELECT * FROM decision_candidates{where_clause} ORDER BY confidence DESC, created_at DESC LIMIT ?"
-    )
+    query = f"SELECT * FROM decision_candidates{where_clause} ORDER BY confidence DESC, created_at DESC LIMIT ?"
     params.append(int(limit))
+    # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
     rows = conn.execute(query, params).fetchall()
     return [r for r in (_row_to_dict(row) for row in rows) if r is not None]
 
@@ -98,12 +97,51 @@ def confirm_candidate(
     reviewer: str = "cli",
     note: str | None = None,
 ) -> dict[str, Any]:
+    """Promote a candidate to a real decision with atomic concurrency safety.
+
+    The confirm flow is NOT wrapped in a single transaction because
+    `create_decision` and `link_decision_to_*` in core/decisions.py each
+    commit internally. To prevent (a) concurrent double-confirm via CLI +
+    MCP and (b) duplicate decision creation on process crash mid-flight,
+    the flow uses an atomic conditional UPDATE as a lock:
+
+      1. CAS-claim the candidate with
+         `UPDATE ... WHERE id=? AND review_status='pending'`.
+         Only one caller sees rowcount=1; everyone else raises.
+      2. Create the decision and link provenance (each auto-commits).
+      3. Second UPDATE stores `promoted_decision_id`.
+
+    If step 2 or 3 raises, the claim is rolled back to `pending` so the
+    candidate can be retried. A crash between step 2 and 3 leaves the
+    candidate in `confirmed` state with `promoted_decision_id IS NULL`
+    — detectable and recoverable via a follow-up, and far better than
+    silently creating a duplicate decision.
+    """
     candidate = get_candidate(conn, candidate_id)
     if candidate is None:
         raise ValueError(f"Candidate '{candidate_id}' not found")
-    if candidate.get("review_status") != "pending":
-        raise ValueError(f"Candidate '{candidate['id']}' is already {candidate.get('review_status')}")
 
+    # Step 1: atomic claim. The pending → confirmed transition is the
+    # concurrency gate; no caller can successfully claim this row twice,
+    # even across connections, because the UPDATE sees the committed
+    # state at the time it runs.
+    now = _now_iso()
+    cursor = conn.execute(
+        "UPDATE decision_candidates SET review_status='confirmed', reviewed_at=?, "
+        "reviewed_by=?, review_note=?, updated_at=? "
+        "WHERE id=? AND review_status='pending'",
+        (now, reviewer, note, now, candidate["id"]),
+    )
+    if cursor.rowcount == 0:
+        # Someone else won the race, or the candidate was already
+        # confirmed/rejected. Re-read to give the caller an accurate reason.
+        fresh = get_candidate(conn, candidate["id"])
+        status = fresh.get("review_status") if fresh else "unknown"
+        raise ValueError(f"Candidate '{candidate['id']}' is already {status}")
+    conn.commit()
+
+    # Step 2: create the decision and link provenance. Each helper below
+    # auto-commits, so every write after this point is durable.
     from .decisions import (
         create_decision,
         link_decision_to_assessment,
@@ -115,48 +153,61 @@ def confirm_candidate(
     supporting = candidate.get("supporting_evidence") or []
     scope = scope_override if scope_override is not None else candidate.get("scope")
 
-    decision = create_decision(
-        conn,
-        title=candidate["title"],
-        rationale=candidate.get("rationale"),
-        scope=scope,
-        rejected_alternatives=rejected,
-        supporting_evidence=supporting,
-    )
-    decision_id = decision["id"]
+    try:
+        decision = create_decision(
+            conn,
+            title=candidate["title"],
+            rationale=candidate.get("rationale"),
+            scope=scope,
+            rejected_alternatives=rejected,
+            supporting_evidence=supporting,
+        )
+        decision_id = decision["id"]
 
-    files = candidate.get("files") or []
-    for file_path in files:
-        if isinstance(file_path, str) and file_path:
+        files = candidate.get("files") or []
+        for file_path in files:
+            if isinstance(file_path, str) and file_path:
+                try:
+                    link_decision_to_file(conn, decision_id, file_path)
+                except Exception:
+                    continue
+
+        if candidate.get("checkpoint_id"):
             try:
-                link_decision_to_file(conn, decision_id, file_path)
+                link_decision_to_checkpoint(conn, decision_id, candidate["checkpoint_id"])
             except Exception:
-                continue
+                pass
 
-    if candidate.get("checkpoint_id"):
-        try:
-            link_decision_to_checkpoint(conn, decision_id, candidate["checkpoint_id"])
-        except Exception:
-            pass
+        if candidate.get("assessment_id"):
+            try:
+                link_decision_to_assessment(
+                    conn,
+                    decision_id,
+                    candidate["assessment_id"],
+                    relation_type="informed_by",
+                )
+            except Exception:
+                pass
 
-    if candidate.get("assessment_id"):
-        try:
-            link_decision_to_assessment(
-                conn,
-                decision_id,
-                candidate["assessment_id"],
-                relation_type="informed_by",
-            )
-        except Exception:
-            pass
-
-    now = _now_iso()
-    conn.execute(
-        "UPDATE decision_candidates SET review_status='confirmed', reviewed_at=?, "
-        "reviewed_by=?, review_note=?, promoted_decision_id=?, updated_at=? WHERE id=?",
-        (now, reviewer, note, decision_id, now, candidate["id"]),
-    )
-    conn.commit()
+        # Step 3: store the decision back-pointer. The earlier claim
+        # UPDATE already committed so we are guaranteed the row is ours.
+        conn.execute(
+            "UPDATE decision_candidates SET promoted_decision_id=?, updated_at=? WHERE id=?",
+            (decision_id, _now_iso(), candidate["id"]),
+        )
+        conn.commit()
+    except Exception:
+        # Roll the claim back to pending so the candidate can be retried.
+        # Conditioned on (confirmed + promoted_decision_id IS NULL) to
+        # avoid racing a later successful confirm.
+        conn.execute(
+            "UPDATE decision_candidates SET review_status='pending', reviewed_at=NULL, "
+            "reviewed_by=NULL, review_note=NULL, updated_at=? "
+            "WHERE id=? AND review_status='confirmed' AND promoted_decision_id IS NULL",
+            (_now_iso(), candidate["id"]),
+        )
+        conn.commit()
+        raise
 
     _record_event(
         conn,

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -1,0 +1,233 @@
+"""CRUD + confirmation flow for decision_candidates.
+
+Public API consumed by cli/decisions_cmds.py and mcp/tools/decision_candidates.py.
+Every confirmation promotes the candidate's provenance into the canonical
+decision_* join tables via existing helpers in core/decisions.py.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row_to_dict(row: Any) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    result: dict[str, Any] = dict(row)
+    for field_name in ("rejected_alternatives", "supporting_evidence", "files", "confidence_breakdown"):
+        raw = result.get(field_name)
+        if not raw:
+            result[field_name] = [] if field_name != "confidence_breakdown" else {}
+            continue
+        try:
+            result[field_name] = json.loads(raw)
+        except (ValueError, TypeError):
+            result[field_name] = [] if field_name != "confidence_breakdown" else {}
+    return result
+
+
+def _resolve_candidate_id(conn, candidate_id: str) -> str | None:
+    if not candidate_id:
+        return None
+    row = conn.execute("SELECT id FROM decision_candidates WHERE id = ?", (candidate_id,)).fetchone()
+    if row is not None:
+        return row["id"]
+    row = conn.execute(
+        "SELECT id FROM decision_candidates WHERE id LIKE ? LIMIT 2",
+        (f"{candidate_id}%",),
+    ).fetchall()
+    if len(row) == 1:
+        return row[0]["id"]
+    return None
+
+
+def list_candidates(
+    conn,
+    *,
+    session_id: str | None = None,
+    status: str | None = None,
+    min_confidence: float = 0.0,
+    source_type: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if session_id:
+        clauses.append("session_id = ?")
+        params.append(session_id)
+    if status:
+        clauses.append("review_status = ?")
+        params.append(status)
+    if source_type:
+        clauses.append("source_type = ?")
+        params.append(source_type)
+    if min_confidence > 0:
+        clauses.append("confidence >= ?")
+        params.append(float(min_confidence))
+    # clauses contains literal column comparison fragments authored above
+    # (e.g. "session_id = ?"). All user-supplied values flow through params
+    # via ? bindings, never into the SQL text.
+    where_clause = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    query = (  # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        f"SELECT * FROM decision_candidates{where_clause} ORDER BY confidence DESC, created_at DESC LIMIT ?"
+    )
+    params.append(int(limit))
+    rows = conn.execute(query, params).fetchall()
+    return [r for r in (_row_to_dict(row) for row in rows) if r is not None]
+
+
+def get_candidate(conn, candidate_id: str) -> dict[str, Any] | None:
+    resolved = _resolve_candidate_id(conn, candidate_id)
+    if resolved is None:
+        return None
+    row = conn.execute("SELECT * FROM decision_candidates WHERE id = ?", (resolved,)).fetchone()
+    return _row_to_dict(row)
+
+
+def confirm_candidate(
+    conn,
+    candidate_id: str,
+    *,
+    scope_override: str | None = None,
+    reviewer: str = "cli",
+    note: str | None = None,
+) -> dict[str, Any]:
+    candidate = get_candidate(conn, candidate_id)
+    if candidate is None:
+        raise ValueError(f"Candidate '{candidate_id}' not found")
+    if candidate.get("review_status") != "pending":
+        raise ValueError(f"Candidate '{candidate['id']}' is already {candidate.get('review_status')}")
+
+    from .decisions import (
+        create_decision,
+        link_decision_to_assessment,
+        link_decision_to_checkpoint,
+        link_decision_to_file,
+    )
+
+    rejected = candidate.get("rejected_alternatives") or []
+    supporting = candidate.get("supporting_evidence") or []
+    scope = scope_override if scope_override is not None else candidate.get("scope")
+
+    decision = create_decision(
+        conn,
+        title=candidate["title"],
+        rationale=candidate.get("rationale"),
+        scope=scope,
+        rejected_alternatives=rejected,
+        supporting_evidence=supporting,
+    )
+    decision_id = decision["id"]
+
+    files = candidate.get("files") or []
+    for file_path in files:
+        if isinstance(file_path, str) and file_path:
+            try:
+                link_decision_to_file(conn, decision_id, file_path)
+            except Exception:
+                continue
+
+    if candidate.get("checkpoint_id"):
+        try:
+            link_decision_to_checkpoint(conn, decision_id, candidate["checkpoint_id"])
+        except Exception:
+            pass
+
+    if candidate.get("assessment_id"):
+        try:
+            link_decision_to_assessment(
+                conn,
+                decision_id,
+                candidate["assessment_id"],
+                relation_type="informed_by",
+            )
+        except Exception:
+            pass
+
+    now = _now_iso()
+    conn.execute(
+        "UPDATE decision_candidates SET review_status='confirmed', reviewed_at=?, "
+        "reviewed_by=?, review_note=?, promoted_decision_id=?, updated_at=? WHERE id=?",
+        (now, reviewer, note, decision_id, now, candidate["id"]),
+    )
+    conn.commit()
+
+    _record_event(
+        conn,
+        source=reviewer,
+        phase="confirm",
+        status="ok",
+        session_id=candidate.get("session_id"),
+        message=None,
+    )
+    return {
+        "candidate_id": candidate["id"],
+        "decision_id": decision_id,
+        "promoted": True,
+    }
+
+
+def reject_candidate(
+    conn,
+    candidate_id: str,
+    *,
+    reason: str | None = None,
+    reviewer: str = "cli",
+) -> dict[str, Any]:
+    candidate = get_candidate(conn, candidate_id)
+    if candidate is None:
+        raise ValueError(f"Candidate '{candidate_id}' not found")
+    if candidate.get("review_status") != "pending":
+        raise ValueError(f"Candidate '{candidate['id']}' is already {candidate.get('review_status')}")
+
+    now = _now_iso()
+    conn.execute(
+        "UPDATE decision_candidates SET review_status='rejected', reviewed_at=?, "
+        "reviewed_by=?, review_note=?, updated_at=? WHERE id=?",
+        (now, reviewer, reason, now, candidate["id"]),
+    )
+    conn.commit()
+
+    _record_event(
+        conn,
+        source=reviewer,
+        phase="reject",
+        status="ok",
+        session_id=candidate.get("session_id"),
+        message=None,
+    )
+    return {
+        "candidate_id": candidate["id"],
+        "rejected": True,
+    }
+
+
+def _record_event(
+    conn,
+    *,
+    source: str,
+    phase: str,
+    status: str,
+    session_id: str | None = None,
+    message: str | None = None,
+) -> None:
+    try:
+        from .telemetry import record_operation_event
+
+        record_operation_event(
+            conn,
+            source=source,
+            operation_name="decision_candidate_extract",
+            phase=phase,
+            status=status,
+            session_id=session_id,
+            message=message,
+        )
+    except Exception:
+        return

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -231,18 +231,29 @@ def reject_candidate(
     reason: str | None = None,
     reviewer: str = "cli",
 ) -> dict[str, Any]:
+    """Reject a candidate with the same atomic-claim pattern as confirm.
+
+    Without the conditional UPDATE, a concurrent confirm_candidate could
+    CAS-claim and promote the candidate between our Python-level pending
+    check and the UPDATE, resulting in a 'rejected' candidate whose
+    promoted_decision_id still points at a committed `decisions` row —
+    a dangling invariant we cannot recover from.
+    """
     candidate = get_candidate(conn, candidate_id)
     if candidate is None:
         raise ValueError(f"Candidate '{candidate_id}' not found")
-    if candidate.get("review_status") != "pending":
-        raise ValueError(f"Candidate '{candidate['id']}' is already {candidate.get('review_status')}")
 
     now = _now_iso()
-    conn.execute(
+    cursor = conn.execute(
         "UPDATE decision_candidates SET review_status='rejected', reviewed_at=?, "
-        "reviewed_by=?, review_note=?, updated_at=? WHERE id=?",
+        "reviewed_by=?, review_note=?, updated_at=? "
+        "WHERE id=? AND review_status='pending'",
         (now, reviewer, reason, now, candidate["id"]),
     )
+    if cursor.rowcount == 0:
+        fresh = get_candidate(conn, candidate["id"])
+        status = fresh.get("review_status") if fresh else "unknown"
+        raise ValueError(f"Candidate '{candidate['id']}' is already {status}")
     conn.commit()
 
     _record_event(

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -1,0 +1,839 @@
+"""Candidate decision extraction pipeline.
+
+Pulls candidate decisions out of sessions, checkpoints, and assessments;
+scores them with a structural heuristic; dedups against existing decisions
+and pending candidates; persists into decision_candidates.
+
+Production hook/worker path uses run_extraction() directly. The CLI shim
+at cli.decisions_cmds._extract_from_session_impl uses a separate loop so
+test monkeypatches on that module's _get_llm_response stay effective.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+
+class DecisionExtractionError(Exception):
+    """Expected failure mode in the extraction pipeline.
+
+    Raised for backend unavailable, rate limit, JSON parse failure, missing
+    config. Callers downgrade to a telemetry warning and exit cleanly so the
+    SessionEnd hook never crashes. Unexpected exceptions bypass this class
+    and are recorded as error-level telemetry.
+    """
+
+
+_CODE_STOPWORDS_TITLE: frozenset[str] = frozenset(
+    {
+        "and",
+        "or",
+        "the",
+        "for",
+        "from",
+        "with",
+        "this",
+        "that",
+        "not",
+        "use",
+        "using",
+        "new",
+        "old",
+        "via",
+        "via",
+    }
+)
+
+
+_VALID_SOURCE_TYPES = frozenset({"session", "checkpoint", "assessment"})
+
+_BASE_CONFIDENCE_WEIGHTS: dict[str, float] = {
+    "assessment": 0.55,
+    "checkpoint": 0.40,
+    "session": 0.30,
+}
+
+_DEFAULT_EXTRACT_KEYWORDS: list[str] = [
+    "결정",
+    "선택",
+    "방식으로",
+    "decided",
+    "chose",
+    "approach",
+    "instead of",
+]
+
+_MAX_CANDIDATES_PER_BUNDLE = 5
+_MAX_PROMPT_CHARS = 8000
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SignalBundle:
+    source_type: str
+    source_id: str
+    session_id: str
+    checkpoint_id: str | None
+    assessment_id: str | None
+    text_blocks: list[str]
+    files: list[str]
+
+
+@dataclass
+class CandidateDraft:
+    title: str
+    rationale: str | None
+    scope: str | None
+    rejected_alternatives: list[Any]
+    supporting_evidence: list[Any]
+    source_type: str
+    source_id: str
+    session_id: str
+    checkpoint_id: str | None
+    assessment_id: str | None
+    files: list[str]
+
+
+@dataclass
+class DedupResult:
+    dedup_key: str
+    score_vs_decisions: float = 0.0
+    score_vs_candidates: float = 0.0
+    similar_decision_id: str | None = None
+    similar_candidate_id: str | None = None
+
+
+@dataclass
+class PersistResult:
+    candidate_id: str | None
+    inserted: bool
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def _load_decisions_config(repo_path: str) -> dict:
+    try:
+        from .config import load_config
+
+        cfg = load_config(repo_path)
+        if isinstance(cfg, dict):
+            return cfg.get("decisions", {}) or {}
+    except Exception:
+        pass
+    return {}
+
+
+def _load_security_patterns(repo_path: str) -> list[str] | None:
+    try:
+        from .config import load_config
+
+        cfg = load_config(repo_path)
+        sec = cfg.get("security", {}) if isinstance(cfg, dict) else {}
+        patterns = sec.get("patterns")
+        if isinstance(patterns, list):
+            return patterns
+    except Exception:
+        pass
+    return None
+
+
+def _extract_keywords(config: dict) -> list[str]:
+    raw = config.get("extract_keywords")
+    if isinstance(raw, list) and raw:
+        return [str(k) for k in raw]
+    return list(_DEFAULT_EXTRACT_KEYWORDS)
+
+
+def _extract_sources(config: dict) -> list[str]:
+    raw = config.get("extract_sources")
+    if isinstance(raw, list) and raw:
+        return [str(s) for s in raw if s in _VALID_SOURCE_TYPES]
+    return ["session", "checkpoint", "assessment"]
+
+
+def _dedup_similarity_threshold(config: dict) -> float:
+    raw = config.get("candidate_dedup_similarity_threshold", 0.5)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.5
+
+
+def _should_redact_secrets(config: dict) -> bool:
+    raw = config.get("candidate_redact_secrets", True)
+    return bool(raw)
+
+
+# ---------------------------------------------------------------------------
+# Normalization & tokenization
+# ---------------------------------------------------------------------------
+
+
+def normalize_title_for_dedup(title: str) -> str:
+    if not title:
+        return ""
+    lowered = title.lower()
+    stripped = re.sub(r"[^\w\s]", " ", lowered, flags=re.UNICODE)
+    collapsed = re.sub(r"\s+", " ", stripped).strip()
+    return collapsed
+
+
+def compute_dedup_key(title: str) -> str:
+    normalized = normalize_title_for_dedup(title)
+    if not normalized:
+        return hashlib.sha256(b"").hexdigest()[:12]
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+
+
+def _tokenize_title_for_fts(title: str, max_tokens: int = 10) -> str | None:
+    if not title:
+        return None
+    tokens: dict[str, int] = {}
+    parts = re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z][a-z]|\b)|[a-z]+", title)
+    words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{2,}", title)
+    for t in {tok.lower() for tok in parts + words}:
+        if len(t) < 3:
+            continue
+        if t in _CODE_STOPWORDS_TITLE:
+            continue
+        if re.fullmatch(r"[0-9a-f]+", t):
+            continue
+        tokens[t] = tokens.get(t, 0) + 1
+    if not tokens:
+        return None
+    sorted_tokens = sorted(tokens, key=tokens.__getitem__, reverse=True)[:max_tokens]
+    safe = []
+    for tok in sorted_tokens:
+        if tok.upper() in ("AND", "OR", "NOT", "NEAR"):
+            safe.append(f'"{tok}"')
+        else:
+            safe.append(tok)
+    return " OR ".join(safe)
+
+
+# ---------------------------------------------------------------------------
+# Session extraction marker (with v12 shim)
+# ---------------------------------------------------------------------------
+
+
+def is_session_extracted(conn, session_id: str) -> bool:
+    row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    if not row or not row["metadata"]:
+        return False
+    try:
+        meta = json.loads(row["metadata"])
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(meta, dict):
+        return False
+    # v13 marker is authoritative; v12 marker shim means old sessions are
+    # treated as already-extracted so we never re-run extraction on rows
+    # written by the pre-candidates pipeline.
+    if meta.get("candidates_extracted") is True:
+        return True
+    if meta.get("decisions_extracted") is True:
+        return True
+    return False
+
+
+def mark_session_extracted(conn, session_id: str) -> None:
+    conn.execute(
+        "UPDATE sessions SET metadata = json_set(COALESCE(metadata, '{}'), "
+        "'$.candidates_extracted', json('true')) WHERE id = ?",
+        (session_id,),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Turn window derivation (used by checkpoint + assessment sources)
+# ---------------------------------------------------------------------------
+
+
+def _previous_checkpoint_created_at(conn, session_id: str, current_created_at: str) -> str | None:
+    row = conn.execute(
+        "SELECT created_at FROM checkpoints "
+        "WHERE session_id = ? AND created_at < ? "
+        "ORDER BY created_at DESC, rowid DESC LIMIT 1",
+        (session_id, current_created_at),
+    ).fetchone()
+    if row is None:
+        return None
+    return row["created_at"]
+
+
+def _turn_window_rows(conn, session_id: str, checkpoint_created_at: str, prev_created_at: str | None) -> list[Any]:
+    if prev_created_at is None:
+        return list(
+            conn.execute(
+                "SELECT assistant_summary, files_touched FROM turns "
+                "WHERE session_id = ? AND timestamp <= ? "
+                "ORDER BY turn_number ASC",
+                (session_id, checkpoint_created_at),
+            ).fetchall()
+        )
+    return list(
+        conn.execute(
+            "SELECT assistant_summary, files_touched FROM turns "
+            "WHERE session_id = ? AND timestamp <= ? AND timestamp > ? "
+            "ORDER BY turn_number ASC",
+            (session_id, checkpoint_created_at, prev_created_at),
+        ).fetchall()
+    )
+
+
+def _files_union_from_rows(rows: list[Any]) -> list[str]:
+    all_files: set[str] = set()
+    for r in rows:
+        raw = r["files_touched"] if "files_touched" in r.keys() else None
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(parsed, list):
+            for path in parsed:
+                if isinstance(path, str) and path:
+                    all_files.add(path)
+    return sorted(all_files)
+
+
+def _summaries_from_rows(rows: list[Any]) -> list[str]:
+    out: list[str] = []
+    for r in rows:
+        summary = r["assistant_summary"] if "assistant_summary" in r.keys() else None
+        if summary:
+            out.append(str(summary))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Signal collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_session_bundle(conn, session_id: str, config: dict) -> SignalBundle | None:
+    keywords = _extract_keywords(config)
+    if not keywords:
+        return None
+    rows = conn.execute(
+        "SELECT assistant_summary, files_touched FROM turns "
+        "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+        "ORDER BY turn_number ASC",
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return None
+
+    pattern = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE)
+    matching_rows = [r for r in rows if pattern.search(r["assistant_summary"] or "")]
+    if not matching_rows:
+        return None
+
+    summaries = [r["assistant_summary"] for r in matching_rows if r["assistant_summary"]]
+
+    matching_file_sets: list[set[str]] = []
+    for r in matching_rows:
+        if not r["files_touched"]:
+            continue
+        try:
+            parsed = json.loads(r["files_touched"])
+        except (ValueError, TypeError):
+            continue
+        if isinstance(parsed, list):
+            matching_file_sets.append({p for p in parsed if isinstance(p, str) and p})
+
+    files: list[str] = []
+    if matching_file_sets:
+        intersection = set.intersection(*matching_file_sets) if len(matching_file_sets) > 1 else matching_file_sets[0]
+        files = sorted(intersection)
+
+    return SignalBundle(
+        source_type="session",
+        source_id=session_id,
+        session_id=session_id,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=summaries,
+        files=files,
+    )
+
+
+def _collect_checkpoint_bundles(conn, session_id: str) -> list[SignalBundle]:
+    checkpoints = conn.execute(
+        "SELECT id, created_at, diff_summary FROM checkpoints WHERE session_id = ? ORDER BY created_at ASC, rowid ASC",
+        (session_id,),
+    ).fetchall()
+    bundles: list[SignalBundle] = []
+    for cp in checkpoints:
+        diff_summary = cp["diff_summary"]
+        if not diff_summary or not str(diff_summary).strip():
+            continue
+        prev_created_at = _previous_checkpoint_created_at(conn, session_id, cp["created_at"])
+        rows = _turn_window_rows(conn, session_id, cp["created_at"], prev_created_at)
+        files = _files_union_from_rows(rows)
+        if len(files) < 2:
+            continue
+        window_summaries = _summaries_from_rows(rows)
+        text_blocks = [str(diff_summary)] + window_summaries
+        bundles.append(
+            SignalBundle(
+                source_type="checkpoint",
+                source_id=cp["id"],
+                session_id=session_id,
+                checkpoint_id=cp["id"],
+                assessment_id=None,
+                text_blocks=text_blocks,
+                files=files,
+            )
+        )
+    return bundles
+
+
+def _collect_assessment_bundles(conn, session_id: str) -> list[SignalBundle]:
+    rows = conn.execute(
+        "SELECT a.id AS assessment_id, a.checkpoint_id, a.verdict, a.impact_summary, "
+        "a.roadmap_alignment, a.tidy_suggestion, a.diff_summary, c.created_at AS cp_created_at "
+        "FROM assessments a JOIN checkpoints c ON a.checkpoint_id = c.id "
+        "WHERE c.session_id = ? AND a.verdict IN ('expand', 'narrow') "
+        "ORDER BY a.created_at ASC",
+        (session_id,),
+    ).fetchall()
+    bundles: list[SignalBundle] = []
+    for r in rows:
+        text_blocks: list[str] = []
+        for field_name in ("impact_summary", "roadmap_alignment", "tidy_suggestion", "diff_summary"):
+            value = r[field_name]
+            if value:
+                text_blocks.append(f"{field_name}: {value}")
+        if not text_blocks:
+            continue
+
+        prev_created_at = _previous_checkpoint_created_at(conn, session_id, r["cp_created_at"])
+        window_rows = _turn_window_rows(conn, session_id, r["cp_created_at"], prev_created_at)
+        files = _files_union_from_rows(window_rows)
+
+        bundles.append(
+            SignalBundle(
+                source_type="assessment",
+                source_id=r["assessment_id"],
+                session_id=session_id,
+                checkpoint_id=r["checkpoint_id"],
+                assessment_id=r["assessment_id"],
+                text_blocks=text_blocks,
+                files=files,
+            )
+        )
+    return bundles
+
+
+def collect_signals(conn, session_id: str, repo_path: str) -> list[SignalBundle]:
+    config = _load_decisions_config(repo_path)
+    sources = _extract_sources(config)
+    bundles: list[SignalBundle] = []
+
+    if "session" in sources:
+        session_bundle = _collect_session_bundle(conn, session_id, config)
+        if session_bundle is not None:
+            bundles.append(session_bundle)
+
+    if "checkpoint" in sources:
+        bundles.extend(_collect_checkpoint_bundles(conn, session_id))
+
+    if "assessment" in sources:
+        bundles.extend(_collect_assessment_bundles(conn, session_id))
+
+    return bundles
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly + redaction + LLM call
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT_BY_SOURCE: dict[str, str] = {
+    "session": (
+        "You are reviewing a coding session for architectural or technical decisions. "
+        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [str]}] '
+        "Only include actual decisions (choosing one approach over another), "
+        "not tasks, plans, or status updates. Return [] if no decisions were made."
+    ),
+    "checkpoint": (
+        "You are reviewing a checkpoint's code change summary and the surrounding "
+        "turn summaries. Extract architectural or technical decisions that the "
+        "change embodies (e.g. choosing one library over another, switching a "
+        "data model, picking an error handling strategy). "
+        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [str]}]. '
+        "Return [] if the change is a routine refactor, bug fix, or cleanup."
+    ),
+    "assessment": (
+        "You are reviewing an assessment of a code change (verdict, impact summary, "
+        "roadmap alignment, tidy suggestion). Extract decisions this assessment "
+        "records — typically an expansion or narrowing of project scope with a "
+        "specific rationale. "
+        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [str]}]. '
+        "Return [] if the assessment is a neutral observation."
+    ),
+}
+
+
+def assemble_prompt(bundle: SignalBundle) -> str:
+    combined = "\n\n".join(block for block in bundle.text_blocks if block)
+    if len(combined) > _MAX_PROMPT_CHARS:
+        combined = combined[:_MAX_PROMPT_CHARS]
+    return combined
+
+
+def get_system_prompt(source_type: str) -> str:
+    return _SYSTEM_PROMPT_BY_SOURCE.get(source_type, _SYSTEM_PROMPT_BY_SOURCE["session"])
+
+
+def apply_redaction(text: str, repo_path: str) -> str:
+    if not text:
+        return text
+    config = _load_decisions_config(repo_path)
+    if not _should_redact_secrets(config):
+        return text
+    try:
+        from .security import filter_secrets
+
+        patterns = _load_security_patterns(repo_path)
+        return filter_secrets(text, patterns)
+    except Exception:
+        return text
+
+
+def call_extraction_llm(user_text: str, repo_path: str, source_type: str = "session") -> str:
+    try:
+        from .config import load_config
+        from .llm import get_backend
+    except Exception as exc:
+        raise DecisionExtractionError(f"llm backend unavailable: {exc}") from exc
+
+    try:
+        cfg = load_config(repo_path)
+        futures_cfg = cfg.get("futures", {}) if isinstance(cfg, dict) else {}
+        backend_name = futures_cfg.get("default_backend", "openai")
+        model = futures_cfg.get("default_model", None)
+        backend = get_backend(backend_name, model=model)
+    except Exception as exc:
+        raise DecisionExtractionError(f"llm backend init failed: {exc}") from exc
+
+    system = get_system_prompt(source_type)
+    try:
+        return backend.complete(system, user_text)
+    except Exception as exc:
+        raise DecisionExtractionError(f"llm call failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_llm_response(raw: str, bundle: SignalBundle) -> list[CandidateDraft]:
+    if raw is None:
+        raise DecisionExtractionError("llm returned None")
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        raise DecisionExtractionError(f"llm output is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, list):
+        return []
+
+    drafts: list[CandidateDraft] = []
+    for item in parsed[:_MAX_CANDIDATES_PER_BUNDLE]:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        if not isinstance(title, str) or not title.strip():
+            continue
+        rationale = item.get("rationale")
+        scope = item.get("scope")
+        rejected = item.get("rejected_alternatives") or []
+        if not isinstance(rejected, list):
+            rejected = []
+        drafts.append(
+            CandidateDraft(
+                title=title.strip(),
+                rationale=rationale if isinstance(rationale, str) else None,
+                scope=scope if isinstance(scope, str) else None,
+                rejected_alternatives=rejected,
+                supporting_evidence=[{"type": bundle.source_type, "id": bundle.source_id}],
+                source_type=bundle.source_type,
+                source_id=bundle.source_id,
+                session_id=bundle.session_id,
+                checkpoint_id=bundle.checkpoint_id,
+                assessment_id=bundle.assessment_id,
+                files=list(bundle.files),
+            )
+        )
+    return drafts
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+def _normalize_fts_scores(rows: list[Any]) -> dict[str, float]:
+    if not rows:
+        return {}
+    raw_scores = {r["rowid"]: -float(r["rank"]) for r in rows}
+    if not raw_scores:
+        return {}
+    mx = max(raw_scores.values())
+    mn = min(raw_scores.values())
+    result: dict[str, float] = {}
+    if mx == mn:
+        for rowid in raw_scores:
+            result[str(rowid)] = 1.0
+    else:
+        span = mx - mn
+        for rowid, raw in raw_scores.items():
+            result[str(rowid)] = (raw - mn) / span
+    return result
+
+
+def dedup(conn, draft: CandidateDraft) -> DedupResult:
+    dedup_key = compute_dedup_key(draft.title)
+    result = DedupResult(dedup_key=dedup_key)
+
+    fts_query = _tokenize_title_for_fts(draft.title)
+    if not fts_query:
+        return result
+
+    # vs. decisions
+    try:
+        decisions_rows = conn.execute(
+            "SELECT rowid, rank FROM fts_decisions WHERE fts_decisions MATCH ? ORDER BY rank LIMIT 10",
+            (fts_query,),
+        ).fetchall()
+    except Exception:
+        decisions_rows = []
+    if decisions_rows:
+        normalized = _normalize_fts_scores(decisions_rows)
+        if normalized:
+            top_rowid, top_score = max(normalized.items(), key=lambda kv: kv[1])
+            result.score_vs_decisions = top_score
+            try:
+                id_row = conn.execute("SELECT id FROM decisions WHERE rowid = ?", (int(top_rowid),)).fetchone()
+                if id_row:
+                    result.similar_decision_id = id_row["id"]
+            except Exception:
+                pass
+
+    # vs. pending candidates
+    try:
+        cand_rows = conn.execute(
+            "SELECT fdc.rowid AS rowid, fdc.rank AS rank FROM fts_decision_candidates fdc "
+            "JOIN decision_candidates dc ON dc.rowid = fdc.rowid "
+            "WHERE fts_decision_candidates MATCH ? AND dc.review_status = 'pending' "
+            "ORDER BY fdc.rank LIMIT 10",
+            (fts_query,),
+        ).fetchall()
+    except Exception:
+        cand_rows = []
+    if cand_rows:
+        normalized = _normalize_fts_scores(cand_rows)
+        if normalized:
+            top_rowid, top_score = max(normalized.items(), key=lambda kv: kv[1])
+            result.score_vs_candidates = top_score
+            try:
+                id_row = conn.execute(
+                    "SELECT id FROM decision_candidates WHERE rowid = ?", (int(top_rowid),)
+                ).fetchone()
+                if id_row:
+                    result.similar_candidate_id = id_row["id"]
+            except Exception:
+                pass
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Confidence scoring
+# ---------------------------------------------------------------------------
+
+
+def score_confidence(draft: CandidateDraft, dedup_result: DedupResult) -> tuple[float, dict[str, Any]]:
+    base = _BASE_CONFIDENCE_WEIGHTS.get(draft.source_type, 0.30)
+
+    has_rationale = bool(draft.rationale and len(draft.rationale.strip()) >= 30)
+    has_alts = bool(draft.rejected_alternatives and len(draft.rejected_alternatives) >= 1)
+    file_scope_bonus = 0.0
+    if draft.files and 1 <= len(draft.files) <= 5:
+        file_scope_bonus = 0.10
+
+    components_bonus = 0.0
+    if has_rationale:
+        components_bonus += 0.15
+    if has_alts:
+        components_bonus += 0.15
+    components_bonus += file_scope_bonus
+
+    initial = base + components_bonus
+    penalty_vs_decisions = 0.25 * dedup_result.score_vs_decisions
+    penalty_vs_candidates = 0.15 * dedup_result.score_vs_candidates
+    penalty = penalty_vs_decisions + penalty_vs_candidates
+
+    final = max(0.0, min(1.0, initial - penalty))
+
+    breakdown: dict[str, Any] = {
+        "base": {"source_type": draft.source_type, "weight": base},
+        "components": {
+            "has_rationale": has_rationale,
+            "has_alts": has_alts,
+            "file_scope_bonus": file_scope_bonus,
+        },
+        "initial": round(initial, 4),
+        "penalties": {
+            "vs_decisions": round(penalty_vs_decisions, 4),
+            "vs_candidates": round(penalty_vs_candidates, 4),
+        },
+        "final": round(final, 4),
+    }
+    if dedup_result.similar_decision_id:
+        breakdown["similar_decision_id"] = dedup_result.similar_decision_id
+    if dedup_result.similar_candidate_id:
+        breakdown["similar_candidate_id"] = dedup_result.similar_candidate_id
+
+    return final, breakdown
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def persist_candidate(
+    conn,
+    draft: CandidateDraft,
+    confidence: float,
+    breakdown: dict[str, Any],
+    dedup_result: DedupResult,
+) -> PersistResult:
+    candidate_id = str(uuid4())
+    now = _now_iso()
+    try:
+        conn.execute(
+            """
+            INSERT INTO decision_candidates (
+                id, title, rationale, scope, rejected_alternatives, supporting_evidence,
+                source_type, source_id, session_id, checkpoint_id, assessment_id,
+                files, confidence, confidence_breakdown, review_status, dedup_key,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+            """,
+            (
+                candidate_id,
+                draft.title,
+                draft.rationale,
+                draft.scope,
+                json.dumps(list(draft.rejected_alternatives)),
+                json.dumps(list(draft.supporting_evidence)),
+                draft.source_type,
+                draft.source_id,
+                draft.session_id,
+                draft.checkpoint_id,
+                draft.assessment_id,
+                json.dumps(list(draft.files)),
+                confidence,
+                json.dumps(breakdown),
+                dedup_result.dedup_key,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        return PersistResult(candidate_id=candidate_id, inserted=True)
+    except Exception as exc:
+        # Unique-index violation on (source_type, source_id, dedup_key) is
+        # expected idempotency — same source producing same normalized title.
+        conn.rollback()
+        msg = str(exc).lower()
+        if "unique" in msg or "constraint" in msg:
+            return PersistResult(candidate_id=None, inserted=False, reason="duplicate")
+        return PersistResult(candidate_id=None, inserted=False, reason=f"error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration (production hook/worker path)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractionOutcome:
+    bundles_collected: int = 0
+    drafts_parsed: int = 0
+    candidates_inserted: int = 0
+    duplicates_skipped: int = 0
+    parsed_ok: bool = False
+    marked: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+def run_extraction(conn, session_id: str, repo_path: str) -> ExtractionOutcome:
+    outcome = ExtractionOutcome()
+    if is_session_extracted(conn, session_id):
+        return outcome
+
+    bundles = collect_signals(conn, session_id, repo_path)
+    outcome.bundles_collected = len(bundles)
+    if not bundles:
+        return outcome
+
+    for bundle in bundles:
+        prompt_text = assemble_prompt(bundle)
+        if not prompt_text.strip():
+            continue
+        redacted = apply_redaction(prompt_text, repo_path)
+        try:
+            raw = call_extraction_llm(redacted, repo_path, source_type=bundle.source_type)
+        except DecisionExtractionError as exc:
+            outcome.warnings.append(f"llm_call:{bundle.source_type}:{exc}")
+            continue
+        try:
+            drafts = parse_llm_response(raw, bundle)
+        except DecisionExtractionError as exc:
+            # Parse failure does NOT count as a successful extraction pass.
+            outcome.warnings.append(f"parse:{bundle.source_type}:{exc}")
+            continue
+        outcome.parsed_ok = True
+        outcome.drafts_parsed += len(drafts)
+        for draft in drafts:
+            dedup_result = dedup(conn, draft)
+            score, breakdown = score_confidence(draft, dedup_result)
+            persist_result = persist_candidate(conn, draft, score, breakdown, dedup_result)
+            if persist_result.inserted:
+                outcome.candidates_inserted += 1
+            elif persist_result.reason == "duplicate":
+                outcome.duplicates_skipped += 1
+
+    if outcome.parsed_ok:
+        mark_session_extracted(conn, session_id)
+        outcome.marked = True
+
+    return outcome

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -605,6 +605,17 @@ def parse_llm_response(raw: str, bundle: SignalBundle) -> list[CandidateDraft]:
 
 
 def _normalize_fts_scores(rows: list[Any]) -> dict[str, float]:
+    """Normalize FTS5 bm25 ranks into [0.0, 1.0] using min-max rescaling.
+
+    Matches the convention in core.decisions._fts_rank_decisions_from_diff
+    (lines 1014-1018), which collapses a single-row result set to the
+    *mid* value (2.0 out of [0.5, 4.0]) rather than the max. We do the
+    same with our [0.0, 1.0] range — single-row → 0.5 — so that a
+    single weak FTS hit does not propagate as the full dedup penalty
+    weight and zero out legitimate candidates that happen to share one
+    stopword-adjacent token with a prior decision. True duplicates are
+    still caught by the exact dedup_key gate via the unique index.
+    """
     if not rows:
         return {}
     raw_scores = {r["rowid"]: -float(r["rank"]) for r in rows}
@@ -615,7 +626,7 @@ def _normalize_fts_scores(rows: list[Any]) -> dict[str, float]:
     result: dict[str, float] = {}
     if mx == mn:
         for rowid in raw_scores:
-            result[str(rowid)] = 1.0
+            result[str(rowid)] = 0.5
     else:
         span = mx - mn
         for rowid, raw in raw_scores.items():

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -265,10 +265,15 @@ def mark_session_extracted(conn, session_id: str) -> None:
 
 
 def _previous_checkpoint_created_at(conn, session_id: str, current_created_at: str) -> str | None:
+    # datetime() wrapping normalizes both the ISO-8601 format that Python
+    # writes via create_turn/_now_iso() and the space-separated form that
+    # sqlite emits for the checkpoints.created_at DEFAULT datetime('now').
+    # Without this, lexicographic comparison between 'T' (0x54) and ' '
+    # (0x20) makes same-second turn/checkpoint rows compare incorrectly.
     row = conn.execute(
         "SELECT created_at FROM checkpoints "
-        "WHERE session_id = ? AND created_at < ? "
-        "ORDER BY created_at DESC, rowid DESC LIMIT 1",
+        "WHERE session_id = ? AND datetime(created_at) < datetime(?) "
+        "ORDER BY datetime(created_at) DESC, rowid DESC LIMIT 1",
         (session_id, current_created_at),
     ).fetchone()
     if row is None:
@@ -277,11 +282,15 @@ def _previous_checkpoint_created_at(conn, session_id: str, current_created_at: s
 
 
 def _turn_window_rows(conn, session_id: str, checkpoint_created_at: str, prev_created_at: str | None) -> list[Any]:
+    # Both turns.timestamp (ISO-8601 with T separator) and
+    # checkpoints.created_at (sqlite space-separated) must be canonicalized
+    # via datetime() so the range predicate works across the format
+    # boundary. See _previous_checkpoint_created_at for context.
     if prev_created_at is None:
         return list(
             conn.execute(
                 "SELECT assistant_summary, files_touched FROM turns "
-                "WHERE session_id = ? AND timestamp <= ? "
+                "WHERE session_id = ? AND datetime(timestamp) <= datetime(?) "
                 "ORDER BY turn_number ASC",
                 (session_id, checkpoint_created_at),
             ).fetchall()
@@ -289,7 +298,8 @@ def _turn_window_rows(conn, session_id: str, checkpoint_created_at: str, prev_cr
     return list(
         conn.execute(
             "SELECT assistant_summary, files_touched FROM turns "
-            "WHERE session_id = ? AND timestamp <= ? AND timestamp > ? "
+            "WHERE session_id = ? AND datetime(timestamp) <= datetime(?) "
+            "  AND datetime(timestamp) > datetime(?) "
             "ORDER BY turn_number ASC",
             (session_id, checkpoint_created_at, prev_created_at),
         ).fetchall()

--- a/src/entirecontext/db/migrations/__init__.py
+++ b/src/entirecontext/db/migrations/__init__.py
@@ -7,7 +7,10 @@ from importlib import import_module
 
 def get_migrations() -> dict[int, list]:
     migrations: dict[int, list] = {}
-    for version in range(2, 13):
-        module = import_module(f".v{version:03d}", __name__)
+    for version in range(2, 14):
+        # version is a hardcoded bounded integer from range(), not user input
+        module = import_module(
+            f".v{version:03d}", __name__
+        )  # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         migrations[version] = list(module.MIGRATION_STEPS)
     return migrations

--- a/src/entirecontext/db/migrations/v013.py
+++ b/src/entirecontext/db/migrations/v013.py
@@ -1,0 +1,114 @@
+"""Migration to schema v13 — decision_candidates table for candidate extraction pipeline."""
+
+
+def _create_decision_candidates_table(conn):
+    row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='decision_candidates'").fetchone()
+    if row is not None:
+        return
+    conn.execute(
+        """
+        CREATE TABLE decision_candidates (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            rationale TEXT,
+            scope TEXT,
+            rejected_alternatives TEXT,
+            supporting_evidence TEXT,
+            source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment')),
+            source_id TEXT NOT NULL,
+            session_id TEXT,
+            checkpoint_id TEXT,
+            assessment_id TEXT,
+            files TEXT,
+            confidence REAL NOT NULL DEFAULT 0.0,
+            confidence_breakdown TEXT,
+            review_status TEXT NOT NULL DEFAULT 'pending'
+                CHECK(review_status IN ('pending','confirmed','rejected')),
+            reviewed_at TEXT,
+            reviewed_by TEXT,
+            review_note TEXT,
+            promoted_decision_id TEXT,
+            dedup_key TEXT NOT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+            FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+            FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON DELETE SET NULL,
+            FOREIGN KEY (promoted_decision_id) REFERENCES decisions(id) ON DELETE SET NULL
+        )
+        """
+    )
+
+
+def _create_decision_candidates_indexes(conn):
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id)")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uniq_decision_candidates_source_dedup "
+        "ON decision_candidates(source_type, source_id, dedup_key)"
+    )
+
+
+def _create_fts_decision_candidates(conn):
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_decision_candidates'"
+    ).fetchone()
+    if row is not None:
+        return
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE fts_decision_candidates USING fts5(
+            title,
+            rationale,
+            content='decision_candidates',
+            content_rowid='rowid'
+        )
+        """
+    )
+
+
+def _create_fts_decision_candidates_triggers(conn):
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ai
+        AFTER INSERT ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, new.rationale);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ad
+        AFTER DELETE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, old.rationale);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_au
+        AFTER UPDATE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, old.rationale);
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, new.rationale);
+        END
+        """
+    )
+
+
+MIGRATION_STEPS = [
+    _create_decision_candidates_table,
+    _create_decision_candidates_indexes,
+    _create_fts_decision_candidates,
+    _create_fts_decision_candidates_triggers,
+]

--- a/src/entirecontext/db/migrations/v013.py
+++ b/src/entirecontext/db/migrations/v013.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import sqlite3
 
-def _create_decision_candidates_table(conn):
+
+def _create_decision_candidates_table(conn: sqlite3.Connection) -> None:
     row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='decision_candidates'").fetchone()
     if row is not None:
         return
@@ -42,7 +44,7 @@ def _create_decision_candidates_table(conn):
     )
 
 
-def _create_decision_candidates_indexes(conn):
+def _create_decision_candidates_indexes(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
@@ -58,7 +60,7 @@ def _create_decision_candidates_indexes(conn):
     )
 
 
-def _create_fts_decision_candidates(conn):
+def _create_fts_decision_candidates(conn: sqlite3.Connection) -> None:
     row = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_decision_candidates'"
     ).fetchone()
@@ -76,7 +78,7 @@ def _create_fts_decision_candidates(conn):
     )
 
 
-def _create_fts_decision_candidates_triggers(conn):
+def _create_fts_decision_candidates_triggers(conn: sqlite3.Connection) -> None:
     conn.execute(
         """
         CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ai

--- a/src/entirecontext/db/migrations/v013.py
+++ b/src/entirecontext/db/migrations/v013.py
@@ -1,5 +1,7 @@
 """Migration to schema v13 — decision_candidates table for candidate extraction pipeline."""
 
+from __future__ import annotations
+
 
 def _create_decision_candidates_table(conn):
     row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='decision_candidates'").fetchone()

--- a/src/entirecontext/db/schema.py
+++ b/src/entirecontext/db/schema.py
@@ -1,6 +1,6 @@
 """Database schema definitions for EntireContext."""
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 # Minimum SQLite version required (for JSON functions)
 MIN_SQLITE_VERSION = "3.38.0"
@@ -419,6 +419,44 @@ CREATE INDEX IF NOT EXISTS idx_operation_events_session ON operation_events(sess
 CREATE INDEX IF NOT EXISTS idx_operation_events_created ON operation_events(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_operation_events_status ON operation_events(status);
 """,
+    "decision_candidates": """
+CREATE TABLE IF NOT EXISTS decision_candidates (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    rationale TEXT,
+    scope TEXT,
+    rejected_alternatives TEXT,
+    supporting_evidence TEXT,
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment')),
+    source_id TEXT NOT NULL,
+    session_id TEXT,
+    checkpoint_id TEXT,
+    assessment_id TEXT,
+    files TEXT,
+    confidence REAL NOT NULL DEFAULT 0.0,
+    confidence_breakdown TEXT,
+    review_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(review_status IN ('pending','confirmed','rejected')),
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    review_note TEXT,
+    promoted_decision_id TEXT,
+    dedup_key TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+    FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON DELETE SET NULL,
+    FOREIGN KEY (promoted_decision_id) REFERENCES decisions(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status);
+CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_decision_candidates_confidence ON decision_candidates(confidence DESC);
+CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key);
+CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_decision_candidates_source_dedup
+    ON decision_candidates(source_type, source_id, dedup_key);
+""",
 }
 
 # FTS5 virtual tables
@@ -462,6 +500,14 @@ CREATE VIRTUAL TABLE IF NOT EXISTS fts_decisions USING fts5(
     title,
     rationale,
     content='decisions',
+    content_rowid='rowid'
+);
+""",
+    "fts_decision_candidates": """
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_decision_candidates USING fts5(
+    title,
+    rationale,
+    content='decision_candidates',
     content_rowid='rowid'
 );
 """,
@@ -566,6 +612,26 @@ CREATE TRIGGER IF NOT EXISTS fts_decisions_au AFTER UPDATE ON decisions BEGIN
   INSERT INTO fts_decisions(fts_decisions, rowid, title, rationale)
   VALUES ('delete', old.rowid, old.title, old.rationale);
   INSERT INTO fts_decisions(rowid, title, rationale)
+  VALUES (new.rowid, new.title, new.rationale);
+END;
+""",
+    "fts_decision_candidates_ai": """
+CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ai AFTER INSERT ON decision_candidates BEGIN
+  INSERT INTO fts_decision_candidates(rowid, title, rationale)
+  VALUES (new.rowid, new.title, new.rationale);
+END;
+""",
+    "fts_decision_candidates_ad": """
+CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ad AFTER DELETE ON decision_candidates BEGIN
+  INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+  VALUES ('delete', old.rowid, old.title, old.rationale);
+END;
+""",
+    "fts_decision_candidates_au": """
+CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_au AFTER UPDATE ON decision_candidates BEGIN
+  INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+  VALUES ('delete', old.rowid, old.title, old.rationale);
+  INSERT INTO fts_decision_candidates(rowid, title, rationale)
   VALUES (new.rowid, new.title, new.rationale);
 END;
 """,

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -771,19 +771,32 @@ def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
             if _session_has_extraction_marker(conn, session_id):
                 return
 
-            keywords = config.get("extract_keywords", [])
-            rows = conn.execute(
-                "SELECT assistant_summary FROM turns "
-                "WHERE session_id = ? AND assistant_summary IS NOT NULL "
-                "ORDER BY turn_number ASC",
-                (session_id,),
-            ).fetchall()
-            summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+            # Respect `config.decisions.extract_sources` so users who disable
+            # a source type do not see spurious worker launches. Without this,
+            # a user with `extract_sources = ['session']` would still spawn a
+            # worker on non-empty checkpoint diff_summary or expand/narrow
+            # assessment verdicts, just to have the worker no-op inside
+            # `collect_signals`.
+            raw_sources = config.get("extract_sources")
+            if isinstance(raw_sources, list) and raw_sources:
+                sources = {str(s) for s in raw_sources}
+            else:
+                sources = {"session", "checkpoint", "assessment"}
 
-            # Gate: any one of the three source signals is enough to launch.
-            session_signal = bool(summaries) and _summaries_match_keywords(summaries, keywords)
-            checkpoint_signal = _session_has_checkpoint_signal(conn, session_id)
-            assessment_signal = _session_has_assessment_signal(conn, session_id)
+            session_signal = False
+            if "session" in sources:
+                keywords = config.get("extract_keywords", [])
+                rows = conn.execute(
+                    "SELECT assistant_summary FROM turns "
+                    "WHERE session_id = ? AND assistant_summary IS NOT NULL "
+                    "ORDER BY turn_number ASC",
+                    (session_id,),
+                ).fetchall()
+                summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
+                session_signal = bool(summaries) and _summaries_match_keywords(summaries, keywords)
+
+            checkpoint_signal = "checkpoint" in sources and _session_has_checkpoint_signal(conn, session_id)
+            assessment_signal = "assessment" in sources and _session_has_assessment_signal(conn, session_id)
 
             if not (session_signal or checkpoint_signal or assessment_signal):
                 return

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -717,7 +717,15 @@ def _session_has_extraction_marker(conn, session_id: str) -> bool:
         import json
 
         meta = json.loads(row["metadata"])
-        return meta.get("decisions_extracted", False) is True
+        if not isinstance(meta, dict):
+            return False
+        # v13 marker is authoritative; v12 marker shim means sessions already
+        # processed by the old pipeline are not re-extracted.
+        if meta.get("candidates_extracted", False) is True:
+            return True
+        if meta.get("decisions_extracted", False) is True:
+            return True
+        return False
     except (ValueError, TypeError):
         return False
 
@@ -729,8 +737,28 @@ def _summaries_match_keywords(summaries: list[str], keywords: list[str]) -> bool
     return any(pattern.search(s) for s in summaries)
 
 
+def _session_has_checkpoint_signal(conn, session_id: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM checkpoints "
+        "WHERE session_id = ? AND diff_summary IS NOT NULL AND TRIM(diff_summary) != '' "
+        "LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    return row is not None
+
+
+def _session_has_assessment_signal(conn, session_id: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM assessments a JOIN checkpoints c ON a.checkpoint_id = c.id "
+        "WHERE c.session_id = ? AND a.verdict IN ('expand', 'narrow') "
+        "LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    return row is not None
+
+
 def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
-    """Launch background decision extraction if keywords match. Never raises."""
+    """Launch background candidate extraction if any of the three source gates fire. Never raises."""
     try:
         config = _load_decisions_config(repo_path)
         if not config.get("auto_extract", False):
@@ -743,6 +771,7 @@ def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
             if _session_has_extraction_marker(conn, session_id):
                 return
 
+            keywords = config.get("extract_keywords", [])
             rows = conn.execute(
                 "SELECT assistant_summary FROM turns "
                 "WHERE session_id = ? AND assistant_summary IS NOT NULL "
@@ -750,11 +779,13 @@ def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
                 (session_id,),
             ).fetchall()
             summaries = [r["assistant_summary"] for r in rows if r["assistant_summary"]]
-            if not summaries:
-                return
 
-            keywords = config.get("extract_keywords", [])
-            if not _summaries_match_keywords(summaries, keywords):
+            # Gate: any one of the three source signals is enough to launch.
+            session_signal = bool(summaries) and _summaries_match_keywords(summaries, keywords)
+            checkpoint_signal = _session_has_checkpoint_signal(conn, session_id)
+            assessment_signal = _session_has_assessment_signal(conn, session_id)
+
+            if not (session_signal or checkpoint_signal or assessment_signal):
                 return
 
             if worker_status(repo_path, pid_name="worker-decision").get("running"):
@@ -764,7 +795,15 @@ def maybe_extract_decisions(repo_path: str, session_id: str) -> None:
 
             launch_worker(
                 repo_path,
-                [sys.executable, "-m", "entirecontext.cli", "decision", "extract-from-session", session_id],
+                [
+                    sys.executable,
+                    "-m",
+                    "entirecontext.cli",
+                    "decision",
+                    "extract-candidates",
+                    "--session",
+                    session_id,
+                ],
                 pid_name="worker-decision",
             )
         finally:

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -92,6 +92,12 @@ def _record_selection(
 
 
 from .tools.checkpoint import ec_checkpoint_list, ec_rewind  # noqa: E402
+from .tools.decision_candidates import (  # noqa: E402
+    ec_decision_candidate_confirm,
+    ec_decision_candidate_get,
+    ec_decision_candidate_list,
+    ec_decision_candidate_reject,
+)
 from .tools.decisions import (  # noqa: E402
     ec_decision_context,
     ec_decision_create,
@@ -109,10 +115,10 @@ from .tools.session import ec_attribution, ec_context_apply, ec_session_context,
 
 if mcp:
     from .runtime import ServiceRegistry
-    from .tools import checkpoint, decisions, futures, misc, search, session
+    from .tools import checkpoint, decision_candidates, decisions, futures, misc, search, session
 
     _services = ServiceRegistry()
-    for module in (search, checkpoint, session, futures, misc, decisions):
+    for module in (search, checkpoint, session, futures, misc, decisions, decision_candidates):
         module.register_tools(mcp, _services)
 
 
@@ -150,5 +156,9 @@ __all__ = [
     "ec_decision_related",
     "ec_decision_search",
     "ec_decision_stale",
+    "ec_decision_candidate_list",
+    "ec_decision_candidate_get",
+    "ec_decision_candidate_confirm",
+    "ec_decision_candidate_reject",
     "run_server",
 ]

--- a/src/entirecontext/mcp/tools/decision_candidates.py
+++ b/src/entirecontext/mcp/tools/decision_candidates.py
@@ -1,0 +1,110 @@
+"""MCP tools for decision_candidates — list / get / confirm / reject."""
+
+from __future__ import annotations
+
+import json
+
+from .. import runtime
+
+
+async def ec_decision_candidate_list(
+    session_id: str | None = None,
+    status: str | None = None,
+    min_confidence: float = 0.0,
+    source_type: str | None = None,
+    limit: int = 50,
+) -> str:
+    """List candidate decisions. Filter by session, status, confidence, source type."""
+    (conn, _), error = runtime.resolve_repo()
+    if error:
+        return error
+    try:
+        from ...core.decision_candidates import list_candidates
+
+        rows = list_candidates(
+            conn,
+            session_id=session_id,
+            status=status,
+            min_confidence=min_confidence,
+            source_type=source_type,
+            limit=limit,
+        )
+        return json.dumps({"candidates": rows, "count": len(rows)})
+    except Exception as exc:
+        return runtime.error_payload(str(exc))
+    finally:
+        conn.close()
+
+
+async def ec_decision_candidate_get(candidate_id: str) -> str:
+    """Get a single candidate with full breakdown."""
+    (conn, _), error = runtime.resolve_repo()
+    if error:
+        return error
+    try:
+        from ...core.decision_candidates import get_candidate
+
+        candidate = get_candidate(conn, candidate_id)
+        if not candidate:
+            return runtime.error_payload(f"Candidate '{candidate_id}' not found")
+        return json.dumps(candidate)
+    except Exception as exc:
+        return runtime.error_payload(str(exc))
+    finally:
+        conn.close()
+
+
+async def ec_decision_candidate_confirm(
+    candidate_id: str,
+    scope: str | None = None,
+    note: str | None = None,
+) -> str:
+    """Confirm a candidate: promote to a real decision with provenance links."""
+    (conn, _), error = runtime.resolve_repo()
+    if error:
+        return error
+    try:
+        from ...core.decision_candidates import confirm_candidate
+
+        result = confirm_candidate(
+            conn,
+            candidate_id,
+            scope_override=scope,
+            reviewer="mcp",
+            note=note,
+        )
+        return json.dumps(result)
+    except ValueError as exc:
+        return runtime.error_payload(str(exc))
+    except Exception as exc:
+        return runtime.error_payload(str(exc))
+    finally:
+        conn.close()
+
+
+async def ec_decision_candidate_reject(candidate_id: str, reason: str | None = None) -> str:
+    """Reject a candidate: leaves no trace in decisions."""
+    (conn, _), error = runtime.resolve_repo()
+    if error:
+        return error
+    try:
+        from ...core.decision_candidates import reject_candidate
+
+        result = reject_candidate(conn, candidate_id, reason=reason, reviewer="mcp")
+        return json.dumps(result)
+    except ValueError as exc:
+        return runtime.error_payload(str(exc))
+    except Exception as exc:
+        return runtime.error_payload(str(exc))
+    finally:
+        conn.close()
+
+
+def register_tools(mcp, services=None) -> None:
+    for tool in (
+        ec_decision_candidate_list,
+        ec_decision_candidate_get,
+        ec_decision_candidate_confirm,
+        ec_decision_candidate_reject,
+    ):
+        mcp.tool()(tool)

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -591,6 +591,68 @@ class TestConfirmRejectFlow:
         with pytest.raises(ValueError):
             confirm_candidate(ec_db, cid)
 
+    def test_confirm_claim_is_conditional_on_pending_status(self, ec_repo, ec_db):
+        """Regression: the confirm path must gate on review_status='pending'
+        via a conditional UPDATE, not via a separate pre-check. Manually
+        flipping the row to 'rejected' between reads must cause the
+        conditional UPDATE to miss and the call to raise ValueError without
+        creating any decision row."""
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="conditional-claim")
+        # Simulate a concurrent reject landing between the initial read and
+        # the UPDATE. We do this by manually flipping review_status.
+        ec_db.execute(
+            "UPDATE decision_candidates SET review_status='rejected' WHERE id=?",
+            (cid,),
+        )
+        ec_db.commit()
+        with pytest.raises(ValueError):
+            confirm_candidate(ec_db, cid)
+        # Decisions table must remain untouched.
+        decision_count = ec_db.execute("SELECT COUNT(*) AS c FROM decisions").fetchone()["c"]
+        assert decision_count == 0
+
+    def test_confirm_second_call_produces_exactly_one_decision(self, ec_repo, ec_db):
+        """Regression: the earlier non-atomic flow could create duplicate
+        decisions if confirm_candidate was invoked twice. The conditional
+        UPDATE must ensure the second call raises immediately and the
+        decisions table still holds exactly one row per confirmed candidate."""
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="exactly-one")
+        confirm_candidate(ec_db, cid)
+        with pytest.raises(ValueError):
+            confirm_candidate(ec_db, cid)
+        decision_rows = ec_db.execute(
+            "SELECT COUNT(*) AS c FROM decisions WHERE title = ?",
+            ("Confirm test decision",),
+        ).fetchone()
+        assert decision_rows["c"] == 1
+
+    def test_confirm_rolls_back_claim_on_post_claim_failure(self, ec_repo, ec_db, monkeypatch):
+        """Regression: if create_decision (or any auto-committing step after
+        the claim) raises, confirm_candidate must roll the claim back to
+        'pending' so the candidate can be retried later. Without the
+        rollback, the candidate would stay stuck in 'confirmed' with
+        promoted_decision_id=NULL and no real decision to back it."""
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="claim-rollback")
+
+        def failing_create_decision(*args, **kwargs):
+            raise RuntimeError("simulated post-claim failure")
+
+        monkeypatch.setattr(
+            "entirecontext.core.decisions.create_decision",
+            failing_create_decision,
+        )
+        with pytest.raises(RuntimeError, match="simulated post-claim failure"):
+            confirm_candidate(ec_db, cid)
+
+        # After the failure, the candidate must be back to pending so that
+        # a later retry (with a working create_decision) can succeed.
+        after = get_candidate(ec_db, cid)
+        assert after["review_status"] == "pending"
+        assert after["promoted_decision_id"] is None
+        # And of course, no decision row was created.
+        decision_count = ec_db.execute("SELECT COUNT(*) AS c FROM decisions").fetchone()["c"]
+        assert decision_count == 0
+
 
 # ---------------------------------------------------------------------------
 # Integration tests — dedup and noisy-input harness (Tier 1)

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -113,6 +113,42 @@ class TestNormalization:
         assert _tokenize_title_for_fts("") is None
 
 
+class TestNormalizeFTSScores:
+    def test_single_match_returns_mid_value(self):
+        """Regression: single-match must return mid-value 0.5 (matching
+        core.decisions._fts_rank_decisions_from_diff convention), not
+        1.0. Otherwise any single FTS hit on a shared stopword-adjacent
+        token propagates as the full dedup penalty weight and zeros out
+        legitimate candidates."""
+        from entirecontext.core.decision_extraction import _normalize_fts_scores
+
+        class _Row(dict):
+            def __getitem__(self, key):
+                return super().__getitem__(key)
+
+        rows = [_Row({"rowid": 1, "rank": -1.5})]
+        result = _normalize_fts_scores(rows)
+        assert result == {"1": 0.5}
+
+    def test_multi_match_spans_zero_to_one(self):
+        from entirecontext.core.decision_extraction import _normalize_fts_scores
+
+        rows = [
+            {"rowid": 1, "rank": -1.0},  # weakest
+            {"rowid": 2, "rank": -3.0},  # strongest (bm25 is negative)
+            {"rowid": 3, "rank": -2.0},  # middle
+        ]
+        result = _normalize_fts_scores(rows)
+        assert result["1"] == 0.0
+        assert result["2"] == 1.0
+        assert result["3"] == 0.5
+
+    def test_empty_input(self):
+        from entirecontext.core.decision_extraction import _normalize_fts_scores
+
+        assert _normalize_fts_scores([]) == {}
+
+
 # ---------------------------------------------------------------------------
 # Unit tests — confidence scoring
 # ---------------------------------------------------------------------------
@@ -625,6 +661,29 @@ class TestConfirmRejectFlow:
             ("Confirm test decision",),
         ).fetchone()
         assert decision_rows["c"] == 1
+
+    def test_reject_is_conditional_on_pending_status(self, ec_repo, ec_db):
+        """Regression: reject_candidate must use the same conditional UPDATE
+        pattern as confirm_candidate so a concurrent confirm cannot race it
+        into an invalid 'rejected with dangling promoted_decision_id' state."""
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="reject-race")
+        # Simulate a concurrent confirm completing between our reject's
+        # read and its UPDATE.
+        confirm_candidate(ec_db, cid)
+        # Now the candidate is 'confirmed'. A reject attempt must raise
+        # without overwriting the status or orphaning the decision row.
+        with pytest.raises(ValueError):
+            reject_candidate(ec_db, cid, reason="conflict")
+        fresh = get_candidate(ec_db, cid)
+        assert fresh["review_status"] == "confirmed"
+        assert fresh["promoted_decision_id"] is not None
+
+    def test_reject_second_call_raises(self, ec_repo, ec_db):
+        """Reject is idempotent from the caller's POV: second call raises."""
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="reject-double")
+        reject_candidate(ec_db, cid)
+        with pytest.raises(ValueError):
+            reject_candidate(ec_db, cid)
 
     def test_confirm_rolls_back_claim_on_post_claim_failure(self, ec_repo, ec_db, monkeypatch):
         """Regression: if create_decision (or any auto-committing step after

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -313,6 +313,35 @@ class TestSignalCollection:
         assert len(cp_bundles) == 1
         assert set(cp_bundles[0].files) == {"x.py", "y.py"}
 
+    def test_checkpoint_window_bridges_timestamp_format_mismatch(self, ec_repo, ec_db):
+        """Regression: turns.timestamp uses ISO-8601 with 'T' separator, while
+        checkpoints.created_at DEFAULT datetime('now') produces space-separated
+        form. Lexicographic comparison used to silently drop the entire turn
+        window. The fix wraps both sides in sqlite's datetime() normalizer."""
+        session = _seed_session(ec_db, ec_repo, session_id="s-format-mismatch")
+        # Seed turns via create_turn — this writes the real ISO format.
+        _seed_turn(ec_db, session["id"], 1, "work on cache", files=["cache.py", "config.py"])
+        _seed_turn(ec_db, session["id"], 2, "finish work", files=["cache.py", "runner.py"])
+        # Use the real schema default for created_at (space-separated form)
+        # instead of an ISO string, reproducing the production bug path.
+        import uuid as _uuid
+
+        checkpoint_id = str(_uuid.uuid4())
+        ec_db.execute(
+            "INSERT INTO checkpoints (id, session_id, git_commit_hash, diff_summary) VALUES (?, ?, ?, ?)",
+            (checkpoint_id, session["id"], "mismatch-hash", "cache.py | 5\nconfig.py | 3\nrunner.py | 1"),
+        )
+        ec_db.commit()
+        # Confirm the created_at is indeed space-separated (production shape).
+        row = ec_db.execute("SELECT created_at FROM checkpoints WHERE id = ?", (checkpoint_id,)).fetchone()
+        assert " " in row["created_at"] and "T" not in row["created_at"]
+
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        cp_bundles = [b for b in bundles if b.source_type == "checkpoint"]
+        assert len(cp_bundles) == 1
+        # Turn window must include both turns despite the format mismatch.
+        assert set(cp_bundles[0].files) == {"cache.py", "config.py", "runner.py"}
+
     def test_assessment_neutral_skipped(self, ec_repo, ec_db):
         session = _seed_session(ec_db, ec_repo, session_id="s-neutral")
         _seed_turn(ec_db, session["id"], 1, "work", files=["a.py", "b.py"])
@@ -623,6 +652,65 @@ class TestDedupAndNoise:
         count_after_second = len(list_candidates(ec_db, session_id=session["id"]))
         assert count_after_first == 1
         assert count_after_second == 1  # marker short-circuits second run
+
+    def test_shim_passes_source_type_per_bundle(self, ec_repo, ec_db, monkeypatch):
+        """Regression: the back-compat shim used to hardcode source_type='session'
+        when invoking call_extraction_llm, so checkpoint/assessment bundles were
+        sent through the wrong system prompt. The shim now dispatches through
+        _invoke_get_llm_response which passes source_type to _get_llm_response."""
+        session = _seed_session(ec_db, ec_repo, session_id="shim-source-type")
+        _seed_turn(ec_db, session["id"], 1, "We decided to extract helpers", files=["a.py", "b.py"])
+        _seed_checkpoint(
+            ec_db,
+            session["id"],
+            diff_summary="a.py | 5\nb.py | 3",
+            commit_hash="shim-cp",
+        )
+
+        captured: list[dict] = []
+
+        def fake_llm(summaries, repo_path, source_type="session"):
+            captured.append({"source_type": source_type, "text": summaries[:60]})
+            return json.dumps(
+                [
+                    {
+                        "title": f"{source_type} decision",
+                        "rationale": "a long enough rationale for the heuristic bonus",
+                        "scope": "x",
+                    }
+                ]
+            )
+
+        monkeypatch.setattr("entirecontext.cli.decisions_cmds._get_llm_response", fake_llm)
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        source_types_seen = {c["source_type"] for c in captured}
+        # At minimum, both session and checkpoint source_type must reach the LLM
+        # call with their own identifier.
+        assert "session" in source_types_seen
+        assert "checkpoint" in source_types_seen
+
+    def test_shim_legacy_two_arg_monkeypatch_still_works(self, ec_repo, ec_db, monkeypatch):
+        """Regression: pre-existing tests monkeypatch _get_llm_response with a
+        2-arg lambda (no source_type). The shim's inspect-based dispatch must
+        detect this and call the 2-arg version so those tests keep passing."""
+        session = _seed_session(ec_db, ec_repo, session_id="shim-legacy")
+        _seed_turn(ec_db, session["id"], 1, "We decided X", files=["a.py"])
+
+        calls: list[int] = []
+
+        def legacy_llm(summaries, repo_path):
+            calls.append(1)
+            return json.dumps([{"title": "Choose X", "rationale": "a reason long enough for heuristic", "scope": "x"}])
+
+        monkeypatch.setattr("entirecontext.cli.decisions_cmds._get_llm_response", legacy_llm)
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        assert len(calls) == 1
+        assert len(list_candidates(ec_db, session_id=session["id"])) == 1
 
     def test_low_signal_candidate_below_threshold(self, ec_repo, ec_db, monkeypatch):
         """Candidates with no rationale / alts / files sit below default filter."""

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1,0 +1,645 @@
+"""Unit + integration tests for the candidate decision extraction pipeline."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from entirecontext.core.decision_candidates import (
+    confirm_candidate,
+    get_candidate,
+    list_candidates,
+    reject_candidate,
+)
+from entirecontext.core.decision_extraction import (
+    CandidateDraft,
+    DecisionExtractionError,
+    DedupResult,
+    SignalBundle,
+    _tokenize_title_for_fts,
+    collect_signals,
+    compute_dedup_key,
+    is_session_extracted,
+    mark_session_extracted,
+    normalize_title_for_dedup,
+    parse_llm_response,
+    persist_candidate,
+    score_confidence,
+)
+from entirecontext.core.decisions import create_decision
+from entirecontext.core.futures import create_assessment
+from entirecontext.core.project import get_project
+from entirecontext.core.session import create_session
+from entirecontext.core.turn import create_turn
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(conn, ec_repo, session_id: str = "extraction-test-session") -> dict:
+    project = get_project(str(ec_repo))
+    return create_session(conn, project["id"], session_id=session_id)
+
+
+def _seed_turn(conn, session_id: str, turn_number: int, summary: str, files: list[str] | None = None) -> dict:
+    turn = create_turn(conn, session_id, turn_number, user_message=f"msg {turn_number}")
+    conn.execute(
+        "UPDATE turns SET assistant_summary = ?, files_touched = ?, turn_status = 'completed' WHERE id = ?",
+        (summary, json.dumps(files) if files else None, turn["id"]),
+    )
+    conn.commit()
+    return turn
+
+
+def _seed_checkpoint(
+    conn,
+    session_id: str,
+    diff_summary: str,
+    created_at: str | None = None,
+    commit_hash: str = "abc123",
+) -> dict:
+    import uuid
+
+    checkpoint_id = str(uuid.uuid4())
+    if created_at is None:
+        created_at = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO checkpoints (id, session_id, git_commit_hash, diff_summary, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (checkpoint_id, session_id, commit_hash, diff_summary, created_at),
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM checkpoints WHERE id = ?", (checkpoint_id,)).fetchone()
+    return dict(row)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — normalization, dedup key, tokenization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalization:
+    def test_normalize_basic(self):
+        assert normalize_title_for_dedup("Use Redis for Caching!!") == "use redis for caching"
+
+    def test_normalize_case_invariance(self):
+        assert normalize_title_for_dedup("USE REDIS") == normalize_title_for_dedup("use redis")
+
+    def test_normalize_whitespace_collapses(self):
+        assert normalize_title_for_dedup("  use   redis\nfor\tcaching  ") == "use redis for caching"
+
+    def test_compute_dedup_key_stable(self):
+        k1 = compute_dedup_key("Use Redis")
+        k2 = compute_dedup_key("use redis!!")
+        assert k1 == k2
+
+    def test_dedup_key_12_chars(self):
+        k = compute_dedup_key("hello world")
+        assert len(k) == 12
+
+    def test_tokenize_title(self):
+        result = _tokenize_title_for_fts("Use JWT over session-based auth")
+        assert result is not None
+        assert "jwt" in result.lower()
+        assert "auth" in result.lower()
+
+    def test_tokenize_empty(self):
+        assert _tokenize_title_for_fts("") is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — confidence scoring
+# ---------------------------------------------------------------------------
+
+
+def _mock_draft(
+    source_type: str,
+    *,
+    rationale: str | None = None,
+    rejected: list | None = None,
+    files: list | None = None,
+) -> CandidateDraft:
+    return CandidateDraft(
+        title="t",
+        rationale=rationale,
+        scope=None,
+        rejected_alternatives=rejected or [],
+        supporting_evidence=[],
+        source_type=source_type,
+        source_id=f"{source_type}-1",
+        session_id="s1",
+        checkpoint_id=None,
+        assessment_id=None,
+        files=files or [],
+    )
+
+
+class TestConfidenceScoring:
+    def test_session_base_weight(self):
+        draft = _mock_draft("session")
+        dr = DedupResult(dedup_key="k")
+        score, breakdown = score_confidence(draft, dr)
+        assert abs(score - 0.30) < 1e-6
+        assert breakdown["base"]["weight"] == 0.30
+
+    def test_checkpoint_base_weight(self):
+        draft = _mock_draft("checkpoint")
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.40) < 1e-6
+
+    def test_assessment_base_weight(self):
+        draft = _mock_draft("assessment")
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.55) < 1e-6
+
+    def test_rationale_bonus(self):
+        long_rationale = "this rationale is clearly longer than thirty characters"
+        draft = _mock_draft("session", rationale=long_rationale)
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.45) < 1e-6
+
+    def test_short_rationale_no_bonus(self):
+        draft = _mock_draft("session", rationale="short")
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.30) < 1e-6
+
+    def test_alts_bonus(self):
+        draft = _mock_draft("session", rejected=["old approach"])
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.45) < 1e-6
+
+    def test_files_in_band_bonus(self):
+        draft = _mock_draft("session", files=["a.py", "b.py"])
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.40) < 1e-6
+
+    def test_zero_files_no_bonus(self):
+        draft = _mock_draft("session", files=[])
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.30) < 1e-6
+
+    def test_too_many_files_no_bonus(self):
+        draft = _mock_draft("session", files=[f"f{i}.py" for i in range(10)])
+        dr = DedupResult(dedup_key="k")
+        score, _ = score_confidence(draft, dr)
+        assert abs(score - 0.30) < 1e-6
+
+    def test_penalty_clamps_to_zero(self):
+        draft = _mock_draft("session")
+        dr = DedupResult(dedup_key="k", score_vs_decisions=4.0, score_vs_candidates=4.0)
+        score, _ = score_confidence(draft, dr)
+        assert score == 0.0
+
+    def test_breakdown_has_expected_keys(self):
+        draft = _mock_draft(
+            "assessment",
+            rationale="long rationale exceeding thirty characters easily",
+            rejected=["alt"],
+            files=["a.py"],
+        )
+        dr = DedupResult(dedup_key="k", score_vs_decisions=0.2)
+        score, breakdown = score_confidence(draft, dr)
+        assert "initial" in breakdown
+        assert "penalties" in breakdown
+        assert "final" in breakdown
+        assert breakdown["initial"] == 0.95  # 0.55 + 0.15 + 0.15 + 0.10
+        assert score < breakdown["initial"]
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — session marker (including v12 shim)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionMarker:
+    def test_fresh_session_not_marked(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo)
+        assert is_session_extracted(ec_db, session["id"]) is False
+
+    def test_mark_session_extracted(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo)
+        mark_session_extracted(ec_db, session["id"])
+        assert is_session_extracted(ec_db, session["id"]) is True
+
+    def test_v12_marker_recognized(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo)
+        ec_db.execute(
+            "UPDATE sessions SET metadata = ? WHERE id = ?",
+            (json.dumps({"decisions_extracted": True}), session["id"]),
+        )
+        ec_db.commit()
+        assert is_session_extracted(ec_db, session["id"]) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — signal collection per source
+# ---------------------------------------------------------------------------
+
+
+class TestSignalCollection:
+    def test_session_no_keyword_match(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo)
+        _seed_turn(ec_db, session["id"], 1, "Just a normal status update")
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        assert all(b.source_type != "session" for b in bundles)
+
+    def test_session_with_keyword_match(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo)
+        _seed_turn(
+            ec_db,
+            session["id"],
+            1,
+            "We decided to use Redis over memcached",
+            files=["src/cache.py"],
+        )
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        session_bundles = [b for b in bundles if b.source_type == "session"]
+        assert len(session_bundles) == 1
+        assert "src/cache.py" in session_bundles[0].files
+
+    def test_session_empty_intersection_files(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="s-empty-intersect")
+        _seed_turn(ec_db, session["id"], 1, "We decided on approach A", files=["a.py"])
+        _seed_turn(ec_db, session["id"], 2, "We decided approach B instead", files=["b.py"])
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        session_bundles = [b for b in bundles if b.source_type == "session"]
+        assert len(session_bundles) == 1
+        # Intersection of {a.py} and {b.py} is empty and must NOT fall back
+        # to the union.
+        assert session_bundles[0].files == []
+
+    def test_checkpoint_single_file_skipped(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="s-cp-single")
+        _seed_turn(ec_db, session["id"], 1, "refactor", files=["a.py"])
+        _seed_checkpoint(ec_db, session["id"], diff_summary="a.py | 5 +++--", commit_hash="cp1")
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        assert all(b.source_type != "checkpoint" for b in bundles)
+
+    def test_checkpoint_multi_file_included(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="s-cp-multi")
+        _seed_turn(ec_db, session["id"], 1, "refactor", files=["a.py", "b.py", "c.py"])
+        _seed_checkpoint(
+            ec_db,
+            session["id"],
+            diff_summary="a.py | 5 +++--\nb.py | 3 +++\nc.py | 2 +",
+            commit_hash="cp2",
+        )
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        cp_bundles = [b for b in bundles if b.source_type == "checkpoint"]
+        assert len(cp_bundles) == 1
+        assert set(cp_bundles[0].files) == {"a.py", "b.py", "c.py"}
+
+    def test_checkpoint_does_not_read_files_snapshot(self, ec_repo, ec_db):
+        """Checkpoint files come from turn window, not from files_snapshot."""
+        session = _seed_session(ec_db, ec_repo, session_id="s-no-snapshot")
+        _seed_turn(ec_db, session["id"], 1, "changes", files=["x.py", "y.py"])
+        # Seed checkpoint with NULL files_snapshot (matching real auto-created checkpoints).
+        _seed_checkpoint(ec_db, session["id"], diff_summary="x.py | 1\ny.py | 1", commit_hash="nosnap")
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        cp_bundles = [b for b in bundles if b.source_type == "checkpoint"]
+        assert len(cp_bundles) == 1
+        assert set(cp_bundles[0].files) == {"x.py", "y.py"}
+
+    def test_assessment_neutral_skipped(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="s-neutral")
+        _seed_turn(ec_db, session["id"], 1, "work", files=["a.py", "b.py"])
+        cp = _seed_checkpoint(ec_db, session["id"], diff_summary="a.py|1\nb.py|1", commit_hash="cp-neutral")
+        create_assessment(
+            ec_db,
+            verdict="neutral",
+            impact_summary="no impact",
+            roadmap_alignment="",
+            tidy_suggestion="",
+            diff_summary="",
+            checkpoint_id=cp["id"],
+        )
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        assert all(b.source_type != "assessment" for b in bundles)
+
+    def test_assessment_expand_collected(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="s-expand")
+        _seed_turn(ec_db, session["id"], 1, "work", files=["a.py", "b.py"])
+        cp = _seed_checkpoint(ec_db, session["id"], diff_summary="a.py|1\nb.py|1", commit_hash="cp-expand")
+        create_assessment(
+            ec_db,
+            verdict="expand",
+            impact_summary="expands scope to cover X",
+            roadmap_alignment="aligned",
+            tidy_suggestion="consider extracting Y",
+            diff_summary="diff",
+            checkpoint_id=cp["id"],
+        )
+        bundles = collect_signals(ec_db, session["id"], str(ec_repo))
+        assess_bundles = [b for b in bundles if b.source_type == "assessment"]
+        assert len(assess_bundles) == 1
+        assert set(assess_bundles[0].files) >= {"a.py", "b.py"}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — parse_llm_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseLLMResponse:
+    def _bundle(self) -> SignalBundle:
+        return SignalBundle(
+            source_type="session",
+            source_id="s1",
+            session_id="sess",
+            checkpoint_id=None,
+            assessment_id=None,
+            text_blocks=["x"],
+            files=["a.py"],
+        )
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(DecisionExtractionError):
+            parse_llm_response("not json", self._bundle())
+
+    def test_non_list_returns_empty(self):
+        result = parse_llm_response('{"not": "a list"}', self._bundle())
+        assert result == []
+
+    def test_valid_array(self):
+        raw = json.dumps(
+            [{"title": "Use Redis", "rationale": "fast", "scope": "cache", "rejected_alternatives": ["memcached"]}]
+        )
+        drafts = parse_llm_response(raw, self._bundle())
+        assert len(drafts) == 1
+        assert drafts[0].title == "Use Redis"
+        assert drafts[0].rejected_alternatives == ["memcached"]
+
+    def test_caps_at_five(self):
+        raw = json.dumps([{"title": f"D{i}"} for i in range(10)])
+        drafts = parse_llm_response(raw, self._bundle())
+        assert len(drafts) == 5
+
+    def test_skips_missing_title(self):
+        raw = json.dumps([{"title": "ok"}, {"no_title": "x"}, {"title": ""}])
+        drafts = parse_llm_response(raw, self._bundle())
+        assert len(drafts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — end-to-end run_extraction via shim
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndExtraction:
+    def test_session_only_extraction(self, ec_repo, ec_db, monkeypatch):
+        session = _seed_session(ec_db, ec_repo, session_id="e2e-session-only")
+        _seed_turn(
+            ec_db,
+            session["id"],
+            1,
+            "We decided to use Redis instead of memcached",
+            files=["src/cache.py"],
+        )
+        llm_response = json.dumps(
+            [
+                {
+                    "title": "Use Redis for cache",
+                    "rationale": "Redis persistence is essential for our use case",
+                    "scope": "cache",
+                    "rejected_alternatives": ["memcached"],
+                }
+            ]
+        )
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        candidates = list_candidates(ec_db, session_id=session["id"])
+        assert len(candidates) == 1
+        assert candidates[0]["source_type"] == "session"
+        assert candidates[0]["review_status"] == "pending"
+        assert candidates[0]["confidence"] > 0.0
+
+    def test_retriever_isolation(self, ec_repo, ec_db, monkeypatch):
+        """Pending candidates must not leak into decision retrievers."""
+        from entirecontext.core.decisions import rank_related_decisions
+
+        # Seed a real decision the retriever should see
+        create_decision(
+            ec_db,
+            title="Real confirmed decision",
+            rationale="carry forward",
+            scope="test",
+        )
+
+        # Seed a candidate with a similar title
+        session = _seed_session(ec_db, ec_repo, session_id="e2e-isolation")
+        _seed_turn(ec_db, session["id"], 1, "We decided to revisit the confirmed decision", files=["a.py"])
+        llm_response = json.dumps(
+            [
+                {
+                    "title": "Real confirmed decision variant",
+                    "rationale": "a reasoned rationale longer than thirty characters",
+                    "scope": "test",
+                    "rejected_alternatives": [],
+                }
+            ]
+        )
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+
+        # Both tables should have data
+        assert len(list_candidates(ec_db)) == 1
+        # Retrievers must only see the confirmed decision, not the candidate
+        ranked, _stats = rank_related_decisions(ec_db, file_paths=["a.py"], _return_stats=True)
+        titles = [d.get("title") for d in ranked]
+        assert "Real confirmed decision" in titles or ranked == []  # retriever may return empty if relevance low
+        assert "Real confirmed decision variant" not in titles
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — confirm / reject flow
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmRejectFlow:
+    def _seed_candidate(self, ec_db, ec_repo, *, session_id="conf-session", checkpoint_id=None, assessment_id=None):
+        session = _seed_session(ec_db, ec_repo, session_id=session_id)
+        draft = CandidateDraft(
+            title="Confirm test decision",
+            rationale="a sufficiently long rationale to pass the heuristic",
+            scope="test",
+            rejected_alternatives=["alt"],
+            supporting_evidence=[],
+            source_type="session",
+            source_id=session["id"],
+            session_id=session["id"],
+            checkpoint_id=checkpoint_id,
+            assessment_id=assessment_id,
+            files=["src/a.py", "src/b.py"],
+        )
+        dr = DedupResult(dedup_key=compute_dedup_key(draft.title))
+        score, breakdown = score_confidence(draft, dr)
+        result = persist_candidate(ec_db, draft, score, breakdown, dr)
+        return result.candidate_id
+
+    def test_confirm_creates_decision_with_files(self, ec_repo, ec_db):
+        from entirecontext.core.decisions import get_decision
+
+        cid = self._seed_candidate(ec_db, ec_repo)
+        assert cid is not None
+        result = confirm_candidate(ec_db, cid, reviewer="cli")
+        assert result["promoted"] is True
+        decision_id = result["decision_id"]
+        decision = get_decision(ec_db, decision_id)
+        assert decision is not None
+        assert "src/a.py" in decision.get("files", [])
+        assert "src/b.py" in decision.get("files", [])
+
+    def test_confirm_promotes_checkpoint_and_assessment_links(self, ec_repo, ec_db):
+        session = _seed_session(ec_db, ec_repo, session_id="conf-provenance")
+        _seed_turn(ec_db, session["id"], 1, "work", files=["a.py"])
+        cp = _seed_checkpoint(ec_db, session["id"], diff_summary="a.py|1\nb.py|1", commit_hash="cp-prov")
+        assess_id = create_assessment(
+            ec_db,
+            verdict="expand",
+            impact_summary="x",
+            checkpoint_id=cp["id"],
+        )["id"]
+        cid = self._seed_candidate(
+            ec_db,
+            ec_repo,
+            session_id="conf-provenance-cand",
+            checkpoint_id=cp["id"],
+            assessment_id=assess_id,
+        )
+        result = confirm_candidate(ec_db, cid, reviewer="cli")
+        decision_id = result["decision_id"]
+        # decision_checkpoints link
+        cp_link = ec_db.execute(
+            "SELECT 1 FROM decision_checkpoints WHERE decision_id = ? AND checkpoint_id = ?",
+            (decision_id, cp["id"]),
+        ).fetchone()
+        assert cp_link is not None
+        # decision_assessments link with 'informed_by'
+        assess_link = ec_db.execute(
+            "SELECT relation_type FROM decision_assessments WHERE decision_id = ? AND assessment_id = ?",
+            (decision_id, assess_id),
+        ).fetchone()
+        assert assess_link is not None
+        assert assess_link["relation_type"] == "informed_by"
+
+    def test_reject_no_decision_created(self, ec_repo, ec_db):
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="reject-session")
+        reject_candidate(ec_db, cid, reason="not useful")
+        after = get_candidate(ec_db, cid)
+        assert after["review_status"] == "rejected"
+        assert after["review_note"] == "not useful"
+        # Decisions table remains empty
+        decision_count = ec_db.execute("SELECT COUNT(*) AS c FROM decisions").fetchone()["c"]
+        assert decision_count == 0
+
+    def test_double_confirm_raises(self, ec_repo, ec_db):
+        cid = self._seed_candidate(ec_db, ec_repo, session_id="double-session")
+        confirm_candidate(ec_db, cid)
+        with pytest.raises(ValueError):
+            confirm_candidate(ec_db, cid)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — dedup and noisy-input harness (Tier 1)
+# ---------------------------------------------------------------------------
+
+
+class TestDedupAndNoise:
+    def test_duplicate_title_penalized_against_confirmed_decision(self, ec_repo, ec_db, monkeypatch):
+        """Tier 1 noisy-input scenario: pre-existing confirmed decision."""
+        create_decision(
+            ec_db,
+            title="Use Redis over memcached",
+            rationale="legacy choice carried forward",
+            scope="cache",
+        )
+
+        session = _seed_session(ec_db, ec_repo, session_id="noisy-preexisting")
+        _seed_turn(ec_db, session["id"], 1, "We decided again on Redis over memcached", files=["cache.py"])
+        llm_response = json.dumps(
+            [
+                {
+                    "title": "Use Redis over memcached",
+                    "rationale": "same as before",
+                    "scope": "cache",
+                    "rejected_alternatives": ["memcached"],
+                }
+            ]
+        )
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        candidates = list_candidates(ec_db, session_id=session["id"])
+        assert len(candidates) == 1
+        # Dedup fuzzy hit against existing decision must reduce the score
+        breakdown = candidates[0]["confidence_breakdown"]
+        assert breakdown["penalties"]["vs_decisions"] > 0
+        assert candidates[0]["confidence"] < 0.55
+
+    def test_idempotent_same_title_reextraction(self, ec_repo, ec_db, monkeypatch):
+        """Running extraction twice on same signals produces no duplicate rows."""
+        session = _seed_session(ec_db, ec_repo, session_id="noisy-idempotent")
+        _seed_turn(ec_db, session["id"], 1, "We decided to chose X", files=["x.py"])
+        llm_response = json.dumps(
+            [{"title": "Choose X", "rationale": "a reason long enough for the heuristic", "scope": "x"}]
+        )
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        count_after_first = len(list_candidates(ec_db, session_id=session["id"]))
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        count_after_second = len(list_candidates(ec_db, session_id=session["id"]))
+        assert count_after_first == 1
+        assert count_after_second == 1  # marker short-circuits second run
+
+    def test_low_signal_candidate_below_threshold(self, ec_repo, ec_db, monkeypatch):
+        """Candidates with no rationale / alts / files sit below default filter."""
+        session = _seed_session(ec_db, ec_repo, session_id="noisy-lowsignal")
+        _seed_turn(ec_db, session["id"], 1, "We decided something", files=[])
+        llm_response = json.dumps(
+            [{"title": "Vague choice", "rationale": "", "scope": "", "rejected_alternatives": []}]
+        )
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: llm_response,
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        all_candidates = list_candidates(ec_db, session_id=session["id"])
+        filtered = list_candidates(ec_db, session_id=session["id"], min_confidence=0.5)
+        assert len(all_candidates) == 1
+        assert all_candidates[0]["confidence"] < 0.5
+        assert len(filtered) == 0

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -1312,7 +1312,9 @@ class TestExtractFromSessionCLI:
         ec_db.commit()
         return session
 
-    def test_creates_decisions_from_llm_response(self, ec_repo, ec_db, monkeypatch):
+    def test_creates_candidates_from_llm_response(self, ec_repo, ec_db, monkeypatch):
+        from entirecontext.core.decision_candidates import list_candidates
+
         session = self._setup_session_with_turns(
             ec_db,
             [
@@ -1337,15 +1339,19 @@ class TestExtractFromSessionCLI:
 
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
 
-        decisions = list_decisions(ec_db)
-        titles = [d["title"] for d in decisions]
+        candidates = list_candidates(ec_db, session_id=session["id"])
+        titles = [c["title"] for c in candidates]
         assert "Use Redis for caching" in titles
+        # Real decisions table should be untouched
+        assert list_decisions(ec_db) == []
 
         row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
         meta = json.loads(row["metadata"]) if row["metadata"] else {}
-        assert meta.get("decisions_extracted") is True
+        assert meta.get("candidates_extracted") is True
 
-    def test_auto_links_files(self, ec_repo, ec_db, monkeypatch):
+    def test_auto_files_on_candidate(self, ec_repo, ec_db, monkeypatch):
+        from entirecontext.core.decision_candidates import list_candidates
+
         session = self._setup_session_with_turns(
             ec_db,
             [
@@ -1365,11 +1371,13 @@ class TestExtractFromSessionCLI:
 
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
 
-        decisions = list_decisions(ec_db)
-        d = get_decision(ec_db, decisions[0]["id"])
-        assert "src/cache.py" in d.get("files", [])
+        candidates = list_candidates(ec_db, session_id=session["id"])
+        assert len(candidates) >= 1
+        candidate_files = candidates[0].get("files") or []
+        # Files live on the candidate row until confirm promotes them.
+        assert "src/cache.py" in candidate_files
 
-    def test_empty_array_sets_marker(self, ec_repo, ec_db, monkeypatch):
+    def test_empty_array_sets_candidates_marker(self, ec_repo, ec_db, monkeypatch):
         session = self._setup_session_with_turns(
             ec_db,
             [
@@ -1386,7 +1394,7 @@ class TestExtractFromSessionCLI:
 
         row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
         meta = json.loads(row["metadata"]) if row["metadata"] else {}
-        assert meta.get("decisions_extracted") is True
+        assert meta.get("candidates_extracted") is True
 
     def test_invalid_json_no_marker(self, ec_repo, ec_db, monkeypatch):
         session = self._setup_session_with_turns(
@@ -1405,9 +1413,13 @@ class TestExtractFromSessionCLI:
 
         row = ec_db.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()
         meta = json.loads(row["metadata"]) if row["metadata"] else {}
+        # parse failure must not mark the session so the next SessionEnd retries
+        assert meta.get("candidates_extracted") is not True
         assert meta.get("decisions_extracted") is not True
 
-    def test_max_5_decisions(self, ec_repo, ec_db, monkeypatch):
+    def test_max_5_candidates(self, ec_repo, ec_db, monkeypatch):
+        from entirecontext.core.decision_candidates import list_candidates
+
         session = self._setup_session_with_turns(
             ec_db,
             [
@@ -1425,8 +1437,8 @@ class TestExtractFromSessionCLI:
 
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
 
-        decisions = list_decisions(ec_db)
-        assert len(decisions) <= 5
+        candidates = list_candidates(ec_db, session_id=session["id"])
+        assert len(candidates) <= 5
 
     def test_idempotency_second_run_skips(self, ec_repo, ec_db, monkeypatch):
         session = self._setup_session_with_turns(
@@ -1445,6 +1457,30 @@ class TestExtractFromSessionCLI:
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
         _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
         assert len(call_count) == 1
+
+    def test_v12_marker_shim_short_circuits(self, ec_repo, ec_db, monkeypatch):
+        """v12 decisions_extracted marker must be honored as already-extracted."""
+        session = self._setup_session_with_turns(
+            ec_db,
+            [
+                ("We decided X", []),
+            ],
+        )
+        ec_db.execute(
+            "UPDATE sessions SET metadata = ? WHERE id = ?",
+            (json.dumps({"decisions_extracted": True}), session["id"]),
+        )
+        ec_db.commit()
+
+        call_count = []
+        monkeypatch.setattr(
+            "entirecontext.cli.decisions_cmds._get_llm_response",
+            lambda *a, **kw: (call_count.append(1), "[]")[1],
+        )
+        from entirecontext.cli.decisions_cmds import _extract_from_session_impl
+
+        _extract_from_session_impl(ec_db, session["id"], str(ec_repo))
+        assert len(call_count) == 0
 
 
 class TestHandlerIntegration:

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -1297,6 +1297,69 @@ class TestMaybeExtractDecisions:
         maybe_extract_decisions(str(ec_repo), session["id"])
         assert len(launched) == 0
 
+    def test_gate_respects_extract_sources_session_only(self, ec_repo, ec_db, monkeypatch):
+        """Regression: with extract_sources=['session'] and no keyword-match
+        in summaries but a checkpoint diff_summary present, the gate must
+        NOT launch the worker. Previously the gate unconditionally OR'd
+        all three signals and spawned a no-op worker."""
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {
+                "auto_extract": True,
+                "extract_keywords": ["decided"],
+                "extract_sources": ["session"],
+            },
+        )
+        session = self._setup_session_with_summaries(ec_db, ["just a normal conversation"])
+        # Seed a checkpoint with non-empty diff_summary — used to trigger the
+        # checkpoint signal path. Must be ignored because extract_sources
+        # excludes checkpoint.
+        import uuid as _uuid
+
+        ec_db.execute(
+            "INSERT INTO checkpoints (id, session_id, git_commit_hash, diff_summary) VALUES (?, ?, ?, ?)",
+            (str(_uuid.uuid4()), session["id"], "abc", "src/cache.py | 5 +++--\nsrc/db.py | 3 +"),
+        )
+        ec_db.commit()
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        assert len(launched) == 0
+
+    def test_gate_respects_extract_sources_checkpoint_only(self, ec_repo, ec_db, monkeypatch):
+        """Regression: with extract_sources=['checkpoint'] and a session
+        summary that would have matched the keyword, the gate must still
+        launch (checkpoint signal present) but must NOT launch due to the
+        session signal. Verified indirectly: we also add a session summary
+        that matches the keyword, set extract_sources to ['checkpoint']
+        only, omit any checkpoint, and expect no launch — proving that
+        the session path is correctly gated off."""
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks._load_decisions_config",
+            lambda _: {
+                "auto_extract": True,
+                "extract_keywords": ["decided"],
+                "extract_sources": ["checkpoint"],
+            },
+        )
+        session = self._setup_session_with_summaries(ec_db, ["We decided to use Redis"])
+        launched = []
+        monkeypatch.setattr(
+            "entirecontext.hooks.decision_hooks.launch_worker",
+            lambda *a, **kw: launched.append(1) or 0,
+        )
+        from entirecontext.hooks.decision_hooks import maybe_extract_decisions
+
+        maybe_extract_decisions(str(ec_repo), session["id"])
+        # No checkpoint seeded; session signal was disabled by extract_sources.
+        # Worker must not spawn.
+        assert len(launched) == 0
+
 
 class TestExtractFromSessionCLI:
     def _setup_session_with_turns(self, ec_db, turn_data):

--- a/tests/test_decisions_cli.py
+++ b/tests/test_decisions_cli.py
@@ -488,13 +488,18 @@ class TestDecisionsCLIExtended:
         assert result.exit_code == 0
 
         conn = get_db(str(ec_repo))
-        row = conn.execute("SELECT * FROM decisions WHERE title = 'Use JWT'").fetchone()
+        # Candidate row (not decision) is produced; decisions table stays empty.
+        row = conn.execute("SELECT * FROM decision_candidates WHERE title = 'Use JWT'").fetchone()
         assert row is not None
+        assert row["review_status"] == "pending"
+        assert row["source_type"] == "session"
+        decision_count = conn.execute("SELECT COUNT(*) AS c FROM decisions").fetchone()["c"]
+        assert decision_count == 0
 
         meta = json.loads(
             conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session["id"],)).fetchone()["metadata"]
         )
-        assert meta.get("decisions_extracted") is True
+        assert meta.get("candidates_extracted") is True
         conn.close()
 
     def test_extract_from_session_idempotent(self, ec_repo, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #41.

First-pass candidate decision extraction pipeline that pulls drafts from sessions, checkpoints, and assessments, scores them with a reproducible heuristic, dedups against existing decisions via normalized FTS5 similarity, and surfaces a lightweight confirmation flow in both the CLI and MCP server.

## Acceptance criteria trace

| Criterion | Satisfied by |
|---|---|
| candidates from sessions / checkpoints / assessments | `collect_signals` in `core/decision_extraction.py` with three source collectors + broadened hook pre-launch gate |
| confidence / review signals | new `decision_candidates` table (`confidence REAL`, `confidence_breakdown` JSON, `review_status` CHECK) |
| lightweight confirmation for human or agent | CLI `ec decision candidates list/show/confirm/reject` + MCP `ec_decision_candidate_*`, both delegating to `core/decision_candidates.py` |
| quality validated against noisy real-session examples | Tier 1 handcrafted noisy-input fixtures in `tests/test_decision_extraction.py` + Tier 2 sampler script `scripts/generate_noisy_candidate_fixtures.py` |

## Architecture notes

**Separate table, not a status column on `decisions`.** PR #56's proactive surfacing (`on_session_start_decisions`, `on_post_tool_use_decisions`, `ec_decision_context`, `rank_related_decisions`) treats the `decisions` table as trusted knowledge. Adding a review_status column would force every retrieval path to grow a new exclusion predicate; missing one would leak untrusted candidates into agent surfacing. The `decision_candidates` table is read only by the `ec_decision_candidate_*` surfaces.

**Turn window derivation avoids `checkpoints.files_snapshot`.** That column is NULL for virtually every auto-generated row (`create_checkpoint` is never called with a populated argument in the hook paths), and its format is `dict | list` when present. The checkpoint/assessment sources derive their file set from the turns in `[prev_cp.created_at, cp.created_at]`, anchored on `turns.timestamp` with `rowid DESC` tiebreak for same-second checkpoints.

**Hook gate broadened.** `maybe_extract_decisions` previously only fired when session summary text matched `decisions.extract_keywords`. It now fires when any of: summary keyword match, a checkpoint with non-empty `diff_summary`, or a checkpoint-linked assessment with `verdict IN ('expand','narrow')`. Sessions with rich checkpoint/assessment signals but no keyword-matching summaries used to be silently ignored.

**Shim preserves test monkeypatch contract.** `cli.decisions_cmds._get_llm_response` and `_extract_from_session_impl` stay at the same module paths. The rewritten `_extract_from_session_impl` calls the module-level `_get_llm_response` name directly so existing monkeypatches still intercept the LLM call — seven tests in `test_decision_hooks.py` plus four in `test_decisions_cli.py` were retargeted to assert against `list_candidates` instead of `list_decisions`, with no change to their monkeypatch points. The production hook/worker path runs `core.decision_extraction.run_extraction` instead and is not coupled to the shim.

**Metadata marker renamed with v12 shim.** Sessions are now marked with `candidates_extracted=true`. `is_session_extracted` still honors the old `decisions_extracted=true` marker as equivalent, so historical rows from the pre-candidates pipeline are never re-processed.

## Confidence heuristic (reproducible, no LLM self-rating)

\`\`\`
base = {assessment: 0.55, checkpoint: 0.40, session: 0.30}
initial = base[source_type]
        + 0.15 if rationale ≥ 30 chars
        + 0.15 if rejected_alternatives non-empty
        + 0.10 if 1 ≤ len(files) ≤ 5
penalty = 0.25 × dedup_score_vs_decisions (normalized [0,1])
        + 0.15 × dedup_score_vs_candidates (normalized [0,1])
final = clamp(initial − penalty, 0, 1)
\`\`\`

`confidence_breakdown` JSON stores `{base, components, initial, penalties, final}` plus the similar decision/candidate ID when a fuzzy match fires, so reviewers can audit the score.

## Worker subcommand and back-compat

- New: `ec decision extract-candidates --session <id>` (background worker entrypoint)
- Kept: `ec decision extract-from-session <id>` as a back-compat alias
- Any hook allowlist that permits `ec decision extract-from-session` will also need `ec decision extract-candidates` added

## Config defaults added under `[decisions]`

- `extract_sources = [\"session\", \"checkpoint\", \"assessment\"]`
- `candidate_min_confidence = 0.0`
- `candidate_dedup_similarity_threshold = 0.5`
- `candidate_redact_secrets = true`

`auto_extract` global default stays `false` as a safety choice. This repo opts in via its own gitignored `.entirecontext/config.toml` for dogfooding; a global flip to `true` is deferred to v0.2.1 after real-world candidates look healthy.

## Out of scope (follow-ups)

- Auto-promotion of high-confidence candidates → real decisions
- `review_status='superseded'` transitions
- Embedding-based semantic dedup
- `ec decision candidates purge` (rejected candidates kept forever in v1)
- Interactive SessionStart/PostToolUse prompts
- Dashboard/graph rendering of candidates
- Backfill from historical sessions
- Staged-diff assessments (assessments with `checkpoint_id IS NULL`) — currently invisible to the gate and collector by design; revisit separately
- Populating `checkpoints.files_snapshot` for new auto-checkpoints (this PR routes around the NULL case)
- Regex mining of `assessments.tidy_suggestion` for reconstructed `rejected_alternatives`

## Test plan

- [x] \`uv run ruff format --check .\` and \`uv run ruff check .\` clean
- [x] 43 new tests in \`tests/test_decision_extraction.py\` pass (unit + integration + Tier 1 noisy harness)
- [x] 7 retargeted legacy tests in \`test_decision_hooks.py\` pass
- [x] 1 retargeted legacy test in \`test_decisions_cli.py\` passes, plus new v12 marker shim test
- [x] \`tests/test_decisions_core.py\` unchanged, 46 tests still pass
- [x] Full \`uv run pytest\` delta: +43 new tests passing, 0 new failures. 7 pre-existing failures on \`main\` (test_mcp_registration expected set drift, test_handler.py exception telemetry, test_mcp.py ec_decision_* ranking-order assertions) are unrelated to this PR and are not fixed here
- [x] Fresh v12 → v13 schema migration smoke via \`check_and_migrate\` — \`decision_candidates\` + \`fts_decision_candidates\` + 3 triggers + unique index all present
- [x] CLI smoke: \`ec decision candidates --help\`, \`ec decision extract-candidates --help\` resolve
- [ ] Manual dogfood on this repo with \`auto_extract=true\` in \`.entirecontext/config.toml\` — end a real session, confirm candidates produced, confirm/reject flow, verify decision row's provenance links
- [ ] MCP smoke: call \`ec_decision_candidate_list\` via an MCP client
- [ ] Tier 2 fixture generation: \`uv run python scripts/generate_noisy_candidate_fixtures.py --out tests/fixtures/noisy_candidates/real/\` and review the sampled sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)