### PR TITLE
ci(release): Upload package assets to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,29 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
 
-  close-release-issues:
+  release:
     needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish GitHub release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: true
+          overwrite_files: true
+
+  close-release-issues:
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ uv tool install entirecontext
 pipx install entirecontext
 ```
 
+Tagged GitHub releases also include the built wheel and source tarball as release assets. PyPI remains the primary install path.
+
 Use the same workflow after either install path:
 
 ```bash
@@ -649,4 +651,3 @@ EntireContext was inspired by:
 ## License
 
 [MIT](LICENSE)
-

--- a/docs/research/github-release-assets-automation.md
+++ b/docs/research/github-release-assets-automation.md
@@ -1,0 +1,34 @@
+# GitHub Release Asset Automation
+
+- Date: 2026-04-15
+- Topic: Attach built package artifacts to GitHub Releases after PyPI publish
+
+## Summary
+
+EntireContext already builds validated package artifacts (`dist/*.whl`, `dist/*.tar.gz`) in the release workflow before publishing to PyPI. The missing piece was exposing the same artifacts on GitHub Releases so users can download the exact built wheel/sdist from the release page.
+
+## Decision
+
+Use a dedicated `release` job after `publish` and publish assets with `softprops/action-gh-release@v2`.
+
+Why this shape:
+
+- Reuses the already-tested `dist/` artifacts instead of rebuilding.
+- Keeps PyPI publish and GitHub Release asset upload as separate responsibilities.
+- Supports idempotent release updates for existing tags via file overwrite behavior.
+
+## Source Notes
+
+Primary source checked:
+
+- GitHub Marketplace snippet for `softprops/action-gh-release@v2`
+  - URL: https://github.com/marketplace/actions/generate-github-release-notes
+  - Relevant note: GitHub Marketplace explicitly recommends `softprops/action-gh-release@v2` and documents `generate_release_notes` behavior. The project release history also shows an `overwrite_files` input was added in the v2 line.
+
+## Applied in EntireContext
+
+- Workflow adds a dedicated `release` job after `publish`
+- Upload scope is limited to:
+  - `dist/*.whl`
+  - `dist/*.tar.gz`
+- Existing release assets can be safely re-uploaded with overwrite enabled

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -7,3 +7,4 @@ Collected research informing EntireContext roadmap and architecture decisions.
 | Topic | File | Date | Summary |
 |-------|------|------|---------|
 | Agent Memory Landscape | [agent-memory-landscape.md](agent-memory-landscape.md) | 2026-02-23 | Analysis of 20 GitHub agent-memory projects; cross-project themes; roadmap candidates |
+| GitHub Release Asset Automation | [github-release-assets-automation.md](github-release-assets-automation.md) | 2026-04-15 | Rationale and source notes for attaching built wheel/sdist artifacts to GitHub Releases |


### PR DESCRIPTION
Add a dedicated post-publish release job that reuses the validated dist artifacts and attaches the wheel and source tarball to GitHub Releases.

Document the new release asset behavior in the README and record the decision source in project research notes.