### PR TITLE
meta(dotagents): Add project agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ htmlcov/
 .coverage
 coverage.json
 .claude
+.cursor/
 .codex/
 .serena/
+agents.lock
+.agents/.gitignore
 *-export.json

--- a/agents.toml
+++ b/agents.toml
@@ -1,0 +1,5 @@
+version = 1
+agents = ["claude", "cursor", "codex"]
+
+[project]
+name = "entirecontext"


### PR DESCRIPTION
Keep dotagents setup reproducible in-repo without replacing tracked agent guidance files.

Ignore generated local agent outputs so user-specific symlinks and lockfiles stay out of commits.