### PR TITLE
ci: add pull_request + push:main verification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Lint
+        run: uv run ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Test
+        run: uv run pytest


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` running lint + test on every `pull_request` and every push to `main`. Closes the v0.2.0 retrospective finding that `release.yml` only runs on tag push — PR #59 body explicitly merged main with 7 known pre-existing test failures because no PR-time gate blocked it (fixed retroactively by PRs #58 and #60).

## Changes

- `.github/workflows/ci.yml` (new, 47 LOC)
  - Triggers: `pull_request` (opened/synchronize/reopened) + `push: branches: [main]`
  - Python 3.12 pinned explicitly via `astral-sh/setup-uv@v6` (release.yml uses runner default — a latent dependency on GitHub runner image rolls)
  - `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true`
  - `permissions: contents: read` (least privilege, explicit)
  - Mirrors `release.yml` lint/test job setup verbatim; omits build/publish/release/close-issues

## Phase A exit criteria (three steps, manual after merge)

This PR is step 1 of Phase A in the v0.2.0 retrospective follow-up plan.

1. ☐ `ci.yml` merged and fires on both `pull_request` and `push: main`
2. ☐ GitHub branch protection rule on `main` enabled, requiring `ci / lint` AND `ci / test` as required status checks (admin bypass ON for solo-maintainer hotfix flexibility)
3. ☐ Verification PR opened with intentional failing test, confirms merge is actually blocked until the test is removed

Without step 3, we've shipped another comment-automation workflow — checks that don't gate merge — which is exactly the asymmetry the retrospective diagnosed.

## Test plan

- [ ] Confirm CI fires on this PR with `ci / lint` and `ci / test` checks
- [ ] Both jobs complete green on PR head
- [ ] Merge to main; confirm `push: main` trigger fires the same workflow on the merge commit
- [ ] Enable branch protection; verify "allow administrators to bypass" is ON
- [ ] Open throwaway verification branch with intentional failing test; confirm PR is blocked from merging; close without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)