### PR TITLE
test: verify branch protection blocks failing PR (DO NOT MERGE)

### DIFF
--- a/tests/test_verify_gate_blocks_merge.py
+++ b/tests/test_verify_gate_blocks_merge.py
@@ -1,0 +1,11 @@
+"""Intentional verification fixture — DO NOT MERGE.
+
+This file is created solely to verify that the Phase A branch-protection
+setup actually blocks a failing PR from merging. It must be removed before
+the PR is closed. If this file is still present after PR close, something
+went wrong with the verification procedure.
+"""
+
+
+def test_intentionally_fails_to_verify_branch_protection() -> None:
+    assert False, "intentional failure — Phase A verification PR, do not merge"


### PR DESCRIPTION
## Purpose

Phase A exit criterion #3 of the v0.2.0 retrospective follow-up plan.

This PR adds an intentionally failing test to prove the Phase A branch-protection setup (PR #63 + the \`required_status_checks\` configuration on \`main\`) **actually blocks a failing PR from merging**. Without this verification, we would have shipped a CI workflow that runs but does not gate merge — the same asymmetry the retrospective diagnosed in the comment-only review bots.

## Expected outcome

- [ ] \`ci / lint\` passes (no code style issue)
- [ ] \`ci / test\` FAILS with a clear assertion error on \`tests/test_verify_gate_blocks_merge.py\`
- [ ] \`gh pr merge\` is rejected because a required status check failed
- [ ] The merge button in the GitHub UI is greyed out / unclickable without admin bypass
- [ ] This PR is closed **without merging**
- [ ] \`ci/verify-gate-blocks-merge\` branch is deleted (both local and remote)

## Do NOT merge

If you find yourself looking at this PR with the intent to merge it, stop. The whole point is that it cannot be merged. If you need to close it, use \`gh pr close 64\` (or whatever number this gets assigned) without the \`--delete-branch\` flag first, then delete the branch explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)