### PR TITLE
refactor(core): transaction() helper + ban internal conn.commit() (Phase C)

### DIFF
--- a/src/entirecontext/core/context.py
+++ b/src/entirecontext/core/context.py
@@ -2,11 +2,39 @@
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 import subprocess
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+
+@contextlib.contextmanager
+def transaction(conn: sqlite3.Connection) -> Iterator[None]:
+    """Own a BEGIN IMMEDIATE boundary, or defer to an outer owner if nested.
+
+    Relies on Python 3.12 ``LEGACY_TRANSACTION_CONTROL`` semantics: ``conn.in_transaction``
+    is ``True`` only after DML has started an implicit transaction. A pure ``SELECT``
+    does not flip the flag, so entering this helper from a read-only caller starts a
+    real ``BEGIN IMMEDIATE``. If the connection is migrated to ``autocommit=True`` in
+    the future, ``tests/test_transaction_helper.py`` will fail and flag the semantic
+    change before silent atomicity regressions ship.
+    """
+    if conn.in_transaction:
+        yield
+        return
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+        conn.commit()
+    except BaseException:
+        try:
+            conn.rollback()
+        except sqlite3.Error:
+            pass
+        raise
 
 
 def _find_git_root(path: str | Path = ".") -> str | None:
@@ -84,7 +112,9 @@ class RepoContext:
     def __exit__(self, *exc: object) -> None:
         self.close()
 
-    def as_request_context(self, *, source: str, turn_id: str | None = None, agent_type: str | None = None) -> RequestContext:
+    def as_request_context(
+        self, *, source: str, turn_id: str | None = None, agent_type: str | None = None
+    ) -> RequestContext:
         return RequestContext(
             source=source,
             session_id=self.current_session_id,

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -11,6 +11,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 from uuid import uuid4
 
+from .context import transaction
 from .resolve import escape_like as _escape_like
 from .resolve import resolve_assessment_id as _resolve_assessment_id
 from .resolve import resolve_checkpoint_id as _resolve_checkpoint_id
@@ -418,29 +419,9 @@ def record_decision_outcome(
     now = _now_iso()
 
     # Wrap outcome insert + updated_at bump + potential auto-promotion in a single
-    # BEGIN IMMEDIATE transaction so concurrent contradicted outcomes can't double-promote
-    # or miss the threshold. When an outer transaction already owns the connection,
-    # leave commit/rollback to the caller — committing here would flush the caller's
-    # in-flight work.
-    #
-    # Use `conn.in_transaction` to distinguish the nested case *before* attempting
-    # BEGIN IMMEDIATE. Going through `try/except sqlite3.OperationalError` would
-    # swallow unrelated lock-contention failures ("database is locked" after
-    # busy_timeout), leaving the caller to silently drop writes into an
-    # uncommitted implicit transaction.
-    if conn.in_transaction:
-        started_tx = False
-    else:
-        conn.execute("BEGIN IMMEDIATE")
-        started_tx = True
-
-    # Explicit rollback on any DML failure: Python's sqlite3 does not auto-rollback
-    # transactions started with an explicit BEGIN IMMEDIATE, so without this guard
-    # an exception in INSERT/UPDATE/auto-promote would leave the write transaction
-    # open on the connection — cascading into "cannot start a transaction within a
-    # transaction" errors on subsequent calls that would then silently drop into
-    # the nested-path branch and write into a stale uncommitted tx.
-    try:
+    # BEGIN IMMEDIATE boundary so concurrent contradicted outcomes can't double-promote
+    # or miss the threshold. `transaction()` defers commit/rollback to any outer owner.
+    with transaction(conn):
         conn.execute(
             """
             INSERT INTO decision_outcomes (
@@ -451,20 +432,8 @@ def record_decision_outcome(
         )
         conn.execute("UPDATE decisions SET updated_at = ? WHERE id = ?", (now, full_decision_id))
 
-        # Auto-promotion: if a contradicted outcome pushes the decision past threshold,
-        # promote its staleness_status. One-way ratchet — never reverts to fresh.
         if outcome_type == "contradicted":
             _maybe_auto_promote_contradicted(conn, full_decision_id, now)
-
-        if started_tx:
-            conn.commit()
-    except Exception:
-        if started_tx:
-            try:
-                conn.rollback()
-            except sqlite3.Error:
-                pass
-        raise
 
     row = conn.execute(
         """
@@ -757,13 +726,7 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
     if old_full == new_full:
         raise ValueError("A decision cannot supersede itself")
 
-    if conn.in_transaction:
-        started_tx = False
-    else:
-        conn.execute("BEGIN IMMEDIATE")
-        started_tx = True
-
-    try:
+    with transaction(conn):
         probe_id: str | None = new_full
         visited: set[str] = {old_full}
         while probe_id is not None:
@@ -780,15 +743,6 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
-        if started_tx:
-            conn.commit()
-    except Exception:
-        if started_tx:
-            try:
-                conn.rollback()
-            except sqlite3.Error:
-                pass
-        raise
     return get_decision(conn, old_full) or {}
 
 

--- a/tests/test_no_internal_commit.py
+++ b/tests/test_no_internal_commit.py
@@ -1,0 +1,110 @@
+"""Ratchet test: ban new internal ``conn.commit()`` calls in ``core/``.
+
+The retrospective (v0.2.0) found that helpers across ``src/entirecontext/core``
+silently take transaction ownership from their callers by calling
+``conn.commit()`` internally. The fix pattern is to own a ``BEGIN IMMEDIATE``
+boundary via ``entirecontext.core.context.transaction`` and let nesting defer
+commit to the outer owner. This test locks down progress on that cleanup.
+
+**Allowlist semantics.** The test records the set of ``core/*.py`` modules that
+currently contain at least one ``conn.commit()`` call. New PRs may not add
+``conn.commit()`` to any module outside that set. As each allowlisted module is
+cleaned up (its last ``conn.commit()`` replaced by a ``with transaction(conn):``
+owner), it must be *removed* from the allowlist so the ratchet tightens.
+
+**Known granularity limitation.** The allowlist is *file-level*, not
+function-level. A second ``conn.commit()`` added inside an already-allowlisted
+file will NOT fail this test. A stronger form would key on ``(file, function)``
+pairs or require a ``# transaction_owner`` marker at each legitimate commit
+site, but file-level is the minimum viable ratchet. Tighten later.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# Files that CURRENTLY contain at least one ``conn.commit()`` in
+# ``src/entirecontext/core/``. This set is a ratchet: it may SHRINK over time,
+# never grow. When a PR lands that removes the last ``conn.commit()`` from one
+# of these modules, drop it from the set in the same PR.
+ALLOWLIST = frozenset(
+    {
+        "agent_graph.py",
+        "ast_index.py",
+        "attribution.py",
+        "checkpoint.py",
+        "consolidation.py",
+        "decision_candidates.py",
+        "decision_extraction.py",
+        "decisions.py",
+        "embedding.py",
+        "event.py",
+        "futures.py",
+        "import_aline.py",
+        "project.py",
+        "purge.py",
+        "search.py",
+        "session.py",
+        "telemetry.py",
+        "turn.py",
+    }
+)
+
+CORE_DIR = Path(__file__).resolve().parent.parent / "src" / "entirecontext" / "core"
+
+
+def _commit_call_locations(path: Path) -> list[int]:
+    """Return line numbers of ``<receiver>.commit()`` zero-arg calls in ``path``.
+
+    Matches any attribute call whose attr is ``commit`` and carries no arguments.
+    That catches the common bindings (``conn.commit()``, ``ec_conn.commit()``,
+    ``self.conn.commit()``) without requiring every helper to use the same
+    parameter name. The price is that it also matches non-sqlite commit calls
+    (e.g., a hypothetical ``transaction.commit()``), which is acceptable: this
+    check runs only on ``core/*.py``, where the relevant receivers are all
+    sqlite connections.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "commit" and not node.args and not node.keywords:
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_new_conn_commit_in_core():
+    violations: list[str] = []
+    cleaned: list[str] = []
+
+    # ``context.py`` is THE transaction owner module — the helper's implementation
+    # calls ``conn.commit()`` by design. Skip it so the ratchet doesn't flag the fix.
+    exempt = {"__init__.py", "context.py"}
+
+    for py in sorted(CORE_DIR.glob("*.py")):
+        if py.name in exempt:
+            continue
+        hits = _commit_call_locations(py)
+        if hits and py.name not in ALLOWLIST:
+            for line in hits:
+                violations.append(f"{py.name}:{line} — new `conn.commit()` not allowed in core/")
+        elif not hits and py.name in ALLOWLIST:
+            cleaned.append(py.name)
+
+    messages: list[str] = []
+    if violations:
+        messages.append(
+            "New `conn.commit()` calls found in core/ modules outside the ratchet allowlist. "
+            "Use `with transaction(conn):` from `entirecontext.core.context` to own the boundary:\n  "
+            + "\n  ".join(violations)
+        )
+    if cleaned:
+        messages.append(
+            "The following files no longer contain `conn.commit()` and must be REMOVED from "
+            "ALLOWLIST in this file (ratchet tightening):\n  " + "\n  ".join(cleaned)
+        )
+
+    assert not messages, "\n\n".join(messages)

--- a/tests/test_transaction_helper.py
+++ b/tests/test_transaction_helper.py
@@ -1,0 +1,61 @@
+"""Regression pins for ``entirecontext.core.context.transaction``.
+
+These tests lock down the helper's behavior under Python 3.12's
+``LEGACY_TRANSACTION_CONTROL`` mode — the same mode ``_configure_connection``
+leaves on every real ``RepoContext.conn``. If a future runtime migration to
+``autocommit=True`` lands without updating the helper, these cases will fail
+and surface the semantic change before silent atomicity regressions ship.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from entirecontext.core.context import transaction
+from entirecontext.db.connection import get_memory_db
+
+
+@pytest.fixture()
+def conn():
+    c = get_memory_db()
+    c.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT NOT NULL)")
+    c.commit()
+    yield c
+    c.close()
+
+
+def test_happy_path_commits_on_normal_exit(conn):
+    with transaction(conn):
+        conn.execute("INSERT INTO t (v) VALUES (?)", ("alpha",))
+    assert conn.in_transaction is False
+    rows = conn.execute("SELECT v FROM t ORDER BY id").fetchall()
+    assert [r["v"] for r in rows] == ["alpha"]
+
+
+def test_nested_defers_to_outer_owner(conn):
+    conn.execute("INSERT INTO t (v) VALUES (?)", ("outer",))
+    assert conn.in_transaction is True
+
+    with transaction(conn):
+        conn.execute("INSERT INTO t (v) VALUES (?)", ("inner",))
+
+    # Nested path must not commit — outer still owns the boundary.
+    assert conn.in_transaction is True
+    conn.commit()
+
+    rows = conn.execute("SELECT v FROM t ORDER BY id").fetchall()
+    assert [r["v"] for r in rows] == ["outer", "inner"]
+
+
+def test_exception_rolls_back_owned_boundary(conn):
+    class Boom(Exception):
+        pass
+
+    with pytest.raises(Boom):
+        with transaction(conn):
+            conn.execute("INSERT INTO t (v) VALUES (?)", ("rolled-back",))
+            raise Boom()
+
+    assert conn.in_transaction is False
+    rows = conn.execute("SELECT v FROM t").fetchall()
+    assert rows == []


### PR DESCRIPTION
## Summary

Phase C of the v0.2.0 retrospective follow-up (A→C→B→D). Closes the transaction ownership gap that produced 5 P1/Important atomicity findings across PRs #55, #56, and #59, where helpers silently take transaction ownership from their callers via internal \`conn.commit()\`.

- New \`transaction(conn)\` context manager in \`core/context.py\` — owns a \`BEGIN IMMEDIATE\` boundary or defers to the outer owner when nested. Preserves Python 3.12 \`LEGACY_TRANSACTION_CONTROL\` semantics.
- Refactored \`record_decision_outcome\` and \`supersede_decision\` in \`decisions.py\` to use \`with transaction(conn):\`, removing the ad-hoc \`started_tx\` scaffolding (~20 LOC net removal, same semantics).
- New \`tests/test_transaction_helper.py\` pins the happy/nested/exception contract.
- New \`tests/test_no_internal_commit.py\` — file-level AST ratchet, 18-file allowlist, \`context.py\` exempt as the transaction owner. Verified against a deliberate violation in \`resolve.py\` (clear \`file:line\` failure).

\`confirm_candidate\` is intentionally NOT refactored — its helper chain (\`create_decision\`, \`link_decision_to_*\`) still carries internal commits that would fragment any wrapper. Deferred to v0.3.0.

## Test plan
- [x] \`uv run pytest tests/test_transaction_helper.py tests/test_no_internal_commit.py -v\` → 4 passed
- [x] \`uv run pytest tests/test_decisions_core.py tests/test_decisions_cli.py tests/test_decision_extraction.py tests/test_decision_hooks.py\` → 246 passed
- [x] \`uv run pytest\` → 1379 passed, 81 skipped
- [x] \`uv run ruff format\` + \`uv run ruff check\` clean
- [x] Deliberate-violation test: injected \`conn.commit()\` into \`resolve.py\`, ran ratchet, confirmed \`resolve.py:11\` failure message, reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)