### PR TITLE
feat(decisions)!: Flip include_contradicted default to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: `include_contradicted` default flipped to `False`** (#69) — `list_decisions`, `fts_search_decisions`, `hybrid_search_decisions`, `ec_decision_search` MCP tool, and `ec decision search` CLI now exclude contradicted decisions by default. Pass `include_contradicted=True` (or `--include-contradicted` from the CLI) to restore the previous behavior. The `ec_decision_list` MCP tool also gains a new `include_contradicted` parameter (default `False`).
+
 ### Added
 
 - **Contract-sync drift guards** — `tests/test_contract_sync.py` asserts `mcp/server.__all__` matches what `register_tools()` actually registers (driven by AST extraction of `server.py`'s module tuple, not a hardcoded copy), that every `ec_*` tool is present in the README `### Available Tools` section bidirectionally (catches stale rows as well as missing rows), that `decision_hooks` fallback filename constants are documented in README, and that the current `SCHEMA_VERSION` is cross-referenced in a CHANGELOG paragraph that also mentions "schema". Replaces `tests/test_mcp_registration.py`, whose hardcoded expected set had silently drifted (its registration loop omitted `tools.decision_candidates` and its expected set omitted the four candidate tools, so it passed via symmetric drift — the exact failure mode the v0.2.0 retrospective finding #2 named).
@@ -35,7 +39,7 @@ Database schema v11 → v13. v0.1.x databases auto-migrate on first `RepoContext
 
 ### Deprecated
 
-- **`fts_search_decisions` / `hybrid_search_decisions` / `ec decision search` `include_contradicted` default** — currently defaults to `True` for backward compatibility during v0.2.x. The default will flip to `False` in **v0.3.0**. Pass `include_contradicted=False` (or `--no-include-contradicted` from the CLI) now to opt into the future default.
+- ~~**`include_contradicted` default**~~ — completed in [Unreleased]: default flipped to `False`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ Decisions carry a `staleness_status` so old guidance can be prevented from domin
 | Entry point | fresh | stale | superseded | contradicted |
 |---|---|---|---|---|
 | `ec_decision_related` / `rank_related_decisions` | shown | demoted 0.85× | hidden (successor substituted) | hidden |
-| `ec_decision_search` / `fts_search_decisions` / `hybrid_search_decisions` | shown | shown | hidden | shown (v0.2.x) / hidden (v0.3.0) |
-| `ec_decision_list` / `ec decision list` | shown | shown | shown | shown (inventory — explicit status filter) |
+| `ec_decision_search` / `fts_search_decisions` / `hybrid_search_decisions` | shown | shown | hidden | hidden |
+| `ec_decision_list` / `ec decision list` | shown | shown | shown | hidden (pass `include_contradicted=True` for inventory) |
 | `ec_decision_get(id)` | shown (no successor) | shown | shown + `successor` pointer | shown |
 | Session-start hook | shown | shown | replaced by successor | hidden |
 
 Opt in to include filtered decisions via flags:
 - `include_stale` (default `True`) — stale decisions pass through with 0.85× demotion
 - `include_superseded` (default `False`) — returns the original without chain collapse
-- `include_contradicted` (default `False` in `rank_related_decisions`; `True` in FTS/hybrid during the v0.2.x deprecation window)
+- `include_contradicted` (default `False` everywhere)
 
 ### Supersession chain behavior
 
@@ -78,10 +78,6 @@ Configure the threshold via `[decisions]` in `.entirecontext/config.toml`:
 [decisions]
 auto_promotion_contradicted_threshold = 2
 ```
-
-### Deprecation window
-
-During the v0.2.x release, `fts_search_decisions` / `hybrid_search_decisions` / `ec decision search` default to `include_contradicted=True` to preserve existing caller behavior. The default will flip to `False` in **v0.3.0**. Pass `include_contradicted=False` now (or `--no-include-contradicted` from the CLI) to opt into the future default.
 
 ## Proactive Retrieval
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -35,12 +35,19 @@ def decision_list(
     status: Optional[str] = typer.Option(None, "--status", help="fresh|stale|superseded|contradicted"),
     file: Optional[str] = typer.Option(None, "--file", help="Filter by linked file path"),
     limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+    include_contradicted: bool = typer.Option(
+        False,
+        "--include-contradicted/--no-include-contradicted",
+        help="Include contradicted decisions (default False)",
+    ),
 ):
     from ..core.decisions import list_decisions
 
     conn, _ = get_repo_connection()
     try:
-        decisions = list_decisions(conn, staleness_status=status, file_path=file, limit=limit)
+        decisions = list_decisions(
+            conn, staleness_status=status, file_path=file, limit=limit, include_contradicted=include_contradicted,
+        )
     except ValueError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(1)

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -316,9 +316,9 @@ def decision_search(
         False, "--include-superseded/--no-include-superseded", help="Include superseded decisions"
     ),
     include_contradicted: bool = typer.Option(
-        True,
+        False,
         "--include-contradicted/--no-include-contradicted",
-        help="Include contradicted decisions (default True; will flip to False in v0.3.0)",
+        help="Include contradicted decisions (default False)",
     ),
 ):
     """Search decisions by keyword."""

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -264,14 +264,13 @@ def list_decisions(
     staleness_status: str | None = None,
     file_path: str | None = None,
     limit: int = 20,
-    include_contradicted: bool = True,
+    include_contradicted: bool = False,
 ) -> list[dict]:
     """List decisions with optional filters.
 
-    include_contradicted: default True for backward compatibility. When False,
-    contradicted decisions are excluded at the SQL level so downstream callers
-    (e.g. the session-start hook) do not lose fresh/stale/superseded results
-    behind a wall of contradicted rows that hit the row-count limit first.
+    include_contradicted: when False, contradicted decisions are excluded at
+    the SQL level so downstream callers do not lose fresh/stale/superseded
+    results behind a wall of contradicted rows that hit the row-count limit.
     The flag is ignored when `staleness_status` explicitly selects one status.
     """
     if staleness_status and staleness_status not in VALID_STALENESS:
@@ -1397,15 +1396,13 @@ def fts_search_decisions(
     limit: int = 20,
     include_stale: bool = True,
     include_superseded: bool = False,
-    include_contradicted: bool = True,
+    include_contradicted: bool = False,
 ) -> list[dict]:
     """FTS5 full-text search over decision title and rationale.
 
     Staleness policy (issue #39):
     - Superseded is excluded by default; set include_superseded=True to include.
-    - Contradicted defaults to True for the v0.2.x deprecation window; it will
-      flip to False in v0.3.0. Pass include_contradicted=False now to opt in
-      to the future default.
+    - Contradicted is excluded by default; set include_contradicted=True to include.
     - Stale decisions are included by default.
     """
     staleness_predicate, staleness_params = _staleness_sql_predicate(
@@ -1446,7 +1443,7 @@ def hybrid_search_decisions(
     k: int = 60,
     include_stale: bool = True,
     include_superseded: bool = False,
-    include_contradicted: bool = True,
+    include_contradicted: bool = False,
 ) -> list[dict]:
     """Hybrid search combining FTS5 relevance and recency via RRF.
 

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -433,6 +433,7 @@ async def ec_decision_list(
     staleness_status: str | None = None,
     file_path: str | None = None,
     limit: int = 20,
+    include_contradicted: bool = False,
 ) -> str:
     """List decisions with optional filters.
 
@@ -440,6 +441,7 @@ async def ec_decision_list(
         staleness_status: Filter by status (fresh/stale/superseded/contradicted)
         file_path: Filter by linked file path
         limit: Maximum results (default 20)
+        include_contradicted: Include contradicted decisions (default False)
     """
     (conn, _), error = runtime.resolve_repo()
     if error:
@@ -447,7 +449,13 @@ async def ec_decision_list(
     try:
         from ...core.decisions import list_decisions
 
-        decisions = list_decisions(conn, staleness_status=staleness_status, file_path=file_path, limit=limit)
+        decisions = list_decisions(
+            conn,
+            staleness_status=staleness_status,
+            file_path=file_path,
+            limit=limit,
+            include_contradicted=include_contradicted,
+        )
         return json.dumps({"decisions": decisions, "count": len(decisions)})
     except ValueError as exc:
         return runtime.error_payload(str(exc))
@@ -486,7 +494,7 @@ async def ec_decision_search(
     repos: str | list[str] | None = None,
     include_stale: bool = True,
     include_superseded: bool = False,
-    include_contradicted: bool = True,
+    include_contradicted: bool = False,
 ) -> str:
     """Search decisions by keyword using FTS5 full-text search.
 
@@ -502,9 +510,7 @@ async def ec_decision_search(
                or a plain repo name string (coerced to a single-element list)
         include_stale: Include decisions marked stale (default True)
         include_superseded: Include decisions that have been superseded (default False)
-        include_contradicted: Include decisions marked contradicted.
-               Defaults True for v0.2.x backward compat; will flip to False in v0.3.0.
-               Pass include_contradicted=False now to opt in to the future default.
+        include_contradicted: Include contradicted decisions (default False)
     """
     if search_type not in ("fts", "hybrid"):
         return runtime.error_payload(f"Invalid search_type '{search_type}'. Use 'fts' or 'hybrid'.")

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -218,7 +218,7 @@ class TestOnSessionStartDecisions:
             staleness_status=None,
             file_path=None,
             limit=20,
-            include_contradicted=True,
+            include_contradicted=False,
         ):
             if file_path is not None:
                 file_path_calls.append(file_path)

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -1101,17 +1101,17 @@ class TestStalenessHardening:
         assert fresh["id"] in ids
         assert sup["id"] in ids
 
-    def test_fts_search_include_contradicted_default_and_opt_out(self, ec_db):
+    def test_fts_search_include_contradicted_default_and_opt_in(self, ec_db):
         c = create_decision(ec_db, title="keywordbravo")
         update_decision_staleness(ec_db, c["id"], "contradicted")
 
-        # Default: include_contradicted=True during the v0.2.x deprecation window.
+        # Default: include_contradicted=False — contradicted excluded.
         default_results = fts_search_decisions(ec_db, "keywordbravo")
-        assert any(r["id"] == c["id"] for r in default_results)
+        assert not any(r["id"] == c["id"] for r in default_results)
 
-        # Opt-in to future default.
-        strict_results = fts_search_decisions(ec_db, "keywordbravo", include_contradicted=False)
-        assert not any(r["id"] == c["id"] for r in strict_results)
+        # Explicit opt-in: include_contradicted=True — contradicted included.
+        inclusive_results = fts_search_decisions(ec_db, "keywordbravo", include_contradicted=True)
+        assert any(r["id"] == c["id"] for r in inclusive_results)
 
     def test_hybrid_search_inherits_filter(self, ec_db):
         fresh = create_decision(ec_db, title="keywordindia")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -65,6 +65,21 @@ class TestDecisionsCore:
         assert len(stale) == 1
         assert stale[0]["title"] == "Stale one"
 
+    def test_list_decisions_excludes_contradicted_by_default(self, ec_db):
+        fresh = create_decision(ec_db, title="Fresh keeper")
+        contradicted = create_decision(ec_db, title="Contradicted hidden")
+        update_decision_staleness(ec_db, contradicted["id"], "contradicted")
+
+        default_results = list_decisions(ec_db)
+        default_ids = [d["id"] for d in default_results]
+        assert fresh["id"] in default_ids
+        assert contradicted["id"] not in default_ids
+
+        inclusive_results = list_decisions(ec_db, include_contradicted=True)
+        inclusive_ids = [d["id"] for d in inclusive_results]
+        assert fresh["id"] in inclusive_ids
+        assert contradicted["id"] in inclusive_ids
+
     def test_list_decisions_file_filter_escapes_like_wildcards(self, ec_db):
         one = create_decision(ec_db, title="Target")
         two = create_decision(ec_db, title="Other")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1437,24 +1437,24 @@ class TestMCPStalenessHardening:
         result = json.loads(asyncio.run(ec_decision_get(a["id"])))
         assert result.get("successor") == {"id": b["id"], "title": "Post"}
 
-    def test_ec_decision_search_opt_in_contradicted(self, mock_repo_db):
+    def test_ec_decision_search_contradicted_default_excluded(self, mock_repo_db):
         from entirecontext.core.decisions import create_decision, update_decision_staleness
         from entirecontext.mcp.tools.decisions import ec_decision_search
 
         d = create_decision(mock_repo_db, title="searchkeywordxray")
         update_decision_staleness(mock_repo_db, d["id"], "contradicted")
 
-        # Default (deprecation window): include_contradicted=True → decision is returned.
+        # Default: include_contradicted=False — contradicted excluded.
         default_result = json.loads(asyncio.run(ec_decision_search(query="searchkeywordxray", search_type="fts")))
         default_ids = [r["id"] for r in default_result["decisions"]]
-        assert d["id"] in default_ids
+        assert d["id"] not in default_ids
 
-        # Opt in to future default: contradicted excluded.
-        strict_result = json.loads(
-            asyncio.run(ec_decision_search(query="searchkeywordxray", search_type="fts", include_contradicted=False))
+        # Explicit opt-in: contradicted included.
+        inclusive_result = json.loads(
+            asyncio.run(ec_decision_search(query="searchkeywordxray", search_type="fts", include_contradicted=True))
         )
-        strict_ids = [r["id"] for r in strict_result["decisions"]]
-        assert d["id"] not in strict_ids
+        inclusive_ids = [r["id"] for r in inclusive_result["decisions"]]
+        assert d["id"] in inclusive_ids
 
 
 class TestEcDecisionContext:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1354,6 +1354,33 @@ class TestMCPDecisionToolsExtended:
         assert d_fresh["id"] in ids
         assert d_stale["id"] not in ids
 
+    def test_ec_decision_list_excludes_contradicted_by_default(self, mock_repo_db):
+        from entirecontext.core.decisions import create_decision, update_decision_staleness
+        from entirecontext.mcp.tools.decisions import ec_decision_list
+
+        d_fresh = create_decision(mock_repo_db, title="Fresh visible")
+        d_contradicted = create_decision(mock_repo_db, title="Contradicted hidden")
+        update_decision_staleness(mock_repo_db, d_contradicted["id"], "contradicted")
+
+        # Default: contradicted excluded (fixture returns raw conn — single MCP call only)
+        result = json.loads(asyncio.run(ec_decision_list()))
+        ids = [d["id"] for d in result["decisions"]]
+        assert d_fresh["id"] in ids
+        assert d_contradicted["id"] not in ids
+
+    def test_ec_decision_list_includes_contradicted_when_requested(self, mock_repo_db):
+        from entirecontext.core.decisions import create_decision, update_decision_staleness
+        from entirecontext.mcp.tools.decisions import ec_decision_list
+
+        d_fresh = create_decision(mock_repo_db, title="Fresh opt-in")
+        d_contradicted = create_decision(mock_repo_db, title="Contradicted opt-in")
+        update_decision_staleness(mock_repo_db, d_contradicted["id"], "contradicted")
+
+        result = json.loads(asyncio.run(ec_decision_list(include_contradicted=True)))
+        ids = [d["id"] for d in result["decisions"]]
+        assert d_fresh["id"] in ids
+        assert d_contradicted["id"] in ids
+
     def test_ec_decision_stale_check(self, mock_repo_db, monkeypatch):
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Flip `include_contradicted` default from `True` → `False` in 6 locations: `list_decisions`, `fts_search_decisions`, `hybrid_search_decisions`, `ec_decision_search` MCP tool, `ec_decision_list` MCP tool (new param), `ec decision search` CLI
- Remove v0.2.x deprecation docstrings and README deprecation window section
- Update retrieval defaults table in README
- Invert test assertions to match new default behavior

Pass `include_contradicted=True` (or `--include-contradicted` from CLI) to restore previous behavior.

## Test plan

- [x] `uv run pytest tests/test_decisions_core.py tests/test_mcp.py tests/test_decision_hooks.py` — 268 passed
- [x] `uv run pytest tests/test_contract_sync.py` — 4 passed (README/MCP contract intact)
- [x] `uv run ruff check .` — all checks passed
- [ ] Verify `ec decision search "query"` excludes contradicted by default
- [ ] Verify `ec_decision_list` MCP tool accepts new `include_contradicted` param

Refs GH-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)