### PR TITLE
feat(telemetry): Wire retrieval selections into decision hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Retrieval telemetry completeness** (#70) — PostToolUse and SessionStart hooks now record per-decision `retrieval_selections` rows alongside the existing `retrieval_events` row, threading `selection_id` into Markdown fallback files. `record_retrieval_event` and `record_retrieval_selection` in `core/telemetry.py` accept a `commit` parameter (default `True`) so hook callers can defer commits for atomicity.
 - **Contract-sync drift guards** — `tests/test_contract_sync.py` asserts `mcp/server.__all__` matches what `register_tools()` actually registers (driven by AST extraction of `server.py`'s module tuple, not a hardcoded copy), that every `ec_*` tool is present in the README `### Available Tools` section bidirectionally (catches stale rows as well as missing rows), that `decision_hooks` fallback filename constants are documented in README, and that the current `SCHEMA_VERSION` is cross-referenced in a CHANGELOG paragraph that also mentions "schema". Replaces `tests/test_mcp_registration.py`, whose hardcoded expected set had silently drifted (its registration loop omitted `tools.decision_candidates` and its expected set omitted the four candidate tools, so it passed via symmetric drift — the exact failure mode the v0.2.0 retrospective finding #2 named).
 
 ## [0.2.0] - 2026-04-15

--- a/src/entirecontext/core/telemetry.py
+++ b/src/entirecontext/core/telemetry.py
@@ -44,6 +44,7 @@ def record_retrieval_event(
     commit_filter: str | None = None,
     agent_filter: str | None = None,
     since_filter: str | None = None,
+    commit: bool = True,
 ) -> dict:
     event_id = str(uuid4())
     now = _now_iso()
@@ -72,7 +73,8 @@ def record_retrieval_event(
             now,
         ),
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return {
         "id": event_id,
         "session_id": session_id,
@@ -101,6 +103,7 @@ def record_retrieval_selection(
     rank: int = 1,
     session_id: str | None = None,
     turn_id: str | None = None,
+    commit: bool = True,
 ) -> dict:
     event = get_retrieval_event(conn, retrieval_event_id)
     if not event:
@@ -125,7 +128,8 @@ def record_retrieval_selection(
             now,
         ),
     )
-    conn.commit()
+    if commit:
+        conn.commit()
     return {
         "id": selection_id,
         "retrieval_event_id": retrieval_event_id,

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -117,6 +117,8 @@ def _format_decision_entry(d: dict, stale: bool = False) -> str:
         parts.append(f"  Files: {files}")
     if rationale_short:
         parts.append(f"  Rationale: {rationale_short}")
+    if d.get("selection_id"):
+        parts.append(f"  Selection: {d['selection_id']}")
     return "\n".join(parts)
 
 
@@ -206,23 +208,59 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                         if len(seen_ids) >= display_limit:
                             break
 
-                if file_related:
-                    entries = [_format_decision_entry(d) for d in file_related[:display_limit]]
-                    sections.append(
-                        "## Related Decisions\n\n"
-                        "The following decisions are linked to recently changed files:\n\n" + "\n\n".join(entries)
-                    )
-
             # 2. Stale decisions — explicit status filter; separate from default policy.
             stale = list_decisions(conn, staleness_status="stale", limit=10)
             stale_new = [d for d in stale if d["id"] not in seen_ids]
             remaining = display_limit - len(seen_ids)
+            stale_full: list[dict] = []
             if stale_new and remaining > 0:
-                stale_entries = []
                 for d in stale_new[:remaining]:
                     full = get_decision(conn, d["id"]) or d
-                    stale_entries.append(_format_decision_entry(full, stale=True))
+                    stale_full.append(full)
                     seen_ids.add(d["id"])
+
+            # 3. Retrieval telemetry: stamp selection_ids before formatting.
+            all_surfaced = file_related + stale_full
+            if all_surfaced:
+                try:
+                    from ..core.telemetry import record_retrieval_event, record_retrieval_selection
+
+                    surfacing_session_id_tel = data.get("session_id")
+                    event = record_retrieval_event(
+                        conn,
+                        source="hook",
+                        search_type="session_start",
+                        target="decision",
+                        query=",".join(changed_files) if changed_files else "",
+                        result_count=len(all_surfaced),
+                        latency_ms=0,
+                        session_id=surfacing_session_id_tel,
+                        file_filter=",".join(changed_files) if changed_files else None,
+                        commit=False,
+                    )
+                    for idx, d in enumerate(all_surfaced, start=1):
+                        sel = record_retrieval_selection(
+                            conn,
+                            event["id"],
+                            result_type="decision",
+                            result_id=d["id"],
+                            rank=idx,
+                            commit=False,
+                        )
+                        d["selection_id"] = sel["id"]
+                    conn.commit()
+                except Exception:
+                    pass
+
+            # 4. Format sections (after telemetry so selection_ids are present).
+            if file_related:
+                entries = [_format_decision_entry(d) for d in file_related[:display_limit]]
+                sections.append(
+                    "## Related Decisions\n\n"
+                    "The following decisions are linked to recently changed files:\n\n" + "\n\n".join(entries)
+                )
+            if stale_full:
+                stale_entries = [_format_decision_entry(d, stale=True) for d in stale_full]
                 sections.append(
                     "## Stale Decisions (action needed)\n\n"
                     + "\n\n".join(stale_entries)
@@ -613,17 +651,8 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
             new_session_wide = sorted(surfaced_session_wide | set(new_ids))
             post_tool_turns[turn_id] = new_ids
             try:
-                from ..core.telemetry import record_retrieval_event
+                from ..core.telemetry import record_retrieval_event, record_retrieval_selection
 
-                # _write_session_metadata_patch MUST run before
-                # record_retrieval_event: the latter commits internally
-                # (telemetry.record_retrieval_event ends with conn.commit),
-                # so reversing this order would leave an orphaned telemetry
-                # row on disk if the metadata write then fails — the
-                # rollback in the except handler cannot undo an already-
-                # committed row. With this ordering, the metadata UPDATE
-                # is still pending when record_retrieval_event commits,
-                # so both writes flush together in one transaction.
                 _write_session_metadata_patch(
                     conn,
                     session_id,
@@ -632,7 +661,7 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
                         "$.post_tool_surfaced_turns": post_tool_turns,
                     },
                 )
-                record_retrieval_event(
+                event = record_retrieval_event(
                     conn,
                     source="hook",
                     search_type="post_tool_use",
@@ -643,7 +672,18 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
                     session_id=session_id,
                     turn_id=turn_id,
                     file_filter=",".join(files),
+                    commit=False,
                 )
+                for idx, d in enumerate(decisions_out, start=1):
+                    sel = record_retrieval_selection(
+                        conn,
+                        event["id"],
+                        result_type="decision",
+                        result_id=d["id"],
+                        rank=idx,
+                        commit=False,
+                    )
+                    d["selection_id"] = sel["id"]
                 conn.commit()
             except Exception:
                 try:

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -250,6 +250,8 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                         d["selection_id"] = sel["id"]
                     conn.commit()
                 except Exception:
+                    for d in all_surfaced:
+                        d.pop("selection_id", None)
                     try:
                         conn.rollback()
                     except Exception:

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -250,7 +250,10 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                         d["selection_id"] = sel["id"]
                     conn.commit()
                 except Exception:
-                    pass
+                    try:
+                        conn.rollback()
+                    except Exception:
+                        pass
 
             # 4. Format sections (after telemetry so selection_ids are present).
             if file_related:
@@ -624,29 +627,15 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
             if not decisions_out:
                 _cleanup_post_tool_fallback(fallback_root, session_id)
                 return None
-            entries = [_format_decision_entry(d) for d in decisions_out]
-            header = "## Related Decisions (current edit)\n\nThe file(s) you just edited are linked to the following prior decisions:\n\n"
-            body = header + "\n\n".join(entries)
-
-            # Write the PostToolUse-specific fallback file. A separate path
-            # from the SessionStart fallback keeps the two writers independent
-            # — deleting our file on empty results can never destroy the
-            # SessionStart context the agent may still be reading (PR #56
-            # Codex review round 3).
-            from pathlib import Path as _Path
-
-            fallback_path = _Path(fallback_root) / ".entirecontext" / _post_tool_fallback_name(session_id)
-            try:
-                fallback_path.parent.mkdir(parents=True, exist_ok=True)
-                fallback_path.write_text(body, encoding="utf-8")
-            except OSError:
-                pass  # never block tool execution
 
             # Persist the dedup state + telemetry event atomically (PR #56
             # review round 4). If any of these writes raise, we must NOT
             # leave the fallback file on disk — otherwise the next tool
             # call in the same turn sees stale metadata and re-surfaces
             # the same decisions, violating the documented per-turn guarantee.
+            #
+            # Telemetry stamps selection_ids on decisions_out BEFORE formatting
+            # so _format_decision_entry can include the Selection: line.
             new_ids = [d["id"] for d in decisions_out]
             new_session_wide = sorted(surfaced_session_wide | set(new_ids))
             post_tool_turns[turn_id] = new_ids
@@ -696,6 +685,21 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
                 # metadata record anchors.
                 _cleanup_post_tool_fallback(fallback_root, session_id)
                 return None
+
+            # Format entries AFTER telemetry so selection_ids appear in output.
+            entries = [_format_decision_entry(d) for d in decisions_out]
+            header = "## Related Decisions (current edit)\n\nThe file(s) you just edited are linked to the following prior decisions:\n\n"
+            body = header + "\n\n".join(entries)
+
+            # Write the PostToolUse-specific fallback file.
+            from pathlib import Path as _Path
+
+            fallback_path = _Path(fallback_root) / ".entirecontext" / _post_tool_fallback_name(session_id)
+            try:
+                fallback_path.parent.mkdir(parents=True, exist_ok=True)
+                fallback_path.write_text(body, encoding="utf-8")
+            except OSError:
+                pass  # never block tool execution
 
             return body
         finally:

--- a/tests/test_decision_hooks.py
+++ b/tests/test_decision_hooks.py
@@ -143,12 +143,17 @@ class TestOnSessionStartDecisions:
         assert result is None
 
     def test_related_decisions_shown(self, ec_repo, ec_db, monkeypatch):
+        from entirecontext.core.project import get_project
+
         monkeypatch.setattr(
             "entirecontext.hooks.decision_hooks._load_decisions_config",
             lambda _: {"show_related_on_start": True},
         )
         d = create_decision(ec_db, title="Arch decision")
         link_decision_to_file(ec_db, d["id"], "src/app.py")
+
+        project = get_project(str(ec_repo))
+        session = create_session(ec_db, project["id"], session_id="s1-telemetry")
 
         test_file = ec_repo / "src" / "app.py"
         test_file.parent.mkdir(parents=True, exist_ok=True)
@@ -162,10 +167,22 @@ class TestOnSessionStartDecisions:
 
         from entirecontext.hooks.decision_hooks import on_session_start_decisions
 
-        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": "s1"})
+        result = on_session_start_decisions({"cwd": str(ec_repo), "session_id": session["id"]})
         assert result is not None
         assert "Arch decision" in result
         assert "Related Decisions" in result
+
+        events = ec_db.execute(
+            "SELECT COUNT(*) AS n FROM retrieval_events WHERE search_type = 'session_start'"
+        ).fetchone()["n"]
+        assert events == 1
+
+        selections = ec_db.execute(
+            "SELECT COUNT(*) AS n FROM retrieval_selections WHERE result_type = 'decision'"
+        ).fetchone()["n"]
+        assert selections >= 1
+
+        assert "Selection:" in result
 
     def test_stale_decisions_shown(self, ec_repo, ec_db, monkeypatch):
         monkeypatch.setattr(
@@ -480,11 +497,15 @@ class TestOnPostToolUseDecisions:
         assert fallback.exists()
         assert "Routing strategy" in fallback.read_text(encoding="utf-8")
 
-        # Single compact retrieval_event row (no per-selection rows in hook path)
         events = ec_db.execute(
             "SELECT COUNT(*) AS n FROM retrieval_events WHERE search_type = 'post_tool_use'"
         ).fetchone()["n"]
         assert events == 1
+
+        selections = ec_db.execute(
+            "SELECT COUNT(*) AS n FROM retrieval_selections WHERE result_type = 'decision'"
+        ).fetchone()["n"]
+        assert selections >= 1
 
     def test_respects_turn_interval_gate(self, ec_repo, ec_db, monkeypatch):
         from entirecontext.hooks.decision_hooks import on_post_tool_use_decisions

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -75,6 +75,8 @@ class TestTelemetryHelpers:
             raise AssertionError("expected ValueError")
 
     def test_commit_false_defers_write(self, ec_repo, ec_db):
+        import sqlite3
+
         project = get_project(str(ec_repo))
         session = create_session(ec_db, project["id"], session_id="telemetry-defer")
         turn = create_turn(ec_db, session["id"], 1, user_message="test", assistant_summary="ok")
@@ -103,9 +105,29 @@ class TestTelemetryHelpers:
         assert event["id"] is not None
         assert sel["id"] is not None
 
+        # A second connection must NOT see uncommitted rows (deferred-commit contract).
+        db_path = str(ec_repo / ".entirecontext" / "db" / "local.db")
+        second_conn = sqlite3.connect(db_path)
+        try:
+            pre = second_conn.execute(
+                "SELECT id FROM retrieval_events WHERE id = ?", (event["id"],)
+            ).fetchone()
+            assert pre is None, "row should not be visible to other connections before commit"
+        finally:
+            second_conn.close()
+
         ec_db.commit()
 
-        row = ec_db.execute("SELECT id FROM retrieval_events WHERE id = ?", (event["id"],)).fetchone()
-        assert row is not None
-        sel_row = ec_db.execute("SELECT id FROM retrieval_selections WHERE id = ?", (sel["id"],)).fetchone()
-        assert sel_row is not None
+        # After commit, a second connection CAN see the rows.
+        second_conn = sqlite3.connect(db_path)
+        try:
+            post = second_conn.execute(
+                "SELECT id FROM retrieval_events WHERE id = ?", (event["id"],)
+            ).fetchone()
+            assert post is not None, "row should be visible after commit"
+            sel_post = second_conn.execute(
+                "SELECT id FROM retrieval_selections WHERE id = ?", (sel["id"],)
+            ).fetchone()
+            assert sel_post is not None, "selection should be visible after commit"
+        finally:
+            second_conn.close()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -73,3 +73,39 @@ class TestTelemetryHelpers:
             assert "Invalid application_type" in str(exc)
         else:
             raise AssertionError("expected ValueError")
+
+    def test_commit_false_defers_write(self, ec_repo, ec_db):
+        project = get_project(str(ec_repo))
+        session = create_session(ec_db, project["id"], session_id="telemetry-defer")
+        turn = create_turn(ec_db, session["id"], 1, user_message="test", assistant_summary="ok")
+
+        event = record_retrieval_event(
+            ec_db,
+            source="hook",
+            search_type="session_start",
+            target="decision",
+            query="test",
+            result_count=1,
+            latency_ms=0,
+            session_id=session["id"],
+            turn_id=turn["id"],
+            commit=False,
+        )
+        sel = record_retrieval_selection(
+            ec_db,
+            event["id"],
+            "decision",
+            "d-1",
+            rank=1,
+            commit=False,
+        )
+
+        assert event["id"] is not None
+        assert sel["id"] is not None
+
+        ec_db.commit()
+
+        row = ec_db.execute("SELECT id FROM retrieval_events WHERE id = ?", (event["id"],)).fetchone()
+        assert row is not None
+        sel_row = ec_db.execute("SELECT id FROM retrieval_selections WHERE id = ?", (sel["id"],)).fetchone()
+        assert sel_row is not None


### PR DESCRIPTION
## Summary

- Add `commit` parameter (default `True`) to `record_retrieval_event` and `record_retrieval_selection` in `core/telemetry.py`, allowing hook callers to defer commits for atomicity (aligns with `eca12dd` convention)
- PostToolUse hook now records per-decision `retrieval_selections` rows alongside the existing `retrieval_events` row, with `selection_id` threaded into `decisions_out`
- SessionStart hook restructured: data collection → telemetry recording → section formatting, so `selection_id` appears in Markdown fallback files
- `_format_decision_entry()` extended with optional `Selection:` line

## Test plan

- [x] `uv run pytest tests/` — 1464 passed
- [x] `uv run ruff check .` — all checks passed
- [x] `test_related_decisions_shown` — asserts `retrieval_events` + `retrieval_selections` rows + `Selection:` in output
- [x] `test_surfaces_decision_when_file_edited` — asserts `retrieval_selections` rows created
- [x] `test_commit_false_defers_write` — verifies deferred commit semantics
- [ ] Manual: trigger hook cycle, verify telemetry rows in SQLite

Refs GH-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)