### PR TITLE
feat(decisions): [decisions.ranking] config for signal weights (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`[decisions.ranking]` config section** (#85) — staleness factors, assessment relation weights, exact-file and git-commit weights, and directory proximity cap are now tunable per repo through the new `[decisions.ranking]` TOML section (defaults unchanged). `rank_related_decisions` accepts a `ranking: RankingWeights` kwarg, and the SessionStart hook and `ec_decision_related` MCP tool load repo config automatically. The `score_breakdown` key set (`file_exact`, `file_proximity`, `assessment`, `diff_relevance`, `git_commit`, `quality`, `staleness_factor`) is now pinned as an additive-only public contract — renames are a breaking change.
+
 ## [0.3.0] - 2026-04-17
 
 v0.3.0 closes the decision-memory feedback arc: retrieval records its footprint, extraction quality gets validated before candidates enter the pipeline, and outcome data flows back into ranking. No schema change — still v13.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Return codes: 0=success, 2=block.
 
 TOML deep merge: defaults ← `~/.entirecontext/config.toml` (global) ← `.entirecontext/config.toml` (per-repo)
 
-Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `security`, `filtering.query_redaction`, `index`, `futures`, `decisions`
+Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `security`, `filtering.query_redaction`, `index`, `futures`, `decisions`, `decisions.ranking`
 
 ## Code Conventions
 

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -91,6 +91,23 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "noise_gate_min_turns_with_files": 3,
         "candidate_dedup_similarity_threshold": 0.5,
         "candidate_redact_secrets": True,
+        "ranking": {
+            "staleness_factors": {
+                "fresh": 1.0,
+                "stale": 0.85,
+                "superseded": 0.5,
+                "contradicted": 0.25,
+            },
+            "assessment_relation_weights": {
+                "supports": 4.0,
+                "informed_by": 4.0,
+                "contradicts": 5.0,
+                "supersedes": 3.0,
+            },
+            "file_exact_weight": 3.0,
+            "git_commit_weight": 3.0,
+            "directory_proximity_cap_levels": 3,
+        },
     },
 }
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -6,6 +6,7 @@ import json
 import re
 import sqlite3
 import subprocess
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -135,12 +136,12 @@ def _escape_like_contains(value: str) -> str:
 
 
 def _parse_decision_json_fields(decision: dict[str, Any]) -> dict[str, Any]:
-    for field in ("rejected_alternatives", "supporting_evidence"):
-        raw = decision.get(field)
+    for json_field in ("rejected_alternatives", "supporting_evidence"):
+        raw = decision.get(json_field)
         try:
-            decision[field] = json.loads(raw) if raw else []
+            decision[json_field] = json.loads(raw) if raw else []
         except (json.JSONDecodeError, TypeError):
-            decision[field] = []
+            decision[json_field] = []
     return decision
 
 
@@ -811,6 +812,76 @@ _ASSESSMENT_RELATION_WEIGHTS: dict[str, float] = {
     "supersedes": 3.0,
 }
 
+
+@dataclass(frozen=True)
+class RankingWeights:
+    """Weights consumed by ``rank_related_decisions``.
+
+    ``[decisions.ranking]`` config overrides merge into these defaults.
+    """
+
+    staleness_factors: dict[str, float] = field(default_factory=lambda: dict(_STALENESS_FACTORS))
+    assessment_relation_weights: dict[str, float] = field(default_factory=lambda: dict(_ASSESSMENT_RELATION_WEIGHTS))
+    file_exact_weight: float = 3.0
+    git_commit_weight: float = 3.0
+    directory_proximity_cap_levels: int = 3
+
+
+_DEFAULT_RANKING_WEIGHTS = RankingWeights()
+
+
+def _coerce_ranking_float(section: dict, key: str, default: float) -> float:
+    raw = section.get(key)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"decisions.ranking.{key} must be a number, got {raw!r}") from exc
+
+
+def _coerce_ranking_int(section: dict, key: str, default: int) -> int:
+    raw = section.get(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"decisions.ranking.{key} must be an integer, got {raw!r}") from exc
+
+
+def _load_ranking_weights(config: dict | None) -> RankingWeights:
+    """Build :class:`RankingWeights` from an ``[decisions.ranking]`` config section.
+
+    Always returns a fresh :class:`RankingWeights` instance — never the
+    module-level ``_DEFAULT_RANKING_WEIGHTS`` singleton — so a caller that
+    mutates an in-field dict (``weights.staleness_factors['fresh'] = 999``)
+    cannot contaminate subsequent calls. ``frozen=True`` on the dataclass
+    only protects attribute reassignment, not the referenced dict contents.
+    """
+    if not config:
+        return RankingWeights()
+    section = (config.get("decisions") or {}).get("ranking") or {}
+    if not section:
+        return RankingWeights()
+
+    staleness_override = section.get("staleness_factors") or {}
+    assessment_override = section.get("assessment_relation_weights") or {}
+    return RankingWeights(
+        staleness_factors={**_STALENESS_FACTORS, **staleness_override},
+        assessment_relation_weights={**_ASSESSMENT_RELATION_WEIGHTS, **assessment_override},
+        file_exact_weight=_coerce_ranking_float(
+            section, "file_exact_weight", _DEFAULT_RANKING_WEIGHTS.file_exact_weight
+        ),
+        git_commit_weight=_coerce_ranking_float(
+            section, "git_commit_weight", _DEFAULT_RANKING_WEIGHTS.git_commit_weight
+        ),
+        directory_proximity_cap_levels=_coerce_ranking_int(
+            section, "directory_proximity_cap_levels", _DEFAULT_RANKING_WEIGHTS.directory_proximity_cap_levels
+        ),
+    )
+
+
 _CODE_STOPWORDS: frozenset[str] = frozenset(
     {
         "function",
@@ -860,11 +931,12 @@ def _normalize_path(path: str) -> str:
     return p
 
 
-def _directory_proximity_score(path_a: str, path_b: str) -> float:
+def _directory_proximity_score(path_a: str, path_b: str, cap_levels: int = 3) -> float:
     """Score directory proximity between two file paths.
 
-    Same directory = 1.5, parent = 0.75, grandparent = 0.375 (halves per level, cap 3).
-    Returns 0.0 if paths share no directory components.
+    Same directory = 1.5, parent = 0.75, grandparent = 0.375 (halves per level,
+    truncated to zero beyond ``cap_levels``). Returns 0.0 if paths share no
+    directory components.
     """
     parts_a = PurePosixPath(_normalize_path(path_a)).parts[:-1]
     parts_b = PurePosixPath(_normalize_path(path_b)).parts[:-1]
@@ -878,7 +950,7 @@ def _directory_proximity_score(path_a: str, path_b: str) -> float:
     if shared == 0:
         return 0.0
     depth_from_match = max(len(parts_a), len(parts_b)) - shared
-    if depth_from_match > 3:
+    if depth_from_match > cap_levels:
         return 0.0
     return 1.5 * (0.5**depth_from_match)
 
@@ -979,8 +1051,13 @@ def _fts_rank_decisions_from_diff(conn, diff_text: str, limit: int = 50) -> dict
     return result
 
 
-def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
-    """Find decision IDs linked to the given files or sharing a parent directory."""
+def _gather_candidates_by_files(conn, file_paths: list[str], cap_levels: int = 3) -> set[str]:
+    """Find decision IDs linked to the given files or sharing a parent directory.
+
+    ``cap_levels`` mirrors :func:`_directory_proximity_score`'s cap so candidate
+    collection scales with the configured ``directory_proximity_cap_levels``.
+    Passing a value larger than 3 only matters if the scorer cap is also raised.
+    """
     if not file_paths:
         return set()
     candidates: set[str] = set()
@@ -996,13 +1073,14 @@ def _gather_candidates_by_files(conn, file_paths: list[str]) -> set[str]:
     ).fetchall()
     candidates.update(r["decision_id"] for r in rows)
 
-    # Ancestor directory matches (for proximity scoring up to 3 levels).
-    # _directory_proximity_score returns non-zero for depth_from_match <= 3, so we must gather
-    # candidates from ancestor dirs at each level to avoid silently excluding sibling/cousin files.
+    # Ancestor directory matches — must match the scorer's proximity cap so a
+    # configured higher cap actually pulls deeper siblings into the candidate
+    # pool rather than silently filtering them.
+    ancestor_levels = max(0, cap_levels) + 1
     ancestor_dirs: set[str] = set()
     for p in normalized:
         parts = PurePosixPath(p).parts[:-1]  # directory components, excluding filename
-        for depth in range(min(len(parts), 4)):
+        for depth in range(min(len(parts), ancestor_levels)):
             ancestor_parts = parts[: len(parts) - depth]
             ancestor = str(PurePosixPath(*ancestor_parts))
             if ancestor and ancestor != ".":
@@ -1042,6 +1120,7 @@ def rank_related_decisions(
     include_stale: bool = True,
     include_superseded: bool = False,
     include_contradicted: bool = False,
+    ranking: RankingWeights | None = None,
     _return_stats: bool = False,
 ) -> list[dict] | tuple[list[dict], dict]:
     """Rank decisions by current-change relevance using multi-signal scoring.
@@ -1067,13 +1146,14 @@ def rank_related_decisions(
       successor passes the filter; otherwise the entire chain is dropped.
     - Set _return_stats=True to get (results, filter_stats).
     """
+    weights = ranking if ranking is not None else _DEFAULT_RANKING_WEIGHTS
     file_paths = [_normalize_path(p) for p in (file_paths or [])]
     assessment_ids = assessment_ids or []
     commit_shas = commit_shas or []
 
     # --- 1. Gather candidates from each signal source ---
     candidate_ids: set[str] = set()
-    candidate_ids |= _gather_candidates_by_files(conn, file_paths)
+    candidate_ids |= _gather_candidates_by_files(conn, file_paths, cap_levels=weights.directory_proximity_cap_levels)
     candidate_ids |= _gather_candidates_by_commits(conn, commit_shas)
 
     resolved_assessment_ids: set[str] = set()
@@ -1218,9 +1298,9 @@ def rank_related_decisions(
         aid = row["assessment_id"]
         rtype = row["relation_type"]
         # Keep max weight per assessment_id
-        if aid not in existing or _ASSESSMENT_RELATION_WEIGHTS.get(rtype, 0) > _ASSESSMENT_RELATION_WEIGHTS.get(
-            existing[aid], 0
-        ):
+        if aid not in existing or weights.assessment_relation_weights.get(
+            rtype, 0
+        ) > weights.assessment_relation_weights.get(existing[aid], 0):
             existing[aid] = rtype
 
     # Commit links
@@ -1240,9 +1320,9 @@ def rank_related_decisions(
         for anc_id in ancestor_ids:
             merged_files |= file_links_by_decision.get(anc_id, set())
             for aid, rtype in assessment_links_by_decision.get(anc_id, {}).items():
-                if aid not in merged_assessments or _ASSESSMENT_RELATION_WEIGHTS.get(
+                if aid not in merged_assessments or weights.assessment_relation_weights.get(
                     rtype, 0
-                ) > _ASSESSMENT_RELATION_WEIGHTS.get(merged_assessments[aid], 0):
+                ) > weights.assessment_relation_weights.get(merged_assessments[aid], 0):
                     merged_assessments[aid] = rtype
             merged_commits |= commit_links_by_decision.get(anc_id, set())
         file_links_by_decision[terminal_id] = merged_files
@@ -1285,13 +1365,13 @@ def rank_related_decisions(
                 exact_matched = False
                 for linked in linked_files:
                     if _normalize_path(linked) == fp:
-                        file_exact += 3.0
+                        file_exact += weights.file_exact_weight
                         exact_matched = True
                         break
                 if not exact_matched:
                     best_prox = 0.0
                     for linked in linked_files:
-                        prox = _directory_proximity_score(fp, linked)
+                        prox = _directory_proximity_score(fp, linked, cap_levels=weights.directory_proximity_cap_levels)
                         if prox > best_prox:
                             best_prox = prox
                     file_proximity += best_prox
@@ -1301,19 +1381,19 @@ def rank_related_decisions(
             links = assessment_links_by_decision.get(did, {})
             for aid, rtype in links.items():
                 if aid in resolved_assessment_ids:
-                    assessment_score += _ASSESSMENT_RELATION_WEIGHTS.get(rtype, 4.0)
+                    assessment_score += weights.assessment_relation_weights.get(rtype, 4.0)
 
         # Git commit signal
         if commit_set:
             linked_commits = commit_links_by_decision.get(did, set())
-            git_commit = 3.0 * len(linked_commits & commit_set)
+            git_commit = weights.git_commit_weight * len(linked_commits & commit_set)
 
         base_score = file_exact + file_proximity + assessment_score + diff_relevance + git_commit
         if base_score <= 0:
             continue
 
         quality_score = calculate_decision_quality_score(outcome_counts_by_decision.get(did, {}))
-        staleness_factor = _STALENESS_FACTORS.get(d.get("staleness_status", "fresh"), 1.0)
+        staleness_factor = weights.staleness_factors.get(d.get("staleness_status", "fresh"), 1.0)
         score = base_score * staleness_factor + quality_score
 
         scored.append(

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -850,6 +850,27 @@ def _coerce_ranking_int(section: dict, key: str, default: int) -> int:
         raise ValueError(f"decisions.ranking.{key} must be an integer, got {raw!r}") from exc
 
 
+def _coerce_ranking_weight_map(
+    section_name: str, override: dict | None, defaults: dict[str, float]
+) -> dict[str, float]:
+    """Deep-merge an override map into defaults, coercing each value to ``float``.
+
+    Catches non-numeric map values (quoted numbers, booleans reified as strings,
+    lists, etc.) at config-load time with a clear ``decisions.ranking.<section>.<key>``
+    error path, instead of letting them slip through and explode later inside
+    ranking arithmetic.
+    """
+    merged = dict(defaults)
+    if not override:
+        return merged
+    for key, raw in override.items():
+        try:
+            merged[key] = float(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"decisions.ranking.{section_name}.{key} must be a number, got {raw!r}") from exc
+    return merged
+
+
 def _load_ranking_weights(config: dict | None) -> RankingWeights:
     """Build :class:`RankingWeights` from an ``[decisions.ranking]`` config section.
 
@@ -865,11 +886,15 @@ def _load_ranking_weights(config: dict | None) -> RankingWeights:
     if not section:
         return RankingWeights()
 
-    staleness_override = section.get("staleness_factors") or {}
-    assessment_override = section.get("assessment_relation_weights") or {}
     return RankingWeights(
-        staleness_factors={**_STALENESS_FACTORS, **staleness_override},
-        assessment_relation_weights={**_ASSESSMENT_RELATION_WEIGHTS, **assessment_override},
+        staleness_factors=_coerce_ranking_weight_map(
+            "staleness_factors", section.get("staleness_factors"), _STALENESS_FACTORS
+        ),
+        assessment_relation_weights=_coerce_ranking_weight_map(
+            "assessment_relation_weights",
+            section.get("assessment_relation_weights"),
+            _ASSESSMENT_RELATION_WEIGHTS,
+        ),
         file_exact_weight=_coerce_ranking_float(
             section, "file_exact_weight", _DEFAULT_RANKING_WEIGHTS.file_exact_weight
         ),

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -184,7 +184,14 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
         if not config.get("show_related_on_start", False):
             return None
 
-        from ..core.decisions import _normalize_path, get_decision, list_decisions, rank_related_decisions
+        from ..core.config import load_config
+        from ..core.decisions import (
+            _load_ranking_weights,
+            _normalize_path,
+            get_decision,
+            list_decisions,
+            rank_related_decisions,
+        )
         from ..db import get_db
 
         conn = get_db(repo_path)
@@ -212,6 +219,8 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
 
             normalized_files = [_normalize_path(f) for f in changed_files if _normalize_path(f)]
 
+            ranking_weights = _load_ranking_weights(load_config(repo_path))
+
             file_related: list[dict] = []
             if normalized_files or diff_text or commit_shas or assessment_ids:
                 ranked = rank_related_decisions(
@@ -222,6 +231,7 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
                     assessment_ids=assessment_ids,
                     limit=display_limit,
                     include_contradicted=False,
+                    ranking=ranking_weights,
                 )
                 for d in ranked:
                     if d["id"] not in seen_ids:
@@ -812,10 +822,13 @@ def _session_passes_noise_gate(conn, session_id: str, min_turns: int = 3) -> boo
 
     Requires at least 1 checkpoint OR at least min_turns turns with non-empty files_touched.
     """
-    has_checkpoint = conn.execute(
-        "SELECT 1 FROM checkpoints WHERE session_id = ? LIMIT 1",
-        (session_id,),
-    ).fetchone() is not None
+    has_checkpoint = (
+        conn.execute(
+            "SELECT 1 FROM checkpoints WHERE session_id = ? LIMIT 1",
+            (session_id,),
+        ).fetchone()
+        is not None
+    )
     if has_checkpoint:
         return True
 

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -55,11 +55,14 @@ async def ec_decision_related(
     - Superseded candidates collapse to their terminal successor when it passes the filter.
     - Set include_filter_stats=True to receive a breakdown of what was filtered.
     """
-    (conn, _), error = runtime.resolve_repo()
+    (conn, repo_path), error = runtime.resolve_repo()
     if error:
         return error
     try:
-        from ...core.decisions import rank_related_decisions
+        from ...core.config import load_config
+        from ...core.decisions import _load_ranking_weights, rank_related_decisions
+
+        ranking_weights = _load_ranking_weights(load_config(repo_path))
 
         started_at = time.perf_counter()
         decisions, filter_stats = rank_related_decisions(
@@ -72,6 +75,7 @@ async def ec_decision_related(
             include_stale=include_stale,
             include_superseded=include_superseded,
             include_contradicted=include_contradicted,
+            ranking=ranking_weights,
             _return_stats=True,
         )
         tracked_event_id = runtime.record_search_event(
@@ -146,8 +150,11 @@ async def ec_decision_context(
     if error:
         return error
     try:
-        from ...core.decisions import _normalize_path, rank_related_decisions
+        from ...core.config import load_config
+        from ...core.decisions import _load_ranking_weights, _normalize_path, rank_related_decisions
         from ...core.telemetry import detect_current_context
+
+        ranking_weights = _load_ranking_weights(load_config(repo_path))
 
         # Track whether the caller explicitly pinned a session. When they
         # did, we must NOT fold repo-wide signals (like `git diff HEAD`)
@@ -293,6 +300,7 @@ async def ec_decision_context(
             commit_shas=commit_shas,
             limit=limit,
             include_stale=include_stale,
+            ranking=ranking_weights,
             _return_stats=True,
         )
 

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -28,7 +28,12 @@ from entirecontext.core.decisions import (
 )
 from entirecontext.core.futures import create_assessment, list_assessments
 from entirecontext.core.project import get_project
-from entirecontext.core.decisions import rank_related_decisions
+from entirecontext.core.decisions import (
+    _DEFAULT_RANKING_WEIGHTS,
+    RankingWeights,
+    _load_ranking_weights,
+    rank_related_decisions,
+)
 from entirecontext.core.session import create_session
 from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
 from entirecontext.core.turn import create_turn
@@ -917,6 +922,161 @@ class TestRankingSignals:
         item = ranked[0]
         for key in ("id", "title", "staleness_status", "updated_at", "base_score", "quality_score", "score"):
             assert key in item
+
+
+# ---------------------------------------------------------------------------
+# Issue #85 (v0.4.0 F3): ranking weight configuration
+# ---------------------------------------------------------------------------
+
+
+class TestRankingWeightsConfig:
+    """[decisions.ranking] config → RankingWeights injection into rank_related_decisions."""
+
+    _EXPECTED_BREAKDOWN_KEYS = frozenset(
+        {
+            "file_exact",
+            "file_proximity",
+            "assessment",
+            "diff_relevance",
+            "git_commit",
+            "quality",
+            "staleness_factor",
+        }
+    )
+
+    def test_score_breakdown_keys_stable(self, ec_db):
+        """score_breakdown keys are a stable additive-only contract (#85)."""
+        d = create_decision(ec_db, title="Key stability decision")
+        link_decision_to_file(ec_db, d["id"], "src/contract.py")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/contract.py"])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert set(item["score_breakdown"].keys()) == set(self._EXPECTED_BREAKDOWN_KEYS), (
+            "score_breakdown keys changed — MCP ec_decision_related callers rely on these exact names; "
+            "rename is forbidden, add-only is allowed."
+        )
+
+    def test_rank_default_matches_legacy(self, ec_db):
+        """ranking=None preserves legacy hardcoded constants (pre-F3 numbers)."""
+        d_a = create_decision(ec_db, title="Fresh file decision")
+        link_decision_to_file(ec_db, d_a["id"], "src/legacy.py")
+        d_b = create_decision(ec_db, title="Commit decision")
+        link_decision_to_commit(ec_db, d_b["id"], "abc1234")
+
+        ranked_files = rank_related_decisions(ec_db, file_paths=["src/legacy.py"])
+        item_a = next(r for r in ranked_files if r["id"] == d_a["id"])
+        assert item_a["score_breakdown"]["file_exact"] == 3.0
+        assert item_a["score_breakdown"]["staleness_factor"] == 1.0
+
+        ranked_commits = rank_related_decisions(ec_db, commit_shas=["abc1234"])
+        item_b = next(r for r in ranked_commits if r["id"] == d_b["id"])
+        assert item_b["score_breakdown"]["git_commit"] == 3.0
+
+        assert _DEFAULT_RANKING_WEIGHTS.staleness_factors == {
+            "fresh": 1.0,
+            "stale": 0.85,
+            "superseded": 0.5,
+            "contradicted": 0.25,
+        }
+        assert _DEFAULT_RANKING_WEIGHTS.assessment_relation_weights == {
+            "supports": 4.0,
+            "informed_by": 4.0,
+            "contradicts": 5.0,
+            "supersedes": 3.0,
+        }
+        assert _DEFAULT_RANKING_WEIGHTS.file_exact_weight == 3.0
+        assert _DEFAULT_RANKING_WEIGHTS.git_commit_weight == 3.0
+        assert _DEFAULT_RANKING_WEIGHTS.directory_proximity_cap_levels == 3
+
+    def test_rank_uses_config_staleness_factors(self, ec_db):
+        """A staleness_factors override in [decisions.ranking] reshapes the staleness demotion."""
+        d = create_decision(ec_db, title="Stale-boost decision", staleness_status="stale")
+        link_decision_to_file(ec_db, d["id"], "src/override.py")
+
+        default_ranked = rank_related_decisions(ec_db, file_paths=["src/override.py"])
+        default_item = next(r for r in default_ranked if r["id"] == d["id"])
+        assert default_item["score_breakdown"]["staleness_factor"] == 0.85  # legacy "stale" default
+
+        boosted = RankingWeights(
+            staleness_factors={**_DEFAULT_RANKING_WEIGHTS.staleness_factors, "stale": 2.0},
+        )
+        override_ranked = rank_related_decisions(ec_db, file_paths=["src/override.py"], ranking=boosted)
+        override_item = next(r for r in override_ranked if r["id"] == d["id"])
+        assert override_item["score_breakdown"]["staleness_factor"] == 2.0
+        assert override_item["score"] > default_item["score"]
+
+    def test_load_ranking_weights_deep_merges_partial_override(self):
+        """Partial [decisions.ranking] override keeps un-specified factors at legacy defaults."""
+        weights = _load_ranking_weights(
+            {
+                "decisions": {
+                    "ranking": {
+                        "staleness_factors": {"fresh": 3.0},
+                        "file_exact_weight": 5.0,
+                    }
+                }
+            }
+        )
+        assert weights.staleness_factors["fresh"] == 3.0
+        assert weights.staleness_factors["stale"] == 0.85  # legacy default preserved
+        assert weights.file_exact_weight == 5.0
+        assert weights.git_commit_weight == 3.0  # legacy default preserved
+        assert weights.assessment_relation_weights == _DEFAULT_RANKING_WEIGHTS.assessment_relation_weights
+
+    def test_load_ranking_weights_empty_config_returns_defaults_by_value(self):
+        """Empty/missing config yields a fresh instance with default values (never the singleton)."""
+        for empty in (None, {}, {"decisions": {}}, {"decisions": {"ranking": {}}}):
+            weights = _load_ranking_weights(empty)
+            assert weights.staleness_factors == _DEFAULT_RANKING_WEIGHTS.staleness_factors
+            assert weights.assessment_relation_weights == _DEFAULT_RANKING_WEIGHTS.assessment_relation_weights
+            assert weights.file_exact_weight == _DEFAULT_RANKING_WEIGHTS.file_exact_weight
+            assert weights.git_commit_weight == _DEFAULT_RANKING_WEIGHTS.git_commit_weight
+            assert weights.directory_proximity_cap_levels == _DEFAULT_RANKING_WEIGHTS.directory_proximity_cap_levels
+            # Isolation: returned instance must never be the module-level singleton,
+            # otherwise a caller mutating staleness_factors would contaminate defaults.
+            assert weights is not _DEFAULT_RANKING_WEIGHTS
+            assert weights.staleness_factors is not _DEFAULT_RANKING_WEIGHTS.staleness_factors
+
+    def test_load_ranking_weights_mutation_does_not_contaminate_singleton(self):
+        """Mutating an in-field dict on a returned instance must not leak into defaults."""
+        poisoned = _load_ranking_weights(None)
+        poisoned.staleness_factors["fresh"] = 999.0
+
+        fresh = _load_ranking_weights(None)
+        assert fresh.staleness_factors["fresh"] == 1.0
+        assert _DEFAULT_RANKING_WEIGHTS.staleness_factors["fresh"] == 1.0
+
+    def test_load_ranking_weights_rejects_non_numeric_with_field_name(self):
+        """Coercion errors must name the offending config key."""
+        with pytest.raises(ValueError, match=r"decisions\.ranking\.file_exact_weight"):
+            _load_ranking_weights({"decisions": {"ranking": {"file_exact_weight": "not-a-number"}}})
+        with pytest.raises(ValueError, match=r"decisions\.ranking\.directory_proximity_cap_levels"):
+            _load_ranking_weights({"decisions": {"ranking": {"directory_proximity_cap_levels": "deep"}}})
+
+    def test_rank_cap_levels_override_widens_candidate_gathering(self, ec_db):
+        """Config cap_levels > 3 must widen _gather_candidates_by_files, not just the scorer.
+
+        Setup: linked file is shallow ("src/a/file.py"); queried file is deep
+        ("src/a/b/c/d/e/deep.py"). They share only "src/a" — a 4-hop ancestor of
+        the queried file. Default cap=3 keeps the queried file's ancestor search
+        shallow enough that it never generates "src/a" as an ancestor dir, so the
+        linked file is not a candidate at all (and its proximity score would be
+        zero anyway under depth_from_match=4 > cap=3). Raising cap to 4 widens
+        both sides.
+        """
+        d_far = create_decision(ec_db, title="Four hops away")
+        link_decision_to_file(ec_db, d_far["id"], "src/a/file.py")
+        deep_path = ["src/a/b/c/d/e/deep.py"]
+
+        default_ranked = rank_related_decisions(ec_db, file_paths=deep_path)
+        assert not any(r["id"] == d_far["id"] for r in default_ranked)
+
+        wide = _load_ranking_weights({"decisions": {"ranking": {"directory_proximity_cap_levels": 4}}})
+        assert wide.directory_proximity_cap_levels == 4
+        wide_ranked = rank_related_decisions(ec_db, file_paths=deep_path, ranking=wide)
+        assert any(r["id"] == d_far["id"] for r in wide_ranked), (
+            "directory_proximity_cap_levels=4 must widen candidate gathering, not just scoring."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -1053,6 +1053,28 @@ class TestRankingWeightsConfig:
         with pytest.raises(ValueError, match=r"decisions\.ranking\.directory_proximity_cap_levels"):
             _load_ranking_weights({"decisions": {"ranking": {"directory_proximity_cap_levels": "deep"}}})
 
+    def test_load_ranking_weights_rejects_non_numeric_map_values(self):
+        """Weight-map values are coerced to float at load time with a path-qualified error.
+
+        PR #87 review comment #discussion_r3098094096: a quoted/wrong-type override like
+        ``staleness_factors.stale = "not-numeric"`` used to slip through the
+        ``{**default, **override}`` merge and only explode later inside scoring
+        arithmetic. Values must now be validated eagerly at config load.
+        """
+        with pytest.raises(ValueError, match=r"decisions\.ranking\.staleness_factors\.stale"):
+            _load_ranking_weights({"decisions": {"ranking": {"staleness_factors": {"stale": "not-numeric"}}}})
+        with pytest.raises(
+            ValueError,
+            match=r"decisions\.ranking\.assessment_relation_weights\.supports",
+        ):
+            _load_ranking_weights(
+                {"decisions": {"ranking": {"assessment_relation_weights": {"supports": ["list-not-scalar"]}}}}
+            )
+        # A valid numeric-string override still coerces cleanly; strict float()
+        # is the contract, not strict type-identity.
+        coerced = _load_ranking_weights({"decisions": {"ranking": {"staleness_factors": {"stale": "0.9"}}}})
+        assert coerced.staleness_factors["stale"] == 0.9
+
     def test_rank_cap_levels_override_widens_candidate_gathering(self, ec_db):
         """Config cap_levels > 3 must widen _gather_candidates_by_files, not just the scorer.
 


### PR DESCRIPTION
## Summary
- v0.4.0 Feed the Loop **F3**. `[decisions.ranking]` TOML section makes the ranker's staleness factors, assessment relation weights, exact-file/git-commit weights, and directory proximity cap tunable per repo. Defaults unchanged.
- SessionStart hook, `ec_decision_related`, and `ec_decision_context` load repo config and inject a `RankingWeights` instance.
- Pins `score_breakdown` keys `{file_exact, file_proximity, assessment, diff_relevance, git_commit, quality, staleness_factor}` as an additive-only public contract via a new regression test.

## Design notes
- `RankingWeights` is a frozen dataclass, but `frozen=True` does **not** protect the inner `dict` fields. `_load_ranking_weights` therefore always returns a **fresh** instance — never the `_DEFAULT_RANKING_WEIGHTS` module singleton — so a caller mutating `weights.staleness_factors['fresh']` cannot contaminate subsequent rankings. Regression test: `test_load_ranking_weights_mutation_does_not_contaminate_singleton`.
- `directory_proximity_cap_levels` is propagated into `_gather_candidates_by_files` as well. A raised cap widens both the candidate pool **and** the scorer, so config changes take effect in ranking output rather than silently dropping at the gathering stage. Regression test: `test_rank_cap_levels_override_widens_candidate_gathering`.
- `[decisions.ranking]` deliberately separates from the upcoming `[decisions.quality]` (F1 outcome decay). Decision record: "F3: split [decisions.ranking] from [decisions.quality] config namespaces".

## Adversarial review
Reviewed by `codex-rescue`. Three PR-blocker findings + one important were all resolved in-branch before this PR opened:
1. Mutable singleton contamination → fresh instance per load.
2. `ec_decision_context()` ignored ranking config → now injects.
3. `_gather_candidates_by_files` hardcoded cap → now takes `cap_levels`.
4. Bare `float()`/`int()` coercion hid field names on error → `_coerce_ranking_float`/`_int` helpers name the offending config key.

## Test plan
- [x] `uv run pytest tests/test_decisions_core.py -v` — 112 passed (109 pre-existing + 8 new F3; one added above the header since the plan)
- [x] `uv run pytest` full suite — 1407 passed, 86 skipped
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format .` — no changes on F3 files
- [x] Decision records created during work: two new decisions in `ec` ledger (namespace split rationale; breakdown key contract)

## Dependencies
Blocks **F1** (#83, `[decisions.quality] recency_half_life_days`), **F2** (#84, extraction penalty), **F4** (#86, UserPromptSubmit async surfacing). Per plan, downstream Fs should wait for this to merge before starting.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)