### PR TITLE
chore(ci): reduce review-bot post-push noise (S4)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,10 @@ on:
       - "src/**/*.py"
       - "tests/**/*.py"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -39,8 +43,6 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: |
             /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-
-            IMPORTANT: This is an automated review triggered by a push event. Even if Claude has previously commented on this PR, you MUST still review it — new commits may have been pushed since the last review. Skip the "already reviewed" check entirely and always proceed with the review.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           use_sticky_comment: true

--- a/.github/workflows/tidy-pilot.yml
+++ b/.github/workflows/tidy-pilot.yml
@@ -9,6 +9,10 @@ permissions:
   pull-requests: write
   models: read
 
+concurrency:
+  group: tidy-pilot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   assess:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Review-bot post-push noise reduction (S4)** — `.github/workflows/claude-code-review.yml` and `tidy-pilot.yml` now set `concurrency: cancel-in-progress` keyed by PR number, so consecutive `synchronize` events cancel any in-flight review run instead of stacking (addresses the stale-commit race seen on PR #59). The explicit "Skip the already reviewed check entirely" prompt directive in claude-code-review.yml has also been removed, allowing claude-code-action's built-in dedup to suppress trivial re-reviews (e.g., the test-comment garbage on PR #55). `tidy-pilot.yml`'s prompt/script body is unchanged in this PR; same-pattern deeper hardening for the second bot is deferred to a follow-up. Tracks ec decisions `eaa24b32` (D.6 origin) and `e98f85a4` (v0.5.0 implement-not-wontfix commitment).
+
 ## [0.4.0] - 2026-04-17
 
 v0.4.0 deepens the decision-memory loop so outcome data flows into both ranking and extraction, and adds UserPromptSubmit as a new retrieval signal channel. No schema change — still v13.


### PR DESCRIPTION
## Summary

- Add `concurrency: cancel-in-progress` keyed by PR number to both `.github/workflows/claude-code-review.yml` and `tidy-pilot.yml`, so consecutive `synchronize` events cancel any in-flight run instead of stacking — directly addresses the stale-commit race seen on PR #59.
- Remove the explicit "Skip the already reviewed check entirely" prompt directive from `claude-code-review.yml`, allowing claude-code-action's built-in dedup to suppress trivial re-reviews (e.g., the test-comment garbage on PR #55).
- `tidy-pilot.yml`'s prompt body / `assess_pr.py` is unchanged in this PR; same-pattern deeper hardening for the second bot is deferred to a follow-up PR so review surface stays focused.

## Context

v0.4.0 retrospective quantified the post-push noise: claude[bot] was ~71% of comment volume, with two visible failure modes — PR #59's stale-commit race (review running against a SHA the next push had already obsoleted) and PR #55's test-comment garbage (forced re-review against `use_sticky_comment` defeating the dedup). v0.5.0 ROADMAP S4 is the minimum-change response targeting both root causes.

`use_sticky_comment: true` is intentionally retained — sticky is the comment-accumulation guard, not the noise source. Removing the prompt directive that *forced* a re-review every push lets the action's built-in already-reviewed check actually run; sticky then ensures the one allowed re-review overwrites instead of appending.

## Refs

- ec decision `eaa24b32` — D.6 origin (v0.4.0 retro finding)
- ec decision `e98f85a4` — v0.5.0 implement-not-wontfix commitment

## Test plan

- [x] YAML syntax: `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml')); yaml.safe_load(open('.github/workflows/tidy-pilot.yml'))"` passes.
- [ ] Confirm `main` branch protection required checks remain `lint` + `test` only (verified via `gh api repos/teslamint/entirecontext/branches/main/protection` during plan; review-bot run cancellations do not block merge).
- [ ] Post-merge self-verification: next real PR exercises the new `concurrency` policy automatically — same-repo `pull_request` event runs the workflow definition at the PR head SHA. Watch the GitHub Actions UI on that next PR to confirm consecutive pushes show one `cancelled` run + one fresh run rather than two parallel runs.

## Out of scope

- `tidy-pilot.yml` prompt / `assess_pr.py` deep hardening — follow-up PR.
- Post-push cooldown, paths-filter tightening — ROADMAP S4 stretch goals.
- S3 (`test/v0.5.0-s3-f4-subprocess-e2e`), S1 (`refactor/v0.5.0-s1-confirm-candidate-atomic`), S2 (`chore/v0.5.0-s2-autocommit-migration`) — separate PRs with their own plan sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)