### PR TITLE
feat(db,core): schema v14 — widen decision_outcomes CHECK to refined/replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Schema v14** — `decision_outcomes.outcome_type` CHECK constraint widened to accept `refined` and `replaced` values (previously only `confirmed`, `contradicted`, `partially_confirmed`, `evolved`). Enables `supersede_decision` auto-linkage to record `replaced` outcomes atomically.
+
 ## [0.5.0] - 2026-04-27
 
 v0.5.0 closes 3x-deferred correctness debt before adding new feature surface — zero new product features, zero schema changes. Still schema v13.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ cli/             business    SQLite     Claude Code   shadow branch
 
 **Per-repo DB**: `.entirecontext/db/local.db`
 **Global DB**: `~/.entirecontext/db/ec.db`
-**Schema version**: 13
+**Schema version**: 14
 
 Key tables: `projects`, `sessions`, `turns`, `turn_content`, `checkpoints`, `agents`, `events`, `assessments`, `assessment_relationships`, `attributions`, `embeddings`, `ast_symbols`, `sync_metadata`, `decisions`, `decision_candidates`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -201,7 +201,7 @@ def decision_stale(
 @decision_app.command("outcome")
 def decision_outcome(
     decision_id: str = typer.Argument(..., help="Decision ID"),
-    outcome: str = typer.Option(..., "--outcome", help="accepted|ignored|contradicted"),
+    outcome: str = typer.Option(..., "--outcome", help="accepted|ignored|contradicted|refined|replaced"),
     selection_id: Optional[str] = typer.Option(None, "--selection-id", help="Decision retrieval selection ID"),
     note: Optional[str] = typer.Option(None, "--note", help="Optional outcome note"),
 ):

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -100,6 +100,8 @@ def decision_show(decision_id: str = typer.Argument(..., help="Decision ID")):
         f" accepted={counts.get('accepted', 0)}"
         f" ignored={counts.get('ignored', 0)}"
         f" contradicted={counts.get('contradicted', 0)}"
+        f" refined={counts.get('refined', 0)}"
+        f" replaced={counts.get('replaced', 0)}"
         f" total={quality.get('total_outcomes', 0)}"
         f" score={quality.get('quality_score', 0.0)}"
     )

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -899,10 +899,12 @@ def apply_outcome_feedback_to_confidence(
 ) -> tuple[float, dict[str, Any]]:
     """Apply a confidence penalty when contradicted outcomes dominate history.
 
-    Penalty logic: if aggregated ``contradicted / total`` strictly exceeds
-    :data:`_OUTCOME_FEEDBACK_RATIO_THRESHOLD` (0.5) across the draft's files,
-    subtract ``penalty`` from ``confidence`` and clamp to ``[0.0, 1.0]``.
-    Otherwise return the input unchanged.
+    Penalty logic: if aggregated ``contradicted / scored_total`` strictly
+    exceeds :data:`_OUTCOME_FEEDBACK_RATIO_THRESHOLD` (0.5) across the draft's
+    files, subtract ``penalty`` from ``confidence`` and clamp to ``[0.0, 1.0]``.
+    ``scored_total`` counts accepted, ignored, and contradicted outcomes only;
+    refined/replaced are neutral and reported without diluting the penalty
+    denominator. Otherwise return the input unchanged.
 
     The returned breakdown always includes an ``outcome_feedback`` section
     (even when no penalty applied) so telemetry and UI can render a
@@ -912,8 +914,11 @@ def apply_outcome_feedback_to_confidence(
     contradicted = int(stats.get("contradicted", 0))
     accepted = int(stats.get("accepted", 0))
     ignored = int(stats.get("ignored", 0))
+    refined = int(stats.get("refined", 0))
+    replaced = int(stats.get("replaced", 0))
+    scored_total = accepted + ignored + contradicted
 
-    ratio = (contradicted / total) if total > 0 else 0.0
+    ratio = (contradicted / scored_total) if scored_total > 0 else 0.0
     applied = ratio > _OUTCOME_FEEDBACK_RATIO_THRESHOLD
     penalty_amount = penalty if applied else 0.0
     final = max(0.0, min(1.0, confidence - penalty_amount))
@@ -923,7 +928,10 @@ def apply_outcome_feedback_to_confidence(
         "contradicted": contradicted,
         "accepted": accepted,
         "ignored": ignored,
+        "refined": refined,
+        "replaced": replaced,
         "total": total,
+        "scored_total": scored_total,
         "ratio": round(ratio, 4),
         "ratio_threshold": _OUTCOME_FEEDBACK_RATIO_THRESHOLD,
         "penalty": round(penalty_amount, 4),

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -861,7 +861,7 @@ def get_file_outcome_stats(
     zeros so callers can disable the feedback path via config without a
     separate branch.
     """
-    zero: dict[str, int] = {"accepted": 0, "ignored": 0, "contradicted": 0, "total": 0}
+    zero: dict[str, int] = {"accepted": 0, "ignored": 0, "contradicted": 0, "refined": 0, "replaced": 0, "total": 0}
     if not file_paths or lookback_days <= 0:
         return zero
 

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -856,7 +856,7 @@ def get_file_outcome_stats(
     decision linked to multiple files in ``file_paths`` counts once per
     outcome).
 
-    Returns ``{"accepted": N, "ignored": N, "contradicted": N, "total": N}``
+    Returns ``{"accepted": N, "ignored": N, "contradicted": N, "refined": N, "replaced": N, "total": N}``
     (zeros when nothing matches). ``lookback_days <= 0`` short-circuits to
     zeros so callers can disable the feedback path via config without a
     separate branch.

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -884,7 +884,7 @@ def get_file_outcome_stats(
     for row in rows:
         ot = row["outcome_type"]
         n = int(row["n"] or 0)
-        if ot in ("accepted", "ignored", "contradicted"):
+        if ot in stats and ot != "total":
             stats[ot] = n
             stats["total"] += n
     return stats

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -891,6 +891,15 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
+        outcome_id = str(uuid4())
+        conn.execute(
+            """
+            INSERT INTO decision_outcomes (
+                id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
+            ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
+            """,
+            (outcome_id, old_full, f"auto: superseded by {new_full}", now),
+        )
     return get_decision(conn, old_full) or {}
 
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -891,15 +891,25 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
-        outcome_id = str(uuid4())
-        conn.execute(
-            """
-            INSERT INTO decision_outcomes (
-                id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
-            ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
-            """,
-            (outcome_id, old_full, f"auto: superseded by {new_full}", now),
-        )
+        existing_outcome = conn.execute(
+            "SELECT id FROM decision_outcomes WHERE decision_id = ? AND outcome_type = 'replaced'",
+            (old_full,),
+        ).fetchone()
+        if existing_outcome:
+            conn.execute(
+                "UPDATE decision_outcomes SET note = ?, created_at = ? WHERE id = ?",
+                (f"auto: superseded by {new_full}", now, existing_outcome["id"]),
+            )
+        else:
+            outcome_id = str(uuid4())
+            conn.execute(
+                """
+                INSERT INTO decision_outcomes (
+                    id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
+                ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
+                """,
+                (outcome_id, old_full, f"auto: superseded by {new_full}", now),
+            )
     return get_decision(conn, old_full) or {}
 
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -39,7 +39,7 @@ class _UnsetType:
 _UNSET = _UnsetType()
 
 VALID_STALENESS = frozenset(("fresh", "stale", "superseded", "contradicted"))
-VALID_DECISION_OUTCOME_TYPES = frozenset(("accepted", "ignored", "contradicted"))
+VALID_DECISION_OUTCOME_TYPES = frozenset(("accepted", "ignored", "contradicted", "refined", "replaced"))
 # relation_type is part of identity so one decision-assessment pair can keep
 # multiple typed links (e.g. informed_by + contradicts) when historically true.
 VALID_DECISION_ASSESSMENT_RELATION_TYPES = frozenset(("supports", "informed_by", "contradicts", "supersedes"))
@@ -155,12 +155,16 @@ def calculate_decision_quality_score(
 
     Legacy formula (1-arg or ``decayed_counts=None``):
         accepted * 1.0 - ignored * 0.5 - contradicted * 2.0, clamped to [-4, +4].
+        refined * 0 — display/audit only, does not affect score.
+        replaced * 0 — paired with staleness superseded factor, no double-penalty.
 
     When ``decayed_counts`` is provided, the same linear combination runs over
     the already time-decayed totals instead. ``counts`` still drives the volume
     smoother so the rank is not swung by a single fresh outcome: if the number
     of real outcomes is below ``min_volume``, the decayed score is linearly
-    attenuated toward zero by ``total / min_volume``.
+    attenuated toward zero by ``total / min_volume``. Volume smoother only counts
+    the three scored types (accepted, ignored, contradicted); refined/replaced
+    are excluded so they cannot dilute the smoother without affecting the score.
     """
     if decayed_counts is None:
         raw_score = (

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -891,14 +891,14 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
-        existing_outcome = conn.execute(
-            "SELECT id FROM decision_outcomes WHERE decision_id = ? AND outcome_type = 'replaced'",
+        existing_auto_outcome = conn.execute(
+            "SELECT id FROM decision_outcomes WHERE decision_id = ? AND outcome_type = 'replaced' AND note LIKE 'auto:%'",
             (old_full,),
         ).fetchone()
-        if existing_outcome:
+        if existing_auto_outcome:
             conn.execute(
                 "UPDATE decision_outcomes SET note = ?, created_at = ? WHERE id = ?",
-                (f"auto: superseded by {new_full}", now, existing_outcome["id"]),
+                (f"auto: superseded by {new_full}", now, existing_auto_outcome["id"]),
             )
         else:
             outcome_id = str(uuid4())

--- a/src/entirecontext/db/migrations/__init__.py
+++ b/src/entirecontext/db/migrations/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 def get_migrations() -> dict[int, list]:
     migrations: dict[int, list] = {}
-    for version in range(2, 14):
+    for version in range(2, 15):
         # version is a hardcoded bounded integer from range(), not user input
         module = import_module(
             f".v{version:03d}", __name__

--- a/src/entirecontext/db/migrations/v014.py
+++ b/src/entirecontext/db/migrations/v014.py
@@ -1,0 +1,57 @@
+"""Migration to schema v14 — widen decision_outcomes.outcome_type CHECK to include 'refined', 'replaced'."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+_WIDENED_DDL = """
+        CREATE TABLE decision_outcomes_new (
+            id TEXT PRIMARY KEY,
+            decision_id TEXT NOT NULL,
+            retrieval_selection_id TEXT,
+            session_id TEXT,
+            turn_id TEXT,
+            outcome_type TEXT NOT NULL CHECK(outcome_type IN ('accepted', 'ignored', 'contradicted', 'refined', 'replaced')),
+            note TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (decision_id) REFERENCES decisions(id) ON DELETE CASCADE,
+            FOREIGN KEY (retrieval_selection_id) REFERENCES retrieval_selections(id) ON DELETE SET NULL,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+            FOREIGN KEY (turn_id) REFERENCES turns(id) ON DELETE SET NULL
+        )
+"""
+
+
+def _rebuild_decision_outcomes(conn: sqlite3.Connection) -> None:
+    existing = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='decision_outcomes'").fetchone()
+
+    if existing is None:
+        conn.execute(_WIDENED_DDL.replace("decision_outcomes_new", "decision_outcomes"))
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_outcomes_decision_id ON decision_outcomes(decision_id)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_decision_outcomes_selection_id ON decision_outcomes(retrieval_selection_id)"
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_outcomes_outcome_type ON decision_outcomes(outcome_type)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_decision_outcomes_created_at ON decision_outcomes(created_at DESC)"
+        )
+        return
+
+    conn.execute(_WIDENED_DDL)
+    conn.execute(
+        "INSERT INTO decision_outcomes_new SELECT id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at FROM decision_outcomes"
+    )
+    conn.execute("DROP TABLE decision_outcomes")
+    conn.execute("ALTER TABLE decision_outcomes_new RENAME TO decision_outcomes")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_outcomes_decision_id ON decision_outcomes(decision_id)")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_outcomes_selection_id ON decision_outcomes(retrieval_selection_id)"
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_outcomes_outcome_type ON decision_outcomes(outcome_type)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_outcomes_created_at ON decision_outcomes(created_at DESC)")
+
+
+MIGRATION_STEPS = [
+    _rebuild_decision_outcomes,
+]

--- a/src/entirecontext/db/schema.py
+++ b/src/entirecontext/db/schema.py
@@ -1,6 +1,6 @@
 """Database schema definitions for EntireContext."""
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 # Minimum SQLite version required (for JSON functions)
 MIN_SQLITE_VERSION = "3.38.0"
@@ -275,7 +275,7 @@ CREATE TABLE IF NOT EXISTS decision_outcomes (
     retrieval_selection_id TEXT,
     session_id TEXT,
     turn_id TEXT,
-    outcome_type TEXT NOT NULL CHECK(outcome_type IN ('accepted', 'ignored', 'contradicted')),
+    outcome_type TEXT NOT NULL CHECK(outcome_type IN ('accepted', 'ignored', 'contradicted', 'refined', 'replaced')),
     note TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     FOREIGN KEY (decision_id) REFERENCES decisions(id) ON DELETE CASCADE,

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -160,9 +160,9 @@ def _format_decision_entry(d: dict, stale: bool = False) -> str:
         )
     quality = d.get("quality_summary") or {}
     counts = quality.get("counts") or {}
-    if any(counts.get(k, 0) > 0 for k in ("accepted", "ignored", "contradicted")):
+    if any(counts.get(k, 0) > 0 for k in ("accepted", "ignored", "contradicted", "refined", "replaced")):
         outcome_parts = []
-        for k in ("accepted", "ignored", "contradicted"):
+        for k in ("accepted", "ignored", "contradicted", "refined", "replaced"):
             v = counts.get(k, 0)
             if v > 0:
                 outcome_parts.append(f"{v} {k}")

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -372,7 +372,7 @@ async def ec_decision_outcome(
     session_id: str | None = None,
     turn_id: str | None = None,
 ) -> str:
-    """Record the outcome of a decision (accepted, ignored, or contradicted).
+    """Record the outcome of a decision (accepted, ignored, contradicted, refined, or replaced).
 
     Links the outcome to a retrieval selection when selection_id is provided,
     enabling quality tracking. Falls back to the current session context when

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -287,6 +287,90 @@ class TestMigration:
         with pytest.raises(sqlite3.IntegrityError):
             db.execute("INSERT INTO sync_metadata (id, sync_status) VALUES (2, 'idle')")
 
+    def test_migrate_v13_to_v14_widens_outcome_check(self):
+        conn = get_memory_db()
+        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)")
+        conn.execute("INSERT INTO schema_version (version, description) VALUES (13, 'v13')")
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+        conn.execute("CREATE TABLE turns (id TEXT PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE retrieval_selections (id TEXT PRIMARY KEY, result_type TEXT, result_id TEXT, session_id TEXT, turn_id TEXT)"
+        )
+        conn.execute(
+            """
+            CREATE TABLE decisions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                rationale TEXT,
+                scope TEXT,
+                staleness_status TEXT NOT NULL DEFAULT 'fresh',
+                superseded_by_id TEXT,
+                rejected_alternatives TEXT,
+                supporting_evidence TEXT,
+                auto_promotion_reset_at TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                updated_at TEXT DEFAULT (datetime('now'))
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE decision_outcomes (
+                id TEXT PRIMARY KEY,
+                decision_id TEXT NOT NULL,
+                retrieval_selection_id TEXT,
+                session_id TEXT,
+                turn_id TEXT,
+                outcome_type TEXT NOT NULL CHECK(outcome_type IN ('accepted', 'ignored', 'contradicted')),
+                note TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                FOREIGN KEY (decision_id) REFERENCES decisions(id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute("INSERT INTO decisions (id, title) VALUES ('d1', 'Test decision')")
+        conn.execute("INSERT INTO decision_outcomes (id, decision_id, outcome_type) VALUES ('o1', 'd1', 'accepted')")
+        conn.execute("INSERT INTO decision_outcomes (id, decision_id, outcome_type) VALUES ('o2', 'd1', 'ignored')")
+        conn.commit()
+
+        check_and_migrate(conn)
+
+        assert get_current_version(conn) == SCHEMA_VERSION
+
+        schema = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='decision_outcomes'"
+        ).fetchone()
+        assert schema is not None
+        assert "refined" in schema[0]
+        assert "replaced" in schema[0]
+
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='decision_outcomes'"
+            ).fetchall()
+        }
+        assert "idx_decision_outcomes_decision_id" in indexes
+        assert "idx_decision_outcomes_selection_id" in indexes
+        assert "idx_decision_outcomes_outcome_type" in indexes
+        assert "idx_decision_outcomes_created_at" in indexes
+
+        preserved = conn.execute("SELECT id, outcome_type FROM decision_outcomes ORDER BY id").fetchall()
+        assert len(preserved) == 2
+        assert preserved[0]["id"] == "o1"
+        assert preserved[0]["outcome_type"] == "accepted"
+        assert preserved[1]["id"] == "o2"
+        assert preserved[1]["outcome_type"] == "ignored"
+
+        conn.execute("INSERT INTO decision_outcomes (id, decision_id, outcome_type) VALUES ('o3', 'd1', 'refined')")
+        conn.execute("INSERT INTO decision_outcomes (id, decision_id, outcome_type) VALUES ('o4', 'd1', 'replaced')")
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("INSERT INTO decision_outcomes (id, decision_id, outcome_type) VALUES ('o5', 'd1', 'invalid')")
+
+        conn.close()
+
     def test_migration_v6_to_v7_recreates_telemetry_tables(self):
         conn = get_memory_db()
         init_schema(conn)

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1106,6 +1106,35 @@ class TestOutcomeFeedbackPenalty:
         assert new_breakdown["outcome_feedback"]["applied"] is False
         assert new_breakdown["outcome_feedback"]["ratio"] == pytest.approx(0.5)
 
+    def test_outcome_feedback_penalty_excludes_neutral_outcomes_from_ratio(self, ec_repo, ec_db):
+        """Refined/replaced outcomes are reported but do not dilute the penalty ratio."""
+        from entirecontext.core.decision_extraction import (
+            apply_outcome_feedback_to_confidence,
+            get_file_outcome_stats,
+        )
+
+        self._seed_decision_with_outcomes(
+            ec_db,
+            title="Risky decision with neutral follow-up",
+            file_paths=["src/service/payment.py"],
+            outcome_types=["contradicted", "contradicted", "accepted", "refined", "replaced", "replaced"],
+        )
+
+        stats = get_file_outcome_stats(ec_db, ["src/service/payment.py"], lookback_days=60)
+        assert stats["contradicted"] == 2
+        assert stats["accepted"] == 1
+        assert stats["refined"] == 1
+        assert stats["replaced"] == 2
+        assert stats["total"] == 6
+
+        breakdown = {"final": 0.60, "penalties": {}}
+        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(0.60, breakdown, stats, penalty=0.15)
+        assert adjusted == pytest.approx(0.45)
+        assert new_breakdown["outcome_feedback"]["applied"] is True
+        assert new_breakdown["outcome_feedback"]["total"] == 6
+        assert new_breakdown["outcome_feedback"]["scored_total"] == 3
+        assert new_breakdown["outcome_feedback"]["ratio"] == pytest.approx(2 / 3, abs=1e-4)
+
     def test_outcome_feedback_sql_path_normalization(self, ec_repo, ec_db):
         """Stored ``./src/...`` and backslash paths must match normalized inputs."""
         from entirecontext.core.decision_extraction import get_file_outcome_stats

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1070,7 +1070,7 @@ class TestOutcomeFeedbackPenalty:
         )
 
         stats = get_file_outcome_stats(ec_db, ["src/service/payment.py"], lookback_days=0)
-        assert stats == {"accepted": 0, "ignored": 0, "contradicted": 0, "total": 0}
+        assert stats == {"accepted": 0, "ignored": 0, "contradicted": 0, "refined": 0, "replaced": 0, "total": 0}
 
         breakdown = {"final": 0.60, "penalties": {}}
         adjusted, new_breakdown = apply_outcome_feedback_to_confidence(0.60, breakdown, stats, penalty=0.15)

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1133,6 +1133,25 @@ class TestOutcomeFeedbackPenalty:
         assert stats["accepted"] == 1
         assert stats["total"] == 3
 
+    def test_outcome_feedback_counts_refined_and_replaced(self, ec_repo, ec_db):
+        """refined and replaced outcomes must appear as non-zero in get_file_outcome_stats."""
+        from entirecontext.core.decision_extraction import get_file_outcome_stats
+
+        self._seed_decision_with_outcomes(
+            ec_db,
+            title="Refined decision",
+            file_paths=["src/service/payment.py"],
+            outcome_types=["refined", "refined", "replaced"],
+        )
+
+        stats = get_file_outcome_stats(ec_db, ["src/service/payment.py"], lookback_days=60)
+        assert stats["refined"] == 2
+        assert stats["replaced"] == 1
+        assert stats["total"] == 3
+        assert stats["accepted"] == 0
+        assert stats["ignored"] == 0
+        assert stats["contradicted"] == 0
+
     def test_outcome_feedback_lookback_cutoff(self, ec_repo, ec_db):
         """Outcomes older than the lookback window must be excluded."""
         from entirecontext.core.decision_extraction import get_file_outcome_stats

--- a/tests/test_decisions_cli.py
+++ b/tests/test_decisions_cli.py
@@ -323,6 +323,34 @@ class TestDecisionsCLI:
         assert conn.closed is True
 
 
+class TestDecisionOutcomeValues:
+    @pytest.mark.parametrize("outcome_value", ["accepted", "ignored", "contradicted", "refined", "replaced"])
+    def test_outcome_accepts_all_five_values(self, ec_repo, monkeypatch, outcome_value):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title=f"Test {outcome_value}")
+        conn.close()
+
+        result = runner.invoke(
+            app,
+            ["decision", "outcome", decision["id"][:12], "--outcome", outcome_value],
+        )
+        assert result.exit_code == 0
+        assert "Recorded decision outcome:" in result.stdout
+
+    def test_outcome_rejects_unknown_value(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Test reject")
+        conn.close()
+
+        result = runner.invoke(
+            app,
+            ["decision", "outcome", decision["id"][:12], "--outcome", "unknown_type"],
+        )
+        assert result.exit_code == 1
+
+
 class TestDecisionsCLIExtended:
     def test_decision_update_success(self, ec_repo, monkeypatch):
         monkeypatch.chdir(ec_repo)

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -345,6 +345,54 @@ class TestDecisionsCore:
                 turn_id=turn_one["id"],
             )
 
+    def test_quality_score_unaffected_by_refined_replaced(self, ec_db):
+        from entirecontext.core.decisions import calculate_decision_quality_score
+
+        counts_3 = {"accepted": 2, "ignored": 1, "contradicted": 0}
+        counts_5 = {"accepted": 2, "ignored": 1, "contradicted": 0, "refined": 3, "replaced": 2}
+
+        assert calculate_decision_quality_score(counts_3) == calculate_decision_quality_score(counts_5)
+
+        d = create_decision(ec_db, title="Quality regression")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+        record_decision_outcome(ec_db, d["id"], "ignored")
+        score_before = get_decision_quality_summary(ec_db, d["id"])["quality_score"]
+
+        record_decision_outcome(ec_db, d["id"], "refined")
+        record_decision_outcome(ec_db, d["id"], "replaced")
+        score_after = get_decision_quality_summary(ec_db, d["id"])["quality_score"]
+
+        assert score_before == score_after
+
+    def test_quality_summary_includes_all_five_keys(self, ec_db):
+        d = create_decision(ec_db, title="Five keys")
+        record_decision_outcome(ec_db, d["id"], "refined")
+        summary = get_decision_quality_summary(ec_db, d["id"])
+        counts = summary["counts"]
+        for key in ("accepted", "ignored", "contradicted", "refined", "replaced"):
+            assert key in counts, f"missing key: {key}"
+        assert counts["refined"] == 1
+
+    def test_quality_score_accepted_weight_is_one(self):
+        from entirecontext.core.decisions import calculate_decision_quality_score
+
+        assert calculate_decision_quality_score({"accepted": 1}) == 1.0
+        assert calculate_decision_quality_score({"accepted": 1, "refined": 10, "replaced": 10}) == 1.0
+
+    def test_record_outcome_accepts_all_five_values(self, ec_db):
+        d = create_decision(ec_db, title="All five")
+        for ot in ("accepted", "ignored", "refined", "replaced"):
+            record_decision_outcome(ec_db, d["id"], ot)
+        outcomes = list_decision_outcomes(ec_db, d["id"])
+        outcome_types = {o["outcome_type"] for o in outcomes}
+        assert {"accepted", "ignored", "refined", "replaced"}.issubset(outcome_types)
+
+    def test_record_outcome_rejects_invalid_value(self, ec_db):
+        d = create_decision(ec_db, title="Reject invalid")
+        with pytest.raises(ValueError, match="Invalid outcome_type"):
+            record_decision_outcome(ec_db, d["id"], "unknown")
+
     def test_rank_related_decisions_applies_quality_adjustment(self, ec_db):
         promoted = create_decision(ec_db, title="Promoted")
         demoted = create_decision(ec_db, title="Demoted")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -536,6 +536,26 @@ class TestSupersedeDecision:
         assert row["staleness_status"] == "superseded"
         assert row["superseded_by_id"] == new["id"]
 
+    def test_re_supersede_updates_outcome_without_duplicates(self, ec_db):
+        old = create_decision(ec_db, title="Old")
+        b = create_decision(ec_db, title="B")
+        c = create_decision(ec_db, title="C")
+
+        supersede_decision(ec_db, old["id"], b["id"])
+        supersede_decision(ec_db, old["id"], c["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type, note FROM decision_outcomes WHERE decision_id = ?",
+            (old["id"],),
+        ).fetchall()
+        assert len(outcomes) == 1
+        assert c["id"] in outcomes[0]["note"]
+
+        row = ec_db.execute(
+            "SELECT superseded_by_id FROM decisions WHERE id = ?", (old["id"],)
+        ).fetchone()
+        assert row["superseded_by_id"] == c["id"]
+
     def test_supersede_replaced_outcome_rolled_back_on_cycle(self, ec_db):
         a = create_decision(ec_db, title="A")
         b = create_decision(ec_db, title="B")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -382,11 +382,11 @@ class TestDecisionsCore:
 
     def test_record_outcome_accepts_all_five_values(self, ec_db):
         d = create_decision(ec_db, title="All five")
-        for ot in ("accepted", "ignored", "refined", "replaced"):
+        for ot in ("accepted", "ignored", "contradicted", "refined", "replaced"):
             record_decision_outcome(ec_db, d["id"], ot)
         outcomes = list_decision_outcomes(ec_db, d["id"])
         outcome_types = {o["outcome_type"] for o in outcomes}
-        assert {"accepted", "ignored", "refined", "replaced"}.issubset(outcome_types)
+        assert {"accepted", "ignored", "contradicted", "refined", "replaced"}.issubset(outcome_types)
 
     def test_record_outcome_rejects_invalid_value(self, ec_db):
         d = create_decision(ec_db, title="Reject invalid")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -556,6 +556,25 @@ class TestSupersedeDecision:
         ).fetchone()
         assert row["superseded_by_id"] == c["id"]
 
+    def test_supersede_preserves_user_authored_replaced_note(self, ec_db):
+        old = create_decision(ec_db, title="Old")
+        new1 = create_decision(ec_db, title="New1")
+        new2 = create_decision(ec_db, title="New2")
+
+        record_decision_outcome(ec_db, old["id"], "replaced", note="manual: deprecated by design")
+        supersede_decision(ec_db, old["id"], new1["id"])
+        supersede_decision(ec_db, old["id"], new2["id"])
+
+        outcomes = list_decision_outcomes(ec_db, old["id"])
+        replaced = [o for o in outcomes if o["outcome_type"] == "replaced"]
+        user_notes = [o for o in replaced if not o["note"].startswith("auto:")]
+        auto_notes = [o for o in replaced if o["note"].startswith("auto:")]
+
+        assert len(user_notes) == 1
+        assert user_notes[0]["note"] == "manual: deprecated by design"
+        assert len(auto_notes) == 1
+        assert new2["id"] in auto_notes[0]["note"]
+
     def test_supersede_replaced_outcome_rolled_back_on_cycle(self, ec_db):
         a = create_decision(ec_db, title="A")
         b = create_decision(ec_db, title="B")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -515,6 +515,41 @@ class TestSupersedeDecision:
         assert row["staleness_status"] == "fresh"
         assert row["superseded_by_id"] is None
 
+    def test_supersede_writes_replaced_outcome_atomically(self, ec_db):
+        old = create_decision(ec_db, title="Old approach")
+        new = create_decision(ec_db, title="New approach")
+
+        supersede_decision(ec_db, old["id"], new["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type, note FROM decision_outcomes WHERE decision_id = ? ORDER BY created_at DESC",
+            (old["id"],),
+        ).fetchall()
+        assert len(outcomes) == 1
+        assert outcomes[0]["outcome_type"] == "replaced"
+        assert new["id"] in outcomes[0]["note"]
+
+        row = ec_db.execute(
+            "SELECT staleness_status, superseded_by_id FROM decisions WHERE id = ?",
+            (old["id"],),
+        ).fetchone()
+        assert row["staleness_status"] == "superseded"
+        assert row["superseded_by_id"] == new["id"]
+
+    def test_supersede_replaced_outcome_rolled_back_on_cycle(self, ec_db):
+        a = create_decision(ec_db, title="A")
+        b = create_decision(ec_db, title="B")
+        supersede_decision(ec_db, a["id"], b["id"])
+
+        with pytest.raises(ValueError, match="cycle"):
+            supersede_decision(ec_db, b["id"], a["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type FROM decision_outcomes WHERE decision_id = ?",
+            (b["id"],),
+        ).fetchall()
+        assert len(outcomes) == 0
+
 
 class TestUnlinkDecision:
     def test_unlink_file(self, ec_db):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1213,6 +1213,15 @@ class TestMCPDecisionTools:
         assert result["retrieval_selection_id"] == selection["id"]
         assert result["outcome_type"] == "accepted"
 
+    @pytest.mark.parametrize("outcome_value", ["accepted", "ignored", "contradicted", "refined", "replaced"])
+    def test_decision_outcome_accepts_all_five_values(self, mock_repo_db, outcome_value):
+        from entirecontext.core.decisions import create_decision
+        from entirecontext.mcp.server import ec_decision_outcome
+
+        decision = create_decision(mock_repo_db, title=f"MCP outcome {outcome_value}")
+        result = json.loads(asyncio.run(ec_decision_outcome(decision["id"][:12], outcome_value)))
+        assert result["outcome_type"] == outcome_value
+
     def test_decision_outcome_rejects_non_decision_selection(self, mock_repo_db):
         from entirecontext.core.decisions import create_decision
         from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection


### PR DESCRIPTION
## Summary

- `SCHEMA_VERSION` 13 → 14: `decision_outcomes.outcome_type` CHECK constraint widens from 3 to 5 values (`accepted`, `ignored`, `contradicted`, `refined`, `replaced`) via SQLite-safe table rebuild migration (`v014.py`)
- `VALID_DECISION_OUTCOME_TYPES` constant updated — all callers validate against it, no scattered hardcoding
- `calculate_decision_quality_score` docstring explicitly documents `refined * 0` and `replaced * 0` contract; volume smoother excludes them
- `get_file_outcome_stats` zero-fill widens to 5 keys; `_format_decision_entry` display loop widens to 5 values

**Breaking**: schema v14 is forward-only. Downgrading to v13 with `refined`/`replaced` rows present is unsupported.

## Test plan

- [x] `test_migrate_v13_to_v14_widens_outcome_check`: rebuild preserves rows + indexes, accepts new values, rejects unknown
- [x] Quality score regression: mixed 5-type set == equivalent 3-type set
- [x] `accepted * 1.0` invariant holds with large `refined`/`replaced` counts
- [x] `record_decision_outcome` accepts all 5 values; rejects unknown
- [x] Intermediate-schema tests (v11→current) remain clean via table-missing branch in v014

🤖 Generated with [Claude Code](https://claude.com/claude-code)