### PR TITLE
feat(core,cli,mcp): recording paths + supersede→replaced auto-linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Schema v14** — `decision_outcomes.outcome_type` CHECK constraint widened to accept `refined` and `replaced` values (previously only `confirmed`, `contradicted`, `partially_confirmed`, `evolved`). Enables `supersede_decision` auto-linkage to record `replaced` outcomes atomically.
+
 ## [0.5.0] - 2026-04-27
 
 v0.5.0 closes 3x-deferred correctness debt before adding new feature surface — zero new product features, zero schema changes. Still schema v13.

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -201,7 +201,7 @@ def decision_stale(
 @decision_app.command("outcome")
 def decision_outcome(
     decision_id: str = typer.Argument(..., help="Decision ID"),
-    outcome: str = typer.Option(..., "--outcome", help="accepted|ignored|contradicted"),
+    outcome: str = typer.Option(..., "--outcome", help="accepted|ignored|contradicted|refined|replaced"),
     selection_id: Optional[str] = typer.Option(None, "--selection-id", help="Decision retrieval selection ID"),
     note: Optional[str] = typer.Option(None, "--note", help="Optional outcome note"),
 ):

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -891,6 +891,15 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
+        outcome_id = str(uuid4())
+        conn.execute(
+            """
+            INSERT INTO decision_outcomes (
+                id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
+            ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
+            """,
+            (outcome_id, old_full, f"auto: superseded by {new_full}", now),
+        )
     return get_decision(conn, old_full) or {}
 
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -891,15 +891,25 @@ def supersede_decision(conn, old_decision_id: str, new_decision_id: str) -> dict
             "UPDATE decisions SET staleness_status = 'superseded', superseded_by_id = ?, updated_at = ? WHERE id = ?",
             (new_full, now, old_full),
         )
-        outcome_id = str(uuid4())
-        conn.execute(
-            """
-            INSERT INTO decision_outcomes (
-                id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
-            ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
-            """,
-            (outcome_id, old_full, f"auto: superseded by {new_full}", now),
-        )
+        existing_outcome = conn.execute(
+            "SELECT id FROM decision_outcomes WHERE decision_id = ? AND outcome_type = 'replaced'",
+            (old_full,),
+        ).fetchone()
+        if existing_outcome:
+            conn.execute(
+                "UPDATE decision_outcomes SET note = ?, created_at = ? WHERE id = ?",
+                (f"auto: superseded by {new_full}", now, existing_outcome["id"]),
+            )
+        else:
+            outcome_id = str(uuid4())
+            conn.execute(
+                """
+                INSERT INTO decision_outcomes (
+                    id, decision_id, retrieval_selection_id, session_id, turn_id, outcome_type, note, created_at
+                ) VALUES (?, ?, NULL, NULL, NULL, 'replaced', ?, ?)
+                """,
+                (outcome_id, old_full, f"auto: superseded by {new_full}", now),
+            )
     return get_decision(conn, old_full) or {}
 
 

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -372,7 +372,7 @@ async def ec_decision_outcome(
     session_id: str | None = None,
     turn_id: str | None = None,
 ) -> str:
-    """Record the outcome of a decision (accepted, ignored, or contradicted).
+    """Record the outcome of a decision (accepted, ignored, contradicted, refined, or replaced).
 
     Links the outcome to a retrieval selection when selection_id is provided,
     enabling quality tracking. Falls back to the current session context when

--- a/tests/test_decisions_cli.py
+++ b/tests/test_decisions_cli.py
@@ -323,6 +323,34 @@ class TestDecisionsCLI:
         assert conn.closed is True
 
 
+class TestDecisionOutcomeValues:
+    @pytest.mark.parametrize("outcome_value", ["accepted", "ignored", "contradicted", "refined", "replaced"])
+    def test_outcome_accepts_all_five_values(self, ec_repo, monkeypatch, outcome_value):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title=f"Test {outcome_value}")
+        conn.close()
+
+        result = runner.invoke(
+            app,
+            ["decision", "outcome", decision["id"][:12], "--outcome", outcome_value],
+        )
+        assert result.exit_code == 0
+        assert "Recorded decision outcome:" in result.stdout
+
+    def test_outcome_rejects_unknown_value(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Test reject")
+        conn.close()
+
+        result = runner.invoke(
+            app,
+            ["decision", "outcome", decision["id"][:12], "--outcome", "unknown_type"],
+        )
+        assert result.exit_code == 1
+
+
 class TestDecisionsCLIExtended:
     def test_decision_update_success(self, ec_repo, monkeypatch):
         monkeypatch.chdir(ec_repo)

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -536,6 +536,26 @@ class TestSupersedeDecision:
         assert row["staleness_status"] == "superseded"
         assert row["superseded_by_id"] == new["id"]
 
+    def test_re_supersede_updates_outcome_without_duplicates(self, ec_db):
+        old = create_decision(ec_db, title="Old")
+        b = create_decision(ec_db, title="B")
+        c = create_decision(ec_db, title="C")
+
+        supersede_decision(ec_db, old["id"], b["id"])
+        supersede_decision(ec_db, old["id"], c["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type, note FROM decision_outcomes WHERE decision_id = ?",
+            (old["id"],),
+        ).fetchall()
+        assert len(outcomes) == 1
+        assert c["id"] in outcomes[0]["note"]
+
+        row = ec_db.execute(
+            "SELECT superseded_by_id FROM decisions WHERE id = ?", (old["id"],)
+        ).fetchone()
+        assert row["superseded_by_id"] == c["id"]
+
     def test_supersede_replaced_outcome_rolled_back_on_cycle(self, ec_db):
         a = create_decision(ec_db, title="A")
         b = create_decision(ec_db, title="B")

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -515,6 +515,41 @@ class TestSupersedeDecision:
         assert row["staleness_status"] == "fresh"
         assert row["superseded_by_id"] is None
 
+    def test_supersede_writes_replaced_outcome_atomically(self, ec_db):
+        old = create_decision(ec_db, title="Old approach")
+        new = create_decision(ec_db, title="New approach")
+
+        supersede_decision(ec_db, old["id"], new["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type, note FROM decision_outcomes WHERE decision_id = ? ORDER BY created_at DESC",
+            (old["id"],),
+        ).fetchall()
+        assert len(outcomes) == 1
+        assert outcomes[0]["outcome_type"] == "replaced"
+        assert new["id"] in outcomes[0]["note"]
+
+        row = ec_db.execute(
+            "SELECT staleness_status, superseded_by_id FROM decisions WHERE id = ?",
+            (old["id"],),
+        ).fetchone()
+        assert row["staleness_status"] == "superseded"
+        assert row["superseded_by_id"] == new["id"]
+
+    def test_supersede_replaced_outcome_rolled_back_on_cycle(self, ec_db):
+        a = create_decision(ec_db, title="A")
+        b = create_decision(ec_db, title="B")
+        supersede_decision(ec_db, a["id"], b["id"])
+
+        with pytest.raises(ValueError, match="cycle"):
+            supersede_decision(ec_db, b["id"], a["id"])
+
+        outcomes = ec_db.execute(
+            "SELECT outcome_type FROM decision_outcomes WHERE decision_id = ?",
+            (b["id"],),
+        ).fetchall()
+        assert len(outcomes) == 0
+
 
 class TestUnlinkDecision:
     def test_unlink_file(self, ec_db):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1213,6 +1213,15 @@ class TestMCPDecisionTools:
         assert result["retrieval_selection_id"] == selection["id"]
         assert result["outcome_type"] == "accepted"
 
+    @pytest.mark.parametrize("outcome_value", ["accepted", "ignored", "contradicted", "refined", "replaced"])
+    def test_decision_outcome_accepts_all_five_values(self, mock_repo_db, outcome_value):
+        from entirecontext.core.decisions import create_decision
+        from entirecontext.mcp.server import ec_decision_outcome
+
+        decision = create_decision(mock_repo_db, title=f"MCP outcome {outcome_value}")
+        result = json.loads(asyncio.run(ec_decision_outcome(decision["id"][:12], outcome_value)))
+        assert result["outcome_type"] == outcome_value
+
     def test_decision_outcome_rejects_non_decision_selection(self, mock_repo_db):
         from entirecontext.core.decisions import create_decision
         from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection


### PR DESCRIPTION
## Summary

- `supersede_decision` now writes a `replaced` outcome row inside the same `with transaction(conn):` boundary as `staleness_status='superseded'` + `superseded_by_id` update — automatic audit trail with note `"auto: superseded by <new_id>"`
- CLI `ec decision outcome --outcome` help text lists all 5 values
- MCP `ec_decision_outcome` docstring lists all 5 values

Depends on #120 (schema v14).

## Test plan

- [x] `test_supersede_writes_replaced_outcome_atomically`: single call writes both staleness update and `replaced` outcome row
- [x] `test_supersede_replaced_outcome_rolled_back_on_cycle`: cycle error leaves `decision_outcomes` empty (atomicity proof)
- [x] CLI: all 5 outcome values accepted; unknown value exits 1
- [x] MCP: all 5 outcome values accepted (parametrized)
- [x] Pre-existing `ec_context_apply` accepted and SessionEnd ignored inference tests unchanged (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)