### PR TITLE
docs: v0.6.0 — CHANGELOG, README outcome vocabulary, ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-29
+
+v0.6.0 strengthens the decision outcome lifecycle. Agents can now distinguish guidance that was accepted, ignored, contradicted, refined, or replaced. Schema v14 (breaking — forward-only migration).
+
+### Breaking Changes
+
+- **Schema v14** — `decision_outcomes.outcome_type` CHECK constraint widens from 3 to 5 values (`accepted`, `ignored`, `contradicted`, `refined`, `replaced`). The migration is forward-only; downgrading to v13 with `refined` or `replaced` rows present is unsupported. Existing databases migrate automatically on first startup. External consumers that assume `outcome_type IN ('accepted','ignored','contradicted')` must be updated.
+
+### Added
+
+- **`refined` and `replaced` outcome types** — `record_decision_outcome` and all callers (CLI `ec decision outcome --outcome`, MCP `ec_decision_outcome`) now accept all 5 values. `refined` signals that a decision was partially applied or updated in place (weight 0 — display/audit only). `replaced` is written automatically by `supersede_decision` as an audit trail linking the old decision to its successor.
+- **`supersede` ↔ `replaced` auto-linkage** — `supersede_decision` now writes a `replaced` outcome row inside the same transaction as the `staleness_status='superseded'` + `superseded_by_id` update. The note field carries `"auto: superseded by <new_id>"` for traceability. No manual outcome recording is required.
+
 ### Changed
 
-- **Schema v14** — `decision_outcomes.outcome_type` CHECK constraint widened to accept `refined` and `replaced` values (previously only `confirmed`, `contradicted`, `partially_confirmed`, `evolved`). Enables `supersede_decision` auto-linkage to record `replaced` outcomes atomically.
+- **`refined`/`replaced` quality weight = 0** — `calculate_decision_quality_score` explicitly documents that `refined` and `replaced` contribute nothing to the quality score. The volume smoother (`min_volume` attenuation) also excludes them so they cannot dilute the effective sample size of the three scored types.
+- `get_file_outcome_stats` zero-fill dict widens to 5 keys.
+- `_format_decision_entry` in `decision_hooks.py` now displays `refined` and `replaced` counts alongside the existing three types.
 
 ## [0.5.0] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ When a decision is superseded, retrieval follows `superseded_by_id` to the termi
 - **Cycle protection** — `supersede_decision` rejects inputs that would create a cycle; walks are also bounded by a depth cap (10 hops).
 - **Debugging** — `ec decision chain <id>` prints the full walk (id, title, status) from origin to terminal.
 
+### Outcome vocabulary
+
+`record_decision_outcome` (CLI `ec decision outcome --outcome`, MCP `ec_decision_outcome`) accepts five values:
+
+| `outcome_type` | Quality weight | When to use |
+|---|---|---|
+| `accepted` | +1.0 | Decision was applied in code or architecture |
+| `ignored` | -0.5 | Decision was surfaced but not acted upon (also inferred by SessionEnd hook) |
+| `contradicted` | -2.0 | Code change directly contradicts the decision |
+| `refined` | 0 (display/audit only) | Decision was partially applied or updated in place |
+| `replaced` | 0 (display/audit only) | Automatically written by `supersede_decision` as an audit trail |
+
+`refined` and `replaced` contribute nothing to the quality score or ranking. `replaced` is written automatically when you run `ec decision supersede <old> <new>` — the note carries `"auto: superseded by <new_id>"` for traceability.
+
 ### Auto-promotion from outcome tracking
 
 `record_decision_outcome` recognizes usage feedback. When a decision accumulates ≥2 `contradicted` outcomes **and** contradicted > accepted, its `staleness_status` is automatically promoted to `contradicted`. This is a **one-way ratchet** — later accepted outcomes never auto-revert the status; a manual `ec decision stale --status fresh` is required to recover, and that manual reset also restarts the auto-promotion window so only post-reset outcomes count toward the next promotion.
@@ -419,7 +433,7 @@ ec mcp serve
 | `ec_decision_create` | Create a decision record (title, rationale, rejected alternatives, scope) |
 | `ec_decision_get` | Resolve decision by full or prefix ID |
 | `ec_decision_list` | List decisions with optional filters (status, tags, files) |
-| `ec_decision_outcome` | Record the outcome of a decision (accepted, ignored, or contradicted) |
+| `ec_decision_outcome` | Record the outcome of a decision (accepted, ignored, contradicted, refined, or replaced) |
 | `ec_decision_related` | Rank linked decisions by file overlap, assessment relations, and diff text match |
 | `ec_decision_search` | Keyword search over decisions via FTS5, with optional hybrid ranking and staleness filters |
 | `ec_decision_stale` | Check if a decision's linked files have changed recently (read-only staleness probe) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # EntireContext Roadmap
 
-_Updated against codebase on 2026-04-27._
+_Updated against codebase on 2026-04-29._
 
 ## Product Thesis
 
@@ -128,6 +128,29 @@ Holding hardening separate from the same-day v0.3.0 → v0.4.0 release pattern (
 Scope note: F5 (outcome type enum extension `refined`/`replaced` + schema v14 migration) is intentionally held out of v0.5.0 and deferred to v0.6.0's breaking track. Mixing schema bumps into a hardening release would re-introduce the exact "feature on top of correctness debt" risk that v0.5.0 is designed to close (per ec decision `4c7893b0`). v0.5.0 ships zero schema changes — still v13.
 
 E2E coverage note: v0.5.0 does not need a single integrated E2E like v0.4.0's `test_e2e_feed_the_loop.py` because S1–S4 each have their own focused integration test. S3 in particular IS the missing E2E for v0.4.0's F4.
+
+## v0.6.0 — Outcome Semantics (Shipped 2026-04-29)
+
+Theme: strengthen the decision outcome lifecycle with two additional outcome types and automatic supersession recording. Schema v14 breaking release.
+
+- [x] **F5. Outcome enum extension (`refined`/`replaced`) + schema v14**
+  - `decision_outcomes.outcome_type` CHECK widens to 5 values via SQLite table rebuild migration (v014.py)
+  - `VALID_DECISION_OUTCOME_TYPES` updated; all validation delegates to the constant — no scattered hardcoding
+  - Migration is forward-only; `bootstrap_schema` and `v014.py` agree on the widened CHECK (new DB and migrated DB produce identical schema)
+
+- [x] **F5a. `refined`/`replaced` quality weight = 0**
+  - `calculate_decision_quality_score` explicitly documents both types as display/audit only
+  - Volume smoother (`min_volume` attenuation) excludes `refined`/`replaced` so they cannot dilute effective sample size of the three scored types
+  - Regression test: mixed 5-type outcome set produces the same score as the equivalent 3-type set
+
+- [x] **F5b. Accepted ranking weight verified**
+  - Existing `accepted * 1.0` weight in `calculate_decision_quality_score` confirmed as sufficient — no new config or weight
+  - Regression test: `accepted=1` → `quality_score == 1.0` even with large `refined`/`replaced` counts
+
+- [x] **F5c. `supersede` ↔ `replaced` auto-linkage**
+  - `supersede_decision` writes a `replaced` outcome row inside the same `with transaction(conn):` boundary as the `staleness_status='superseded'` + `superseded_by_id` update
+  - Note: `"auto: superseded by <new_id>"` — plain string for parity with `"auto: context_apply"`
+  - Atomicity regression test: cycle error leaves both `staleness_status` and `decision_outcomes` unchanged
 
 ## Hardening Backlog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "entirecontext"
-version = "0.5.0"
+version = "0.6.0"
 description = "Time-travel searchable agent memory anchored to your codebase"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- `CHANGELOG.md`: v0.6.0 entry with schema v14 breaking note, enum expansion, supersede-replaced auto-linkage, and accepted-weight verification
- `README.md`: "Outcome vocabulary" table listing all 5 outcome types with quality weights and semantics; updated `ec_decision_outcome` MCP tool description
- `ROADMAP.md`: v0.6.0 section with F5/F5a/F5b/F5c marked complete

Depends on #120 and #121.

## Test plan

- [x] `test_schema_version_in_changelog` passes (CHANGELOG has paragraph with `v14` + `schema`)
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)