### PR TITLE
build: Sync uv.lock version after PR #122

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "entirecontext"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygments" },


### PR DESCRIPTION
## Summary

- Sync the editable entirecontext package entry in uv.lock from 0.5.0 to 0.6.0
- Follow up on PR #122, where pyproject.toml was bumped to 0.6.0 but uv.lock was left at 0.5.0
- Keep the lockfile diff scoped to the package version line only

## Test plan

- uv lock --check
- uv run --extra dev pytest
- uv build
- git diff --check

Refs PR #122