### PR TITLE
test(codex): enable repo before notify ingest to satisfy gate

### DIFF
--- a/tests/test_codex_ingest.py
+++ b/tests/test_codex_ingest.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from entirecontext.db import get_db
-from entirecontext.hooks.codex_ingest import ingest_codex_notify_event
+from entirecontext.hooks.codex_ingest import _save_state, ingest_codex_notify_event
 
 
 def _write_codex_session_file(codex_home: Path, *, session_id: str, cwd: str) -> Path:
@@ -42,10 +42,19 @@ def _write_codex_session_file(codex_home: Path, *, session_id: str, cwd: str) ->
     return path
 
 
+def _enable_codex_notify(repo: Path) -> None:
+    # Presence of the repo-local codex_notify.json marks the repo as
+    # Codex-notify-enabled (see codex_ingest._is_repo_enabled, which gates
+    # ingestion). The gate checks file existence only, so an empty state
+    # dict is sufficient.
+    _save_state(str(repo), {})
+
+
 def test_ingest_codex_notify_event_creates_session_and_turn(ec_repo):
     codex_home = ec_repo.parent / "codex-home"
     session_id = "s-codex-1"
     _write_codex_session_file(codex_home, session_id=session_id, cwd=str(ec_repo))
+    _enable_codex_notify(ec_repo)
 
     ingest_codex_notify_event(
         {"thread_id": session_id, "cwd": str(ec_repo), "codex_home": str(codex_home)},
@@ -70,6 +79,7 @@ def test_ingest_codex_notify_event_is_idempotent(ec_repo):
     codex_home = ec_repo.parent / "codex-home"
     session_id = "s-codex-2"
     _write_codex_session_file(codex_home, session_id=session_id, cwd=str(ec_repo))
+    _enable_codex_notify(ec_repo)
 
     payload = {"thread_id": session_id, "cwd": str(ec_repo), "codex_home": str(codex_home)}
     ingest_codex_notify_event(payload, payload_text="{}")


### PR DESCRIPTION
## Problem

CI on `main` is red. Run `26103144675` (push of `e27256a`, #130) fails `test (3.12)` and `test (3.13)`:

- `test_ingest_codex_notify_event_creates_session_and_turn` → `TypeError: 'NoneType' object is not subscriptable`
- `test_ingest_codex_notify_event_is_idempotent` → `assert 0 == 1`

The previous `main` commit `46eb9d3` (#119) had a green CI run, so this is a regression isolated to #130 (not schema v14).

## Root cause

`e27256a` added an intentional gate to `ingest_codex_notify_event`:

```python
if not _is_repo_enabled(repo_path):
    return
```

`_is_repo_enabled` requires the repo to be registered in the global `codex_notify.json` or have a repo-local one. The `ec_repo` fixture runs `init_project` but never enables Codex notify, so the function early-returns and writes no session/turn/turn_content. `e27256a` changed the source but did not update `tests/test_codex_ingest.py`.

## Fix

Test-only. The gate is a deliberate safety feature and is **unchanged**. The two tests now enable the repo (via the module's own repo-local state writer `_save_state`, fully isolated inside the `ec_repo` tmp fixture) before ingesting, reflecting the new precondition.

## Verification

- `uv run pytest tests/test_codex_ingest.py -q` → 2 passed
- Full suite `uv run pytest` → **1506 passed, 92 skipped, 0 failed**
- `uv run ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)