### PR TITLE
feat(decisions): v0.6.1 — rejected-alternative normalization + accepted-boost regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-20
+
+v0.6.1 hardens the rejected-alternatives data shape for decision memory. Legacy string entries are normalized to structured objects; a new `ec decision alternatives` sub-command group provides audit, normalize, and set operations. Extraction prompts now request structured reasons without inventing them.
+
+### Added
+
+- **Rejected-alternative normalization helpers** — `normalize_alternative`, `normalize_rejected_alternatives`, and `audit_rejected_alternatives` in `core/decisions.py`. Accepts legacy plain strings and already-structured `{"alternative", "reason"}` dicts; idempotent on structured input. Uses `"Unknown from recorded context"` as the canonical placeholder when no reason is present.
+- **`ec decision alternatives audit`** — read-only command listing quality issues (legacy strings, missing reasons, malformed entries) per decision without mutating data.
+- **`ec decision alternatives normalize`** — converts legacy string entries to structured form; `--dry-run` previews without writing; exits non-zero if malformed entries block normalization.
+- **`ec decision alternatives set`** — replaces a decision's `rejected_alternatives` list with a validated structured JSON array; accepts both string and structured items via the shared normalizer.
+
+### Changed
+
+- **Extraction prompts** — all three source-type prompts (`session`, `checkpoint`, `assessment`) now request `{"alternative": str, "reason": str}` objects and explicitly instruct the model not to invent reasons when the source text provides none.
+- **`parse_llm_response`** — normalizes each rejected-alternative entry through the shared `normalize_alternative` helper; malformed entries are dropped silently (not a parse failure).
+
 ## [0.6.0] - 2026-05-10
 
 v0.6.0 advances the outcome lifecycle core for decision memory. Database schema v14 widens decision outcome vocabulary, supersession now records replacement feedback, and candidate confirmation records the commit that introduced the promoted decision.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,12 +161,12 @@ Plan reference: `docs/brainstorms/v0-6-0-roadmap-plan.md`.
 
 Theme: clean up the rejected-alternatives data shape without mutating existing records or inventing rationale.
 
-- [ ] Rejected alternative normalization helpers in `core/decisions.py` accepting legacy strings and structured objects
-- [ ] `ec decision alternatives audit` — list reasonless, malformed, mixed, or legacy alternatives without mutating data
-- [ ] `ec decision alternatives normalize` — convert legacy strings to structured objects; use `"Unknown from recorded context"` for missing reasons
-- [ ] `ec decision alternatives set` or equivalent manual update command for explicit structured replacements
-- [ ] Tighten extraction prompts to request rejected-alternative reasons only when source text contains enough evidence; parser and candidate-confirmation paths share the same normalizer
-- [ ] Tests: legacy string compatibility, malformed JSON detection, mixed arrays, empty alternatives, empty reasons, audit categories, normalization idempotency, manual set behavior
+- [x] Rejected alternative normalization helpers in `core/decisions.py` accepting legacy strings and structured objects
+- [x] `ec decision alternatives audit` — list reasonless, malformed, mixed, or legacy alternatives without mutating data
+- [x] `ec decision alternatives normalize` — convert legacy strings to structured objects; use `"Unknown from recorded context"` for missing reasons
+- [x] `ec decision alternatives set` or equivalent manual update command for explicit structured replacements
+- [x] Tighten extraction prompts to request rejected-alternative reasons only when source text contains enough evidence; parser and candidate-confirmation paths share the same normalizer
+- [x] Tests: legacy string compatibility, malformed JSON detection, mixed arrays, empty alternatives, empty reasons, audit categories, normalization idempotency, manual set behavior
 
 ## Hardening Backlog
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -813,5 +813,152 @@ def candidates_reject(
 decision_app.add_typer(candidates_app, name="candidates")
 
 
+# ---------------------------------------------------------------------------
+# ec decision alternatives <audit|normalize|set>
+# ---------------------------------------------------------------------------
+
+alternatives_app = typer.Typer(help="Rejected-alternative quality commands")
+
+
+@alternatives_app.command("audit")
+def alternatives_audit(
+    decision_id: str = typer.Argument(..., help="Decision ID (prefix ok)"),
+):
+    """Report quality issues in a decision's rejected alternatives (read-only)."""
+    import json
+
+    from ..core.decisions import audit_rejected_alternatives, get_decision
+
+    conn, _ = get_repo_connection()
+    try:
+        decision = get_decision(conn, decision_id)
+    finally:
+        conn.close()
+
+    if not decision:
+        console.print(f"[red]Decision not found:[/red] {decision_id}")
+        raise typer.Exit(1)
+
+    raw = decision.get("rejected_alternatives") or []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except Exception:
+            raw = []
+
+    report = audit_rejected_alternatives(raw)
+    did_short = decision["id"][:12]
+    console.print(f"[bold]Audit: decision {did_short}[/bold]  ({report['total']} alternative(s))")
+
+    if not report["needs_normalization"] and not report["missing_reason"] and not report["malformed"]:
+        console.print("[green]All alternatives are structured and complete.[/green]")
+        return
+
+    if report["legacy_strings"]:
+        console.print(f"  [yellow]Legacy strings (need normalization):[/yellow] {report['legacy_strings']}")
+    if report["missing_reason"]:
+        console.print(f"  [dim]Missing/unknown reason:[/dim] {report['missing_reason']}")
+    if report["malformed"]:
+        console.print(f"  [red]Malformed (cannot normalize) at indices:[/red] {report['malformed']}")
+
+
+@alternatives_app.command("normalize")
+def alternatives_normalize(
+    decision_id: str = typer.Argument(..., help="Decision ID (prefix ok)"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without writing"),
+):
+    """Convert legacy string alternatives to structured form (idempotent)."""
+    import json
+
+    from ..core.decisions import (
+        audit_rejected_alternatives,
+        get_decision,
+        normalize_rejected_alternatives,
+        update_decision,
+    )
+
+    conn, _ = get_repo_connection()
+    try:
+        decision = get_decision(conn, decision_id)
+        if not decision:
+            console.print(f"[red]Decision not found:[/red] {decision_id}")
+            raise typer.Exit(1)
+
+        raw = decision.get("rejected_alternatives") or []
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception:
+                raw = []
+
+        try:
+            normalized = normalize_rejected_alternatives(raw)
+        except (ValueError, TypeError):
+            report = audit_rejected_alternatives(raw)
+            console.print(f"[red]Cannot normalize: malformed entries at indices {report['malformed']}[/red]")
+            console.print("Fix or remove those entries first using [bold]ec decision alternatives set[/bold].")
+            raise typer.Exit(1)
+
+        if normalized == raw:
+            console.print("[green]Already normalized — nothing to do.[/green]")
+            return
+
+        if dry_run:
+            console.print("[dim](dry-run)[/dim] Would write:")
+            for item in normalized:
+                console.print(f"  alternative: {item['alternative']}")
+                console.print(f"  reason:      {item['reason']}")
+                console.print()
+            return
+
+        update_decision(conn, decision["id"], rejected_alternatives=normalized)
+    finally:
+        conn.close()
+
+    console.print(f"[green]Normalized {len(normalized)} alternative(s) for decision {decision['id'][:12]}.[/green]")
+
+
+@alternatives_app.command("set")
+def alternatives_set(
+    decision_id: str = typer.Argument(..., help="Decision ID (prefix ok)"),
+    alternatives_json: str = typer.Argument(..., help='JSON array, e.g. \'[{"alternative":"A","reason":"too slow"}]\''),
+):
+    """Replace rejected alternatives with a validated structured list."""
+    import json
+
+    from ..core.decisions import get_decision, normalize_rejected_alternatives, update_decision
+
+    try:
+        raw = json.loads(alternatives_json)
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Invalid JSON:[/red] {exc}")
+        raise typer.Exit(1)
+
+    if not isinstance(raw, list):
+        console.print("[red]Input must be a JSON array.[/red]")
+        raise typer.Exit(1)
+
+    try:
+        normalized = normalize_rejected_alternatives(raw)
+    except (ValueError, TypeError) as exc:
+        console.print(f"[red]Validation error:[/red] {exc}")
+        raise typer.Exit(1)
+
+    conn, _ = get_repo_connection()
+    try:
+        decision = get_decision(conn, decision_id)
+        if not decision:
+            console.print(f"[red]Decision not found:[/red] {decision_id}")
+            raise typer.Exit(1)
+        update_decision(conn, decision["id"], rejected_alternatives=normalized)
+    finally:
+        conn.close()
+
+    console.print(f"[green]Set {len(normalized)} alternative(s) for decision {decision['id'][:12]}.[/green]")
+
+
+decision_app.add_typer(alternatives_app, name="alternatives")
+
+
 def register(app: typer.Typer) -> None:
     app.add_typer(decision_app, name="decision")

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -480,28 +480,40 @@ def collect_signals(conn, session_id: str, repo_path: str) -> list[SignalBundle]
 _SYSTEM_PROMPT_BY_SOURCE: dict[str, str] = {
     "session": (
         "You are reviewing a coding session for architectural or technical decisions. "
-        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
-        '"rejected_alternatives": [str]}] '
+        "Return a JSON array: "
+        '[{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [{"alternative": str, "reason": str}]}] '
         "Only include actual decisions (choosing one approach over another), "
-        "not tasks, plans, or status updates. Return [] if no decisions were made."
+        "not tasks, plans, or status updates. Return [] if no decisions were made. "
+        "For each rejected alternative, provide the reason it was not chosen — "
+        "only if the reason is explicit in the source text. "
+        'If no reason is stated, omit the "reason" key entirely (do not invent one).'
     ),
     "checkpoint": (
         "You are reviewing a checkpoint's code change summary and the surrounding "
         "turn summaries. Extract architectural or technical decisions that the "
         "change embodies (e.g. choosing one library over another, switching a "
         "data model, picking an error handling strategy). "
-        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
-        '"rejected_alternatives": [str]}]. '
-        "Return [] if the change is a routine refactor, bug fix, or cleanup."
+        "Return a JSON array: "
+        '[{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [{"alternative": str, "reason": str}]}]. '
+        "Return [] if the change is a routine refactor, bug fix, or cleanup. "
+        "For each rejected alternative, provide the reason it was not chosen — "
+        "only if the reason is explicit in the source text. "
+        'If no reason is stated, omit the "reason" key entirely (do not invent one).'
     ),
     "assessment": (
         "You are reviewing an assessment of a code change (verdict, impact summary, "
         "roadmap alignment, tidy suggestion). Extract decisions this assessment "
         "records — typically an expansion or narrowing of project scope with a "
         "specific rationale. "
-        'Return a JSON array: [{"title": str, "rationale": str, "scope": str, '
-        '"rejected_alternatives": [str]}]. '
-        "Return [] if the assessment is a neutral observation."
+        "Return a JSON array: "
+        '[{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [{"alternative": str, "reason": str}]}]. '
+        "Return [] if the assessment is a neutral observation. "
+        "For each rejected alternative, provide the reason it was not chosen — "
+        "only if the reason is explicit in the source text. "
+        'If no reason is stated, omit the "reason" key entirely (do not invent one).'
     ),
 }
 
@@ -579,9 +591,17 @@ def parse_llm_response(raw: str, bundle: SignalBundle) -> list[CandidateDraft]:
             continue
         rationale = item.get("rationale")
         scope = item.get("scope")
-        rejected = item.get("rejected_alternatives") or []
-        if not isinstance(rejected, list):
-            rejected = []
+        raw_rejected = item.get("rejected_alternatives") or []
+        if not isinstance(raw_rejected, list):
+            raw_rejected = []
+        from .decisions import normalize_alternative
+
+        rejected: list[dict[str, str]] = []
+        for alt_item in raw_rejected:
+            try:
+                rejected.append(normalize_alternative(alt_item))
+            except (ValueError, TypeError):
+                pass
         drafts.append(
             CandidateDraft(
                 title=title.strip(),

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -1786,3 +1786,79 @@ def hybrid_search_decisions(
             doc["hybrid_score"] = round(scores[rid], 6)
             results.append(doc)
     return results
+
+
+# ---------------------------------------------------------------------------
+# Rejected-alternative normalization helpers (v0.6.1)
+# ---------------------------------------------------------------------------
+
+UNKNOWN_REASON = "Unknown from recorded context"
+
+
+def normalize_alternative(item: Any) -> dict[str, str]:
+    """Coerce a single rejected-alternative entry to ``{"alternative": str, "reason": str}``.
+
+    Accepts:
+    - already-structured dict with at least an ``"alternative"`` key
+    - plain string (legacy format)
+    - anything else → raises ``ValueError``
+    """
+    if isinstance(item, dict):
+        alt = item.get("alternative")
+        if not isinstance(alt, str) or not alt.strip():
+            raise ValueError(f"Structured alternative missing non-empty 'alternative' key: {item!r}")
+        reason = item.get("reason")
+        return {
+            "alternative": alt.strip(),
+            "reason": reason.strip() if isinstance(reason, str) and reason.strip() else UNKNOWN_REASON,
+        }
+    if isinstance(item, str):
+        if not item.strip():
+            raise ValueError(f"Alternative string must not be empty: {item!r}")
+        return {"alternative": item.strip(), "reason": UNKNOWN_REASON}
+    raise ValueError(f"Cannot normalize rejected alternative of type {type(item).__name__}: {item!r}")
+
+
+def normalize_rejected_alternatives(items: list[Any]) -> list[dict[str, str]]:
+    """Normalize a full ``rejected_alternatives`` list.  Idempotent on already-structured input."""
+    if not isinstance(items, list):
+        raise TypeError(f"rejected_alternatives must be a list, got {type(items).__name__}")
+    return [normalize_alternative(item) for item in items]
+
+
+def audit_rejected_alternatives(items: list[Any]) -> dict[str, Any]:
+    """Inspect a ``rejected_alternatives`` list and report issues without modifying data.
+
+    Returns a dict with:
+    - ``"total"``: int — total number of entries
+    - ``"legacy_strings"``: int — entries that are plain strings (need normalization)
+    - ``"missing_reason"``: int — structured entries whose reason is missing/blank/UNKNOWN_REASON
+    - ``"malformed"``: list[int] — 0-based indices of entries that cannot be normalized at all
+    - ``"needs_normalization"``: bool — True if any issue was found
+    """
+    total = len(items)
+    legacy_strings = 0
+    missing_reason = 0
+    malformed: list[int] = []
+
+    for idx, item in enumerate(items):
+        try:
+            normalize_alternative(item)
+        except (ValueError, TypeError):
+            malformed.append(idx)
+            continue
+
+        if isinstance(item, str):
+            legacy_strings += 1
+        elif isinstance(item, dict):
+            reason = item.get("reason")
+            if not isinstance(reason, str) or not reason.strip() or reason.strip() == UNKNOWN_REASON:
+                missing_reason += 1
+
+    return {
+        "total": total,
+        "legacy_strings": legacy_strings,
+        "missing_reason": missing_reason,
+        "malformed": malformed,
+        "needs_normalization": bool(legacy_strings or malformed),
+    }

--- a/tests/test_decision_alternatives.py
+++ b/tests/test_decision_alternatives.py
@@ -1,0 +1,553 @@
+"""Tests for rejected-alternative normalization helpers and CLI (v0.6.1, #113-#118)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from entirecontext.cli import app
+from entirecontext.core.decisions import (
+    UNKNOWN_REASON,
+    audit_rejected_alternatives,
+    create_decision,
+    get_decision,
+    normalize_alternative,
+    normalize_rejected_alternatives,
+)
+from entirecontext.db import get_db
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# normalize_alternative
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAlternative:
+    def test_string_input_becomes_structured(self):
+        result = normalize_alternative("Redis")
+        assert result == {"alternative": "Redis", "reason": UNKNOWN_REASON}
+
+    def test_string_strips_whitespace(self):
+        result = normalize_alternative("  Redis  ")
+        assert result["alternative"] == "Redis"
+
+    def test_structured_input_passthrough(self):
+        item = {"alternative": "Redis", "reason": "too much ops overhead"}
+        result = normalize_alternative(item)
+        assert result == item
+
+    def test_structured_strips_whitespace(self):
+        item = {"alternative": "  Redis  ", "reason": "  too slow  "}
+        result = normalize_alternative(item)
+        assert result["alternative"] == "Redis"
+        assert result["reason"] == "too slow"
+
+    def test_structured_missing_reason_fills_unknown(self):
+        result = normalize_alternative({"alternative": "SQLite"})
+        assert result["reason"] == UNKNOWN_REASON
+
+    def test_structured_blank_reason_fills_unknown(self):
+        result = normalize_alternative({"alternative": "SQLite", "reason": "   "})
+        assert result["reason"] == UNKNOWN_REASON
+
+    def test_structured_empty_alternative_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            normalize_alternative({"alternative": ""})
+
+    def test_structured_missing_alternative_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            normalize_alternative({"reason": "some reason"})
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            normalize_alternative("")
+
+    def test_blank_string_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            normalize_alternative("   ")
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(ValueError, match="Cannot normalize"):
+            normalize_alternative(42)
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="Cannot normalize"):
+            normalize_alternative(None)
+
+    def test_idempotent_on_already_structured(self):
+        item = {"alternative": "Redis", "reason": "too much ops overhead"}
+        first = normalize_alternative(item)
+        second = normalize_alternative(first)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# normalize_rejected_alternatives
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRejectedAlternatives:
+    def test_empty_list(self):
+        assert normalize_rejected_alternatives([]) == []
+
+    def test_all_strings(self):
+        result = normalize_rejected_alternatives(["Redis", "Postgres"])
+        assert all(r["reason"] == UNKNOWN_REASON for r in result)
+        assert [r["alternative"] for r in result] == ["Redis", "Postgres"]
+
+    def test_mixed_strings_and_structured(self):
+        items = ["Redis", {"alternative": "Postgres", "reason": "already using SQLite"}]
+        result = normalize_rejected_alternatives(items)
+        assert result[0] == {"alternative": "Redis", "reason": UNKNOWN_REASON}
+        assert result[1] == {"alternative": "Postgres", "reason": "already using SQLite"}
+
+    def test_already_structured_passthrough(self):
+        items = [{"alternative": "Redis", "reason": "ops overhead"}]
+        assert normalize_rejected_alternatives(items) == items
+
+    def test_non_list_raises(self):
+        with pytest.raises(TypeError, match="must be a list"):
+            normalize_rejected_alternatives("Redis")  # type: ignore[arg-type]
+
+    def test_malformed_item_raises(self):
+        with pytest.raises(ValueError):
+            normalize_rejected_alternatives([42])
+
+    def test_idempotent(self):
+        items = ["Redis", {"alternative": "Postgres", "reason": "already using SQLite"}]
+        first = normalize_rejected_alternatives(items)
+        second = normalize_rejected_alternatives(first)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# audit_rejected_alternatives
+# ---------------------------------------------------------------------------
+
+
+class TestAuditRejectedAlternatives:
+    def test_empty_list(self):
+        report = audit_rejected_alternatives([])
+        assert report["total"] == 0
+        assert report["needs_normalization"] is False
+
+    def test_all_structured_with_reasons(self):
+        items = [{"alternative": "Redis", "reason": "too heavy"}]
+        report = audit_rejected_alternatives(items)
+        assert report["needs_normalization"] is False
+        assert report["legacy_strings"] == 0
+        assert report["malformed"] == []
+
+    def test_detects_legacy_strings(self):
+        report = audit_rejected_alternatives(["Redis", "Postgres"])
+        assert report["legacy_strings"] == 2
+        assert report["needs_normalization"] is True
+
+    def test_detects_missing_reasons(self):
+        items = [{"alternative": "Redis"}, {"alternative": "Postgres", "reason": "too slow"}]
+        report = audit_rejected_alternatives(items)
+        assert report["missing_reason"] == 1
+        assert report["needs_normalization"] is False
+
+    def test_detects_unknown_reason_as_missing(self):
+        items = [{"alternative": "Redis", "reason": UNKNOWN_REASON}]
+        report = audit_rejected_alternatives(items)
+        assert report["missing_reason"] == 1
+
+    def test_detects_malformed_entries(self):
+        items = [42, {"alternative": "Redis"}]
+        report = audit_rejected_alternatives(items)
+        assert 0 in report["malformed"]
+        assert report["needs_normalization"] is True
+
+    def test_malformed_index_is_correct(self):
+        items = [
+            {"alternative": "Redis", "reason": "too heavy"},
+            42,
+            {"alternative": "Postgres"},
+        ]
+        report = audit_rejected_alternatives(items)
+        assert report["malformed"] == [1]
+
+    def test_mixed_issues(self):
+        items = ["legacy", {"alternative": "Postgres", "reason": "too slow"}, None]
+        report = audit_rejected_alternatives(items)
+        assert report["legacy_strings"] == 1
+        assert 2 in report["malformed"]
+        assert report["needs_normalization"] is True
+
+
+# ---------------------------------------------------------------------------
+# CLI: ec decision alternatives audit
+# ---------------------------------------------------------------------------
+
+
+class TestAlternativesAuditCLI:
+    def test_all_structured_reports_ok(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Audit clean",
+            rejected_alternatives=[{"alternative": "Redis", "reason": "ops overhead"}],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "audit", decision["id"][:12]])
+        assert result.exit_code == 0
+        assert "structured and complete" in result.stdout
+
+    def test_legacy_strings_flagged(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Audit legacy",
+            rejected_alternatives=["Redis", "Postgres"],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "audit", decision["id"][:12]])
+        assert result.exit_code == 0
+        assert "Legacy strings" in result.stdout or "legacy" in result.stdout.lower()
+
+    def test_not_found_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        result = runner.invoke(app, ["decision", "alternatives", "audit", "nonexistent"])
+        assert result.exit_code != 0
+
+    def test_empty_alternatives_shows_total_zero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="No alternatives")
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "audit", decision["id"][:12]])
+        assert result.exit_code == 0
+        assert "0 alternative" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# CLI: ec decision alternatives normalize
+# ---------------------------------------------------------------------------
+
+
+class TestAlternativesNormalizeCLI:
+    def test_normalizes_legacy_strings(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Normalize me",
+            rejected_alternatives=["Redis", "Postgres"],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        assert result.exit_code == 0
+
+        conn = get_db(str(ec_repo))
+        updated = get_decision(conn, decision["id"])
+        conn.close()
+        alts = updated["rejected_alternatives"]
+        assert all(isinstance(a, dict) for a in alts)
+        assert all(a["reason"] == UNKNOWN_REASON for a in alts)
+        assert {a["alternative"] for a in alts} == {"Redis", "Postgres"}
+
+    def test_fills_missing_structured_reason(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Normalize missing reason",
+            rejected_alternatives=[{"alternative": "Redis"}],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        assert result.exit_code == 0
+
+        conn = get_db(str(ec_repo))
+        updated = get_decision(conn, decision["id"])
+        conn.close()
+        assert updated["rejected_alternatives"] == [{"alternative": "Redis", "reason": UNKNOWN_REASON}]
+
+    def test_already_normalized_is_noop(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Already structured",
+            rejected_alternatives=[{"alternative": "Redis", "reason": "ops overhead"}],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        assert result.exit_code == 0
+        assert "nothing to do" in result.stdout.lower() or "already" in result.stdout.lower()
+
+    def test_dry_run_does_not_write(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        original_alts = ["Redis"]
+        decision = create_decision(
+            conn,
+            title="Dry run decision",
+            rejected_alternatives=original_alts,
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "normalize", "--dry-run", decision["id"][:12]])
+        assert result.exit_code == 0
+        assert "dry-run" in result.stdout.lower()
+
+        conn = get_db(str(ec_repo))
+        unchanged = get_decision(conn, decision["id"])
+        conn.close()
+        assert unchanged["rejected_alternatives"] == original_alts
+
+    def test_malformed_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Malformed")
+        conn.close()
+
+        conn = get_db(str(ec_repo))
+        conn.execute(
+            "UPDATE decisions SET rejected_alternatives = ? WHERE id = ?",
+            (json.dumps([42, "valid"]), decision["id"]),
+        )
+        conn.commit()
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        assert result.exit_code != 0
+
+    def test_idempotent_second_run(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Idempotent test",
+            rejected_alternatives=["Redis"],
+        )
+        conn.close()
+
+        runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        result2 = runner.invoke(app, ["decision", "alternatives", "normalize", decision["id"][:12]])
+        assert result2.exit_code == 0
+        assert "nothing to do" in result2.stdout.lower() or "already" in result2.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: ec decision alternatives set
+# ---------------------------------------------------------------------------
+
+
+class TestAlternativesSetCLI:
+    def test_set_structured_list(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Set me")
+        conn.close()
+
+        new_alts = json.dumps([{"alternative": "Redis", "reason": "ops overhead"}])
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], new_alts])
+        assert result.exit_code == 0
+
+        conn = get_db(str(ec_repo))
+        updated = get_decision(conn, decision["id"])
+        conn.close()
+        assert updated["rejected_alternatives"] == [{"alternative": "Redis", "reason": "ops overhead"}]
+
+    def test_set_string_items_normalizes(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Set with strings")
+        conn.close()
+
+        new_alts = json.dumps(["Redis", "Postgres"])
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], new_alts])
+        assert result.exit_code == 0
+
+        conn = get_db(str(ec_repo))
+        updated = get_decision(conn, decision["id"])
+        conn.close()
+        alts = updated["rejected_alternatives"]
+        assert all(isinstance(a, dict) for a in alts)
+
+    def test_invalid_json_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Bad JSON")
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], "{bad json}"])
+        assert result.exit_code != 0
+        assert "Invalid JSON" in result.stdout or "json" in result.stdout.lower()
+
+    def test_non_array_json_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Non-array")
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], '{"not": "array"}'])
+        assert result.exit_code != 0
+
+    def test_malformed_item_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(conn, title="Malformed item")
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], "[42]"])
+        assert result.exit_code != 0
+        assert "Validation error" in result.stdout or "error" in result.stdout.lower()
+
+    def test_set_empty_list_clears_alternatives(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        conn = get_db(str(ec_repo))
+        decision = create_decision(
+            conn,
+            title="Clear me",
+            rejected_alternatives=["Redis"],
+        )
+        conn.close()
+
+        result = runner.invoke(app, ["decision", "alternatives", "set", decision["id"][:12], "[]"])
+        assert result.exit_code == 0
+
+        conn = get_db(str(ec_repo))
+        updated = get_decision(conn, decision["id"])
+        conn.close()
+        assert updated["rejected_alternatives"] == []
+
+    def test_not_found_exits_nonzero(self, ec_repo, monkeypatch):
+        monkeypatch.chdir(ec_repo)
+        result = runner.invoke(app, ["decision", "alternatives", "set", "nonexistent", "[]"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Extraction parser: structured format acceptance (#117)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionParserStructuredFormat:
+    def test_structured_alternatives_parsed_correctly(self):
+        from entirecontext.core.decision_extraction import SignalBundle, parse_llm_response
+
+        bundle = SignalBundle(
+            source_type="session",
+            source_id="s1",
+            session_id="s1",
+            checkpoint_id=None,
+            assessment_id=None,
+            text_blocks=["..."],
+            files=set(),
+        )
+        raw_json = json.dumps(
+            [
+                {
+                    "title": "Use PostgreSQL over SQLite",
+                    "rationale": "Need concurrent writers",
+                    "scope": "database",
+                    "rejected_alternatives": [
+                        {"alternative": "SQLite", "reason": "no concurrent writes"},
+                        {"alternative": "MySQL", "reason": "licensing concerns"},
+                    ],
+                }
+            ]
+        )
+        drafts = parse_llm_response(raw_json, bundle)
+        assert len(drafts) == 1
+        alts = drafts[0].rejected_alternatives
+        assert len(alts) == 2
+        assert alts[0] == {"alternative": "SQLite", "reason": "no concurrent writes"}
+        assert alts[1] == {"alternative": "MySQL", "reason": "licensing concerns"}
+
+    def test_legacy_string_alternatives_normalized(self):
+        from entirecontext.core.decision_extraction import SignalBundle, parse_llm_response
+
+        bundle = SignalBundle(
+            source_type="session",
+            source_id="s1",
+            session_id="s1",
+            checkpoint_id=None,
+            assessment_id=None,
+            text_blocks=["..."],
+            files=set(),
+        )
+        raw_json = json.dumps(
+            [
+                {
+                    "title": "Use PostgreSQL",
+                    "rationale": "...",
+                    "scope": "database",
+                    "rejected_alternatives": ["SQLite", "MySQL"],
+                }
+            ]
+        )
+        drafts = parse_llm_response(raw_json, bundle)
+        assert len(drafts) == 1
+        alts = drafts[0].rejected_alternatives
+        assert all(isinstance(a, dict) for a in alts)
+        assert all(a["reason"] == UNKNOWN_REASON for a in alts)
+
+    def test_malformed_alternatives_dropped_silently(self):
+        from entirecontext.core.decision_extraction import SignalBundle, parse_llm_response
+
+        bundle = SignalBundle(
+            source_type="session",
+            source_id="s1",
+            session_id="s1",
+            checkpoint_id=None,
+            assessment_id=None,
+            text_blocks=["..."],
+            files=set(),
+        )
+        raw_json = json.dumps(
+            [
+                {
+                    "title": "Use PostgreSQL",
+                    "rationale": "...",
+                    "scope": "db",
+                    "rejected_alternatives": [42, "valid string", None],
+                }
+            ]
+        )
+        drafts = parse_llm_response(raw_json, bundle)
+        assert len(drafts) == 1
+        alts = drafts[0].rejected_alternatives
+        assert len(alts) == 1
+        assert alts[0]["alternative"] == "valid string"
+
+    def test_structured_without_reason_fills_unknown(self):
+        from entirecontext.core.decision_extraction import SignalBundle, parse_llm_response
+
+        bundle = SignalBundle(
+            source_type="session",
+            source_id="s1",
+            session_id="s1",
+            checkpoint_id=None,
+            assessment_id=None,
+            text_blocks=["..."],
+            files=set(),
+        )
+        raw_json = json.dumps(
+            [
+                {
+                    "title": "Use PostgreSQL",
+                    "rationale": "...",
+                    "scope": "db",
+                    "rejected_alternatives": [{"alternative": "SQLite"}],
+                }
+            ]
+        )
+        drafts = parse_llm_response(raw_json, bundle)
+        assert drafts[0].rejected_alternatives[0]["reason"] == UNKNOWN_REASON

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -445,7 +445,9 @@ class TestParseLLMResponse:
         drafts = parse_llm_response(raw, self._bundle())
         assert len(drafts) == 1
         assert drafts[0].title == "Use Redis"
-        assert drafts[0].rejected_alternatives == ["memcached"]
+        assert drafts[0].rejected_alternatives == [
+            {"alternative": "memcached", "reason": "Unknown from recorded context"}
+        ]
 
     def test_caps_at_five(self):
         raw = json.dumps([{"title": f"D{i}"} for i in range(10)])
@@ -1319,6 +1321,31 @@ class TestOutcomeFeedbackPenalty:
         assert new_breakdown["outcome_feedback"]["applied"] is False
         assert new_breakdown["outcome_feedback"]["total"] == 4
         assert new_breakdown["outcome_feedback"]["scored_total"] == 2
+
+    def test_accepted_outcomes_alone_do_not_boost_confidence(self, ec_repo, ec_db):
+        """Stats with only accepted outcomes must leave extraction confidence unchanged (no boost path)."""
+        from entirecontext.core.decision_extraction import (
+            apply_outcome_feedback_to_confidence,
+            get_file_outcome_stats,
+        )
+
+        self._seed_decision_with_outcomes(
+            ec_db,
+            title="Only accepted outcomes",
+            file_paths=["src/service/accepted_only.py"],
+            outcome_types=["accepted", "accepted", "accepted"],
+        )
+
+        stats = get_file_outcome_stats(ec_db, ["src/service/accepted_only.py"], lookback_days=60)
+        assert stats["accepted"] == 3
+        assert stats["contradicted"] == 0
+        assert stats["total"] == 3
+
+        original = 0.72
+        breakdown = {"final": original, "penalties": {}}
+        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(original, breakdown, stats, penalty=0.15)
+        assert adjusted == original
+        assert new_breakdown["outcome_feedback"]["applied"] is False
 
 
 class TestExtractionWeightsConfig:

--- a/tests/test_decisions_core.py
+++ b/tests/test_decisions_core.py
@@ -1173,6 +1173,18 @@ class TestRankingWeightsConfig:
         assert override_item["score_breakdown"]["accepted_boost"] == 5.0
         assert override_item["base_score"] > default_item["base_score"]
 
+    def test_multiple_accepted_outcomes_boost_is_binary(self, ec_db):
+        """Multiple accepted outcomes still yield the flat boost once — boost is binary, not additive."""
+        d = create_decision(ec_db, title="Multi-accepted decision")
+        link_decision_to_file(ec_db, d["id"], "src/multi_accepted.py")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+        record_decision_outcome(ec_db, d["id"], "accepted")
+
+        ranked = rank_related_decisions(ec_db, file_paths=["src/multi_accepted.py"])
+        item = next(r for r in ranked if r["id"] == d["id"])
+        assert item["score_breakdown"]["accepted_boost"] == 2.0
+
     def test_rank_default_matches_legacy(self, ec_db):
         """ranking=None preserves legacy hardcoded constants (pre-F3 numbers)."""
         d_a = create_decision(ec_db, title="Fresh file decision")

--- a/tests/test_project_cmds.py
+++ b/tests/test_project_cmds.py
@@ -484,7 +484,9 @@ class TestCodexIntegration:
         assert "old-hook.py" in local_content
 
     @patch("entirecontext.core.project.find_git_root")
-    def test_disable_from_different_repo_does_not_restore_other_repos_upstream(self, mock_git_root, tmp_path, monkeypatch):
+    def test_disable_from_different_repo_does_not_restore_other_repos_upstream(
+        self, mock_git_root, tmp_path, monkeypatch
+    ):
         first_repo = tmp_path / "repo-a"
         second_repo = tmp_path / "repo-b"
         first_repo.mkdir()


### PR DESCRIPTION
## Summary

- Add `normalize_alternative` / `normalize_rejected_alternatives` / `audit_rejected_alternatives` helpers so legacy `list[str]` rejected-alternatives are losslessly coerced to `{"alternative", "reason"}` objects (never invents reasons; uses `UNKNOWN_REASON` sentinel)
- Add `ec decision alternatives audit/normalize/set` CLI sub-commands
- Update extraction prompts to request structured `{alternative, reason}` objects without inventing reasons; parser normalizes LLM output via the new helpers
- Add 48 tests in `test_decision_alternatives.py` covering normalization, audit, all 3 CLI commands, and extraction parser
- Add 2 regression tests confirming `accepted_boost` is binary (not additive) and that `accepted`-only outcomes leave extraction confidence unchanged

## Issues closed

Closes #110
Closes #111
Closes #113
Closes #114
Closes #115
Closes #116
Closes #117
Closes #118

## Test plan

- [ ] `uv run pytest tests/test_decisions_core.py tests/test_decision_extraction.py tests/test_decision_alternatives.py` — all green
- [ ] `uv run ruff check . && uv run ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)