### PR TITLE
feat(session): backfill-ended-at CLI + remove unverified_changes.patch (B1+B3)

### DIFF
--- a/src/entirecontext/cli/session_cmds.py
+++ b/src/entirecontext/cli/session_cmds.py
@@ -457,7 +457,10 @@ def session_activate(
 def session_backfill_ended_at(
     dry_run: bool = typer.Option(True, "--dry-run/--apply", help="Preview without changes (default) or apply."),
     max_age_hours: int = typer.Option(
-        1, "--max-age-hours", help="Minimum age in hours before a NULL ended_at row is eligible."
+        1,
+        "--max-age-hours",
+        help="Minimum age in hours before a NULL ended_at row is eligible.",
+        min=1,
     ),
 ):
     """Backfill ended_at for sessions where SessionEnd hook was never fired.
@@ -466,12 +469,17 @@ def session_backfill_ended_at(
     --max-age-hours. Sets ended_at = last_activity_at for each eligible row.
     Safe default is --dry-run; pass --apply to commit changes.
     """
-    from ..core.project import find_git_root
+    from ..core.project import find_git_root, get_project
     from ..db import get_db
 
     repo_path = find_git_root()
     if not repo_path:
         console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    project = get_project(repo_path)
+    if not project:
+        console.print("[yellow]Not initialized. Run 'ec init'.[/yellow]")
         raise typer.Exit(1)
 
     conn = get_db(repo_path)
@@ -505,13 +513,26 @@ def session_backfill_ended_at(
             console.print("[dim]Dry-run mode — no changes made. Use --apply to commit.[/dim]")
             return
 
+        # Optimistic concurrency: re-check ended_at IS NULL and last_activity_at unchanged
+        # to avoid clobbering sessions closed or resumed between SELECT and UPDATE.
+        updated = 0
         for row in rows:
-            conn.execute(
-                "UPDATE sessions SET ended_at = last_activity_at WHERE id = ?",
-                (row["id"],),
+            cursor = conn.execute(
+                "UPDATE sessions SET ended_at = last_activity_at"
+                " WHERE id = ? AND ended_at IS NULL AND last_activity_at = ?",
+                (row["id"], row["last_activity_at"]),
             )
+            updated += cursor.rowcount
         conn.commit()
-        console.print(f"[green]Updated {len(rows)} session(s).[/green]")
+
+        skipped = len(rows) - updated
+        if skipped > 0:
+            console.print(
+                f"[green]Updated {updated} session(s).[/green]"
+                f" [dim]({skipped} skipped due to concurrent activity)[/dim]"
+            )
+        else:
+            console.print(f"[green]Updated {updated} session(s).[/green]")
     finally:
         conn.close()
 

--- a/src/entirecontext/cli/session_cmds.py
+++ b/src/entirecontext/cli/session_cmds.py
@@ -453,5 +453,68 @@ def session_activate(
     console.print(table)
 
 
+@session_app.command("backfill-ended-at")
+def session_backfill_ended_at(
+    dry_run: bool = typer.Option(True, "--dry-run/--apply", help="Preview without changes (default) or apply."),
+    max_age_hours: int = typer.Option(
+        1, "--max-age-hours", help="Minimum age in hours before a NULL ended_at row is eligible."
+    ),
+):
+    """Backfill ended_at for sessions where SessionEnd hook was never fired.
+
+    Targets rows where ended_at IS NULL and last_activity_at is older than
+    --max-age-hours. Sets ended_at = last_activity_at for each eligible row.
+    Safe default is --dry-run; pass --apply to commit changes.
+    """
+    from ..core.project import find_git_root
+    from ..db import get_db
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    conn = get_db(repo_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, last_activity_at FROM sessions"
+            " WHERE ended_at IS NULL"
+            " AND last_activity_at IS NOT NULL"
+            " AND datetime(last_activity_at) < datetime('now', ?)",
+            (f"-{int(max_age_hours)} hours",),
+        ).fetchall()
+
+        if not rows:
+            console.print("[dim]No eligible sessions found.[/dim]")
+            return
+
+        table = Table(
+            title=f"Sessions with NULL ended_at (>{max_age_hours}h old) — {'DRY RUN' if dry_run else 'APPLY'}"
+        )
+        table.add_column("ID", style="dim", max_width=12)
+        table.add_column("last_activity_at")
+        table.add_column("Action")
+
+        for row in rows:
+            table.add_row(row["id"][:12], row["last_activity_at"] or "", "set ended_at = last_activity_at")
+
+        console.print(table)
+        console.print(f"\n[bold]{len(rows)} row(s) eligible.[/bold]")
+
+        if dry_run:
+            console.print("[dim]Dry-run mode — no changes made. Use --apply to commit.[/dim]")
+            return
+
+        for row in rows:
+            conn.execute(
+                "UPDATE sessions SET ended_at = last_activity_at WHERE id = ?",
+                (row["id"],),
+            )
+        conn.commit()
+        console.print(f"[green]Updated {len(rows)} session(s).[/green]")
+    finally:
+        conn.close()
+
+
 def register(app: typer.Typer) -> None:
     app.add_typer(session_app, name="session")

--- a/tests/test_session_cmds.py
+++ b/tests/test_session_cmds.py
@@ -169,11 +169,21 @@ class TestSessionBackfillEndedAt:
             result = runner.invoke(app, ["session", "backfill-ended-at"])
             assert result.exit_code == 1
 
+    def test_not_initialized(self):
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value=None),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at"])
+            assert result.exit_code == 1
+            assert "init" in result.output.lower()
+
     def test_no_eligible_rows(self):
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchall.return_value = []
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at"])
@@ -188,6 +198,7 @@ class TestSessionBackfillEndedAt:
         ]
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at"])
@@ -203,8 +214,10 @@ class TestSessionBackfillEndedAt:
             {"id": "sess-old-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
         ]
         mock_conn.execute.return_value.fetchall.return_value = eligible
+        mock_conn.execute.return_value.rowcount = 1
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at", "--apply"])
@@ -218,12 +231,43 @@ class TestSessionBackfillEndedAt:
         mock_conn.execute.return_value.fetchall.return_value = []
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "2"])
             assert result.exit_code == 0
             call_args = mock_conn.execute.call_args
             assert "-2 hours" in call_args[0][1]
+
+    def test_max_age_hours_zero_rejected(self):
+        result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "0"])
+        assert result.exit_code != 0
+
+    def test_max_age_hours_negative_rejected(self):
+        result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "-5"])
+        assert result.exit_code != 0
+
+    def test_apply_skips_concurrent_modification(self):
+        """UPDATE WHERE re-checks ended_at IS NULL and last_activity_at; rowcount=0 = skipped."""
+        mock_conn = MagicMock()
+        eligible = [
+            {"id": "sess-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
+            {"id": "sess-002-uuid", "last_activity_at": "2025-01-02T10:00:00"},
+        ]
+        select_cursor = MagicMock()
+        select_cursor.fetchall.return_value = eligible
+        update_cursor = MagicMock()
+        update_cursor.rowcount = 0
+        mock_conn.execute.side_effect = [select_cursor, update_cursor, update_cursor]
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at", "--apply"])
+            assert result.exit_code == 0
+            assert "Updated 0 session(s)" in result.output
+            assert "2 skipped" in result.output
 
 
 class TestSessionCurrent:

--- a/tests/test_session_cmds.py
+++ b/tests/test_session_cmds.py
@@ -163,6 +163,69 @@ class TestSessionShow:
             assert "not found" in result.output.lower()
 
 
+class TestSessionBackfillEndedAt:
+    def test_not_in_repo(self):
+        with patch("entirecontext.core.project.find_git_root", return_value=None):
+            result = runner.invoke(app, ["session", "backfill-ended-at"])
+            assert result.exit_code == 1
+
+    def test_no_eligible_rows(self):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at"])
+            assert result.exit_code == 0
+            assert "No eligible" in result.output
+
+    def test_dry_run_shows_rows_without_update(self):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            {"id": "sess-old-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
+            {"id": "sess-old-002-uuid", "last_activity_at": "2025-01-02T10:00:00"},
+        ]
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at"])
+            assert result.exit_code == 0
+            assert "sess-old-001" in result.output
+            assert "2 row(s) eligible" in result.output
+            assert "Dry-run" in result.output
+            mock_conn.commit.assert_not_called()
+
+    def test_apply_updates_eligible_rows(self):
+        mock_conn = MagicMock()
+        eligible = [
+            {"id": "sess-old-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
+        ]
+        mock_conn.execute.return_value.fetchall.return_value = eligible
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at", "--apply"])
+            assert result.exit_code == 0
+            assert "Updated 1 session(s)" in result.output
+            mock_conn.commit.assert_called_once()
+
+    def test_recent_rows_not_eligible(self):
+        """Rows younger than max_age_hours must not appear (SQL enforces this; mock verifies query param)."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "2"])
+            assert result.exit_code == 0
+            call_args = mock_conn.execute.call_args
+            assert "-2 hours" in call_args[0][1]
+
+
 class TestSessionCurrent:
     def test_not_in_repo(self):
         with patch("entirecontext.core.project.find_git_root", return_value=None):


### PR DESCRIPTION
## Summary

- **B1**: `ec session backfill-ended-at` 명령 추가 — `ended_at IS NULL` + `last_activity_at` 이 오래된 세션을 안전하게 복구
- **B3**: `unverified_changes.patch` 제거 — 패치 내용(docs/* 2개 파일)이 이미 commit e27256a 에 main에 머지됨

## B1 Details

```
ec session backfill-ended-at           # dry-run (기본값)
ec session backfill-ended-at --apply   # 실제 UPDATE
ec session backfill-ended-at --max-age-hours 2  # 기본값: 1h
```

- 기본 `--dry-run`: DB 변경 없이 대상 행 표시
- `--apply` 명시 시에만 `UPDATE sessions SET ended_at = last_activity_at`
- `--max-age-hours 1` (기본): 최근 1시간 이내 세션은 보호

## Test plan

- [x] 5개 신규 테스트 (`TestSessionBackfillEndedAt`) — 18/18 통과
- [x] `ruff check` + `ruff format` 무오류
- [ ] 실제 NULL row 픽스쳐로 dry-run → 행 개수 보고, apply → 0개 NULL 남음

## ec decisions recorded

- `37f3f5f9` — unverified_changes.patch 제거 회고

🤖 Generated with [Claude Code](https://claude.ai/claude-code)