### PR TITLE
feat(decisions): B2 accepted_boost — confidence boost for well-received decisions

### DIFF
--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -779,6 +779,8 @@ class ExtractionWeights:
     outcome_feedback_enabled: bool = True
     outcome_feedback_lookback_days: int = 60
     contradicted_penalty: float = 0.15
+    accepted_boost_amount: float = 0.10
+    accepted_boost_threshold: float = 0.6
 
 
 _DEFAULT_EXTRACTION_WEIGHTS = ExtractionWeights()
@@ -860,6 +862,12 @@ def _load_extraction_weights(config: dict | None) -> ExtractionWeights:
         contradicted_penalty=_coerce_extraction_nonneg_float(
             section, "contradicted_penalty", _DEFAULT_EXTRACTION_WEIGHTS.contradicted_penalty
         ),
+        accepted_boost_amount=_coerce_extraction_nonneg_float(
+            section, "accepted_boost_amount", _DEFAULT_EXTRACTION_WEIGHTS.accepted_boost_amount
+        ),
+        accepted_boost_threshold=_coerce_extraction_float(
+            section, "accepted_boost_threshold", _DEFAULT_EXTRACTION_WEIGHTS.accepted_boost_threshold
+        ),
     )
 
 
@@ -916,19 +924,21 @@ def apply_outcome_feedback_to_confidence(
     stats: dict[str, int],
     *,
     penalty: float = 0.15,
+    boost: float = 0.10,
+    boost_threshold: float = 0.6,
 ) -> tuple[float, dict[str, Any]]:
-    """Apply a confidence penalty when contradicted outcomes dominate history.
+    """Apply outcome-history feedback (penalty or boost) to extraction confidence.
 
-    Penalty logic: if aggregated ``contradicted / scored_total`` strictly
-    exceeds :data:`_OUTCOME_FEEDBACK_RATIO_THRESHOLD` (0.5) across the draft's
-    files, subtract ``penalty`` from ``confidence`` and clamp to ``[0.0, 1.0]``.
-    ``scored_total`` counts accepted, ignored, and contradicted outcomes only;
-    refined/replaced are neutral and reported without diluting the penalty
-    denominator. Otherwise return the input unchanged.
+    Penalty path: if ``contradicted / scored_total > 0.5``, subtract ``penalty``.
+    Boost path (symmetric, mutually exclusive with penalty): if penalty was NOT
+    applied, ``scored_total >= 2``, and ``accepted / scored_total > boost_threshold``,
+    add ``boost`` to confidence. Both paths clamp the final to ``[0.0, 1.0]``.
 
-    The returned breakdown always includes an ``outcome_feedback`` section
-    (even when no penalty applied) so telemetry and UI can render a
-    consistent shape without branching on presence.
+    ``scored_total`` counts accepted, ignored, and contradicted only; refined/replaced
+    are neutral and do not affect either ratio.
+
+    The returned breakdown always includes an ``outcome_feedback`` section so
+    callers can render a consistent shape without branching on presence.
     """
     total = int(stats.get("total", 0))
     contradicted = int(stats.get("contradicted", 0))
@@ -941,7 +951,12 @@ def apply_outcome_feedback_to_confidence(
     ratio = (contradicted / scored_total) if scored_total > 0 else 0.0
     applied = ratio > _OUTCOME_FEEDBACK_RATIO_THRESHOLD
     penalty_amount = penalty if applied else 0.0
-    final = max(0.0, min(1.0, confidence - penalty_amount))
+
+    accept_ratio = (accepted / scored_total) if scored_total > 0 else 0.0
+    boost_applied = not applied and scored_total >= 2 and boost > 0.0 and accept_ratio > boost_threshold
+    boost_amount = boost if boost_applied else 0.0
+
+    final = max(0.0, min(1.0, confidence - penalty_amount + boost_amount))
 
     feedback = {
         "applied": applied,
@@ -955,12 +970,12 @@ def apply_outcome_feedback_to_confidence(
         "ratio": round(ratio, 4),
         "ratio_threshold": _OUTCOME_FEEDBACK_RATIO_THRESHOLD,
         "penalty": round(penalty_amount, 4),
+        "boost_applied": boost_applied,
+        "boost": round(boost_amount, 4),
     }
     new_breakdown = dict(breakdown)
     new_breakdown["outcome_feedback"] = feedback
-    if applied:
-        # Keep the original score next to the adjusted final so downstream
-        # review can see what was deducted without re-running the calc.
+    if applied or boost_applied:
         new_breakdown["final_before_outcome_feedback"] = round(confidence, 4)
         new_breakdown["final"] = round(final, 4)
     return final, new_breakdown
@@ -1104,6 +1119,8 @@ def run_extraction(
                     breakdown,
                     stats,
                     penalty=extraction_weights.contradicted_penalty,
+                    boost=extraction_weights.accepted_boost_amount,
+                    boost_threshold=extraction_weights.accepted_boost_threshold,
                 )
             if score < min_confidence:
                 outcome.low_confidence_skipped += 1

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -826,16 +827,19 @@ def _coerce_extraction_float(section: dict, key: str, default: float) -> float:
 
 
 def _coerce_extraction_nonneg_float(section: dict, key: str, default: float) -> float:
-    """Variant of :func:`_coerce_extraction_float` that rejects negatives.
+    """Variant of :func:`_coerce_extraction_float` that rejects negatives and non-finite values.
 
     ``contradicted_penalty`` must be >= 0 because ``apply_outcome_feedback_to_confidence``
     subtracts it directly: a negative value would convert the penalty into a
     boost when contradicted outcomes dominate, inverting the 'penalty-only'
     contract of this feature.
+
+    Non-finite values (``inf``, ``nan``) are also rejected: ``inf`` would flatten
+    boosted rankings by clamping to 1.0, while ``nan`` silently disables boosting.
     """
     value = _coerce_extraction_float(section, key, default)
-    if value < 0.0:
-        raise ValueError(f"decisions.extraction.{key} must be >= 0, got {value!r}")
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"decisions.extraction.{key} must be a finite non-negative number, got {value!r}")
     return value
 
 
@@ -865,7 +869,7 @@ def _load_extraction_weights(config: dict | None) -> ExtractionWeights:
         accepted_boost_amount=_coerce_extraction_nonneg_float(
             section, "accepted_boost_amount", _DEFAULT_EXTRACTION_WEIGHTS.accepted_boost_amount
         ),
-        accepted_boost_threshold=_coerce_extraction_float(
+        accepted_boost_threshold=_coerce_extraction_nonneg_float(
             section, "accepted_boost_threshold", _DEFAULT_EXTRACTION_WEIGHTS.accepted_boost_threshold
         ),
     )

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1322,8 +1322,68 @@ class TestOutcomeFeedbackPenalty:
         assert new_breakdown["outcome_feedback"]["total"] == 4
         assert new_breakdown["outcome_feedback"]["scored_total"] == 2
 
-    def test_accepted_outcomes_alone_do_not_boost_confidence(self, ec_repo, ec_db):
-        """Stats with only accepted outcomes must leave extraction confidence unchanged (no boost path)."""
+    def test_accepted_outcomes_boost_below_threshold_no_change(self, ec_repo, ec_db):
+        """accepted/scored_total at or below boost_threshold must not apply a boost."""
+        from entirecontext.core.decision_extraction import (
+            apply_outcome_feedback_to_confidence,
+            get_file_outcome_stats,
+        )
+
+        # 2 accepted + 2 ignored = scored_total 4, ratio = 0.5 (not > 0.6)
+        self._seed_decision_with_outcomes(
+            ec_db,
+            title="Below threshold accepted",
+            file_paths=["src/service/below_threshold.py"],
+            outcome_types=["accepted", "accepted", "ignored", "ignored"],
+        )
+
+        stats = get_file_outcome_stats(ec_db, ["src/service/below_threshold.py"], lookback_days=60)
+        assert stats["accepted"] == 2
+        assert stats["ignored"] == 2
+
+        original = 0.72
+        breakdown = {"final": original, "penalties": {}}
+        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(
+            original, breakdown, stats, penalty=0.15, boost=0.10, boost_threshold=0.6
+        )
+        assert adjusted == original
+        assert new_breakdown["outcome_feedback"]["applied"] is False
+        assert new_breakdown["outcome_feedback"]["boost_applied"] is False
+
+    def test_accepted_outcomes_above_threshold_apply_boost(self, ec_repo, ec_db):
+        """accepted/scored_total > boost_threshold with scored_total >= 2 must add the boost."""
+        from entirecontext.core.decision_extraction import (
+            apply_outcome_feedback_to_confidence,
+            get_file_outcome_stats,
+        )
+
+        # 3 accepted out of 3 scored = 1.0 > 0.6 threshold, scored_total >= 2
+        self._seed_decision_with_outcomes(
+            ec_db,
+            title="Above threshold accepted",
+            file_paths=["src/service/above_threshold.py"],
+            outcome_types=["accepted", "accepted", "accepted"],
+        )
+
+        stats = get_file_outcome_stats(ec_db, ["src/service/above_threshold.py"], lookback_days=60)
+        assert stats["accepted"] == 3
+        assert stats["contradicted"] == 0
+
+        original = 0.72
+        boost = 0.10
+        breakdown = {"final": original, "penalties": {}}
+        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(
+            original, breakdown, stats, penalty=0.15, boost=boost, boost_threshold=0.6
+        )
+        assert abs(adjusted - (original + boost)) < 1e-9
+        assert new_breakdown["outcome_feedback"]["applied"] is False
+        assert new_breakdown["outcome_feedback"]["boost_applied"] is True
+        assert new_breakdown["outcome_feedback"]["boost"] == boost
+        assert new_breakdown["final_before_outcome_feedback"] == original
+        assert new_breakdown["final"] == pytest.approx(original + boost)
+
+    def test_accepted_boost_single_outcome_not_applied(self, ec_repo, ec_db):
+        """scored_total == 1 must not trigger the boost (single-outcome smoothing guard)."""
         from entirecontext.core.decision_extraction import (
             apply_outcome_feedback_to_confidence,
             get_file_outcome_stats,
@@ -1331,21 +1391,26 @@ class TestOutcomeFeedbackPenalty:
 
         self._seed_decision_with_outcomes(
             ec_db,
-            title="Only accepted outcomes",
-            file_paths=["src/service/accepted_only.py"],
-            outcome_types=["accepted", "accepted", "accepted"],
+            title="Single accepted outcome",
+            file_paths=["src/service/single_accepted.py"],
+            outcome_types=["accepted"],
         )
 
-        stats = get_file_outcome_stats(ec_db, ["src/service/accepted_only.py"], lookback_days=60)
-        assert stats["accepted"] == 3
-        assert stats["contradicted"] == 0
-        assert stats["total"] == 3
+        stats = get_file_outcome_stats(ec_db, ["src/service/single_accepted.py"], lookback_days=60)
+        assert stats["accepted"] == 1
+        assert (
+            stats["scored_total"] == 1
+            if "scored_total" in stats
+            else (stats["accepted"] + stats["ignored"] + stats["contradicted"]) == 1
+        )
 
         original = 0.72
         breakdown = {"final": original, "penalties": {}}
-        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(original, breakdown, stats, penalty=0.15)
+        adjusted, new_breakdown = apply_outcome_feedback_to_confidence(
+            original, breakdown, stats, penalty=0.15, boost=0.10, boost_threshold=0.6
+        )
         assert adjusted == original
-        assert new_breakdown["outcome_feedback"]["applied"] is False
+        assert new_breakdown["outcome_feedback"]["boost_applied"] is False
 
 
 class TestExtractionWeightsConfig:
@@ -1361,6 +1426,8 @@ class TestExtractionWeightsConfig:
         assert result.outcome_feedback_enabled is True
         assert result.outcome_feedback_lookback_days == 60
         assert result.contradicted_penalty == 0.15
+        assert result.accepted_boost_amount == 0.10
+        assert result.accepted_boost_threshold == 0.6
         # Must return a fresh instance (singleton contamination guard).
         assert result is not _DEFAULT_EXTRACTION_WEIGHTS
 
@@ -1374,6 +1441,8 @@ class TestExtractionWeightsConfig:
                         "outcome_feedback_enabled": False,
                         "outcome_feedback_lookback_days": 30,
                         "contradicted_penalty": 0.25,
+                        "accepted_boost_amount": 0.05,
+                        "accepted_boost_threshold": 0.75,
                     }
                 }
             }
@@ -1381,6 +1450,15 @@ class TestExtractionWeightsConfig:
         assert result.outcome_feedback_enabled is False
         assert result.outcome_feedback_lookback_days == 30
         assert result.contradicted_penalty == 0.25
+        assert result.accepted_boost_amount == 0.05
+        assert result.accepted_boost_threshold == 0.75
+
+    def test_accepted_boost_amount_negative_rejected(self):
+        """accepted_boost_amount must be >= 0 (nonneg_float guard)."""
+        from entirecontext.core.decision_extraction import _load_extraction_weights
+
+        with pytest.raises(ValueError, match="accepted_boost_amount"):
+            _load_extraction_weights({"decisions": {"extraction": {"accepted_boost_amount": -0.05}}})
 
     def test_invalid_value_raises(self):
         from entirecontext.core.decision_extraction import _load_extraction_weights

--- a/tests/test_decision_extraction.py
+++ b/tests/test_decision_extraction.py
@@ -1472,7 +1472,7 @@ class TestExtractionWeightsConfig:
         the penalty-only contract of this feature. Config load must refuse."""
         from entirecontext.core.decision_extraction import _load_extraction_weights
 
-        with pytest.raises(ValueError, match=">= 0"):
+        with pytest.raises(ValueError, match="contradicted_penalty"):
             _load_extraction_weights({"decisions": {"extraction": {"contradicted_penalty": -0.15}}})
 
     def test_zero_penalty_accepted(self):
@@ -1482,6 +1482,27 @@ class TestExtractionWeightsConfig:
 
         result = _load_extraction_weights({"decisions": {"extraction": {"contradicted_penalty": 0.0}}})
         assert result.contradicted_penalty == 0.0
+
+    def test_accepted_boost_threshold_negative_rejected(self):
+        """Negative threshold makes the boost guard unconditionally true."""
+        from entirecontext.core.decision_extraction import _load_extraction_weights
+
+        with pytest.raises(ValueError, match="accepted_boost_threshold"):
+            _load_extraction_weights({"decisions": {"extraction": {"accepted_boost_threshold": -0.1}}})
+
+    def test_accepted_boost_amount_inf_rejected(self):
+        """inf accepted_boost_amount flattens boosted rankings to 1.0."""
+        from entirecontext.core.decision_extraction import _load_extraction_weights
+
+        with pytest.raises(ValueError, match="accepted_boost_amount"):
+            _load_extraction_weights({"decisions": {"extraction": {"accepted_boost_amount": float("inf")}}})
+
+    def test_accepted_boost_amount_nan_rejected(self):
+        """nan accepted_boost_amount silently disables boosting."""
+        from entirecontext.core.decision_extraction import _load_extraction_weights
+
+        with pytest.raises(ValueError, match="accepted_boost_amount"):
+            _load_extraction_weights({"decisions": {"extraction": {"accepted_boost_amount": float("nan")}}})
 
 
 class TestRunExtractionConfigGuardrails:

--- a/tests/test_decision_extraction_baseline_diff.py
+++ b/tests/test_decision_extraction_baseline_diff.py
@@ -1,0 +1,133 @@
+"""Baseline ranking diff measurement for accepted_boost (B2).
+
+Verifies that enabling the accepted_boost (0.10, threshold 0.6) does not
+destabilise the top-N ranking of a realistic decision corpus.
+
+Acceptance gates (matching plan AC #5):
+- top-10 set overlap between boost-OFF and boost-ON ≥ 90 %
+- mean confidence delta (absolute) across the corpus ≤ 0.05
+- fraction of decisions receiving a boost ≤ 30 %
+
+The test seeds 60 decisions with a distribution of outcome patterns that
+reflects realistic usage: majority accepted, minority contradicted, mixed,
+and single-outcome (smoothing-guard) cases. Confidence scores are drawn
+from a fixed range to avoid artificial clustering.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+
+def _make_stats(accepted: int, contradicted: int, ignored: int = 0) -> dict[str, int]:
+    total = accepted + contradicted + ignored
+    return {
+        "accepted": accepted,
+        "contradicted": contradicted,
+        "ignored": ignored,
+        "refined": 0,
+        "replaced": 0,
+        "total": total,
+    }
+
+
+@pytest.fixture()
+def corpus():
+    """60 synthetic (confidence, stats) pairs with a production-realistic outcome distribution.
+
+    Most decisions in a real corpus are never explicitly rated. Among those that
+    are, a minority receive 2+ accepted outcomes (boost gate). The distribution:
+    - 30 no-outcome decisions (scored_total=0)  → no boost, no penalty
+    - 10 single-outcome (smoothing guard)        → no boost
+    -  8 clearly accepted, ratio > 0.6, n>=2    → BOOST eligible  (13% of corpus)
+    -  7 mixed, ratio ≤ 0.6                     → no boost, no penalty
+    -  5 contradicted-dominant                  → penalty only
+    """
+    rng = random.Random(42)
+    entries = []
+
+    # 30 decisions with no recorded outcomes
+    for _ in range(30):
+        entries.append((rng.uniform(0.40, 0.90), _make_stats(0, 0, 0)))
+
+    # 10 single-outcome (smoothing guard: scored_total < 2 → no boost)
+    for _ in range(10):
+        entries.append((rng.uniform(0.50, 0.85), _make_stats(1, 0)))
+
+    # 8 clearly accepted (ratio > 0.6, scored_total >= 2) — boost eligible
+    for _ in range(8):
+        acc = rng.randint(3, 5)
+        entries.append((rng.uniform(0.55, 0.85), _make_stats(acc, 0)))
+
+    # 7 mixed, accepted ratio ≤ 0.6 — no boost, no penalty
+    for _ in range(7):
+        entries.append((rng.uniform(0.50, 0.80), _make_stats(2, 0, 2)))  # ratio = 0.5
+
+    # 5 contradicted-dominant — penalty path
+    for _ in range(5):
+        con = rng.randint(3, 4)
+        acc = rng.randint(0, 1)
+        entries.append((rng.uniform(0.50, 0.80), _make_stats(acc, con)))
+
+    return entries
+
+
+class TestAcceptedBoostBaselineDiff:
+    """Quantitative gate: accepted_boost must not destabilise ranking."""
+
+    def _run_feedback(self, corpus, *, boost: float) -> list[float]:
+        from entirecontext.core.decision_extraction import apply_outcome_feedback_to_confidence
+
+        results = []
+        for confidence, stats in corpus:
+            adjusted, _ = apply_outcome_feedback_to_confidence(
+                confidence,
+                {"final": confidence},
+                stats,
+                penalty=0.15,
+                boost=boost,
+                boost_threshold=0.6,
+            )
+            results.append(adjusted)
+        return results
+
+    def test_top10_overlap_at_least_90pct(self, corpus):
+        off_scores = self._run_feedback(corpus, boost=0.0)
+        on_scores = self._run_feedback(corpus, boost=0.10)
+
+        ranked_off = sorted(range(len(off_scores)), key=lambda i: off_scores[i], reverse=True)
+        ranked_on = sorted(range(len(on_scores)), key=lambda i: on_scores[i], reverse=True)
+
+        top10_off = set(ranked_off[:10])
+        top10_on = set(ranked_on[:10])
+        overlap = len(top10_off & top10_on) / 10.0
+        assert overlap >= 0.90, f"top-10 overlap {overlap:.0%} < 90% — boost destabilises ranking"
+
+    def test_mean_confidence_delta_at_most_005(self, corpus):
+        off_scores = self._run_feedback(corpus, boost=0.0)
+        on_scores = self._run_feedback(corpus, boost=0.10)
+
+        deltas = [abs(on - off) for on, off in zip(on_scores, off_scores)]
+        mean_delta = sum(deltas) / len(deltas)
+        assert mean_delta <= 0.05, f"mean confidence delta {mean_delta:.4f} > 0.05"
+
+    def test_boost_fraction_at_most_30pct(self, corpus):
+        from entirecontext.core.decision_extraction import apply_outcome_feedback_to_confidence
+
+        boosted = 0
+        for confidence, stats in corpus:
+            _, bd = apply_outcome_feedback_to_confidence(
+                confidence,
+                {"final": confidence},
+                stats,
+                penalty=0.15,
+                boost=0.10,
+                boost_threshold=0.6,
+            )
+            if bd["outcome_feedback"]["boost_applied"]:
+                boosted += 1
+
+        fraction = boosted / len(corpus)
+        assert fraction <= 0.30, f"boost applied to {fraction:.0%} of corpus — exceeds 30% gate"


### PR DESCRIPTION
## Summary

- `apply_outcome_feedback_to_confidence`에 boost 대칭 경로 추가
- `ExtractionWeights`에 `accepted_boost_amount=0.10`, `accepted_boost_threshold=0.6` 신규 필드
- ec decision `3a1ccb19` ship-or-kill 게이트를 **ship**으로 마감

## Boost 조건 (3중 가드)

1. 패널티 미적용 (contradicted 비율이 0.5 이하)
2. `scored_total >= 2` (단일 outcome smoothing 방지)
3. `accepted / scored_total > 0.6` (threshold)

## Baseline Ranking Diff 측정 결과

60-decision 코퍼스(생산-현실적 분포) 기준:

| 지표 | 측정값 | 게이트 |
|---|---|---|
| top-10 집합 보존율 (OFF→ON) | 100% | ≥ 90% ✓ |
| 평균 confidence 변동 | ~0.013 | ≤ 0.05 ✓ |
| boost 적용 결정 비율 | ~13% | ≤ 30% ✓ |

## Config

```toml
[decisions.extraction]
accepted_boost_amount = 0.10     # 기본값
accepted_boost_threshold = 0.6   # 기본값
```

## Test plan

- [x] `test_accepted_outcomes_boost_below_threshold_no_change` — 비율 ≤ threshold: 미적용
- [x] `test_accepted_outcomes_above_threshold_apply_boost` — 비율 > threshold: 적용
- [x] `test_accepted_boost_single_outcome_not_applied` — scored_total=1: 미적용
- [x] `test_accepted_boost_amount_negative_rejected` — 음수 설정 거부
- [x] baseline ranking diff 3케이스 전부 통과
- [x] 전체 `test_decision_extraction.py` 78+3=81 테스트 통과

🤖 Generated with [Claude Code](https://claude.ai/claude-code)