### PR TITLE
fix(session): resolve PR #134 review comments for backfill-ended-at

### DIFF
--- a/src/entirecontext/cli/session_cmds.py
+++ b/src/entirecontext/cli/session_cmds.py
@@ -457,7 +457,10 @@ def session_activate(
 def session_backfill_ended_at(
     dry_run: bool = typer.Option(True, "--dry-run/--apply", help="Preview without changes (default) or apply."),
     max_age_hours: int = typer.Option(
-        1, "--max-age-hours", help="Minimum age in hours before a NULL ended_at row is eligible."
+        1,
+        "--max-age-hours",
+        help="Minimum age in hours before a NULL ended_at row is eligible.",
+        min=1,
     ),
 ):
     """Backfill ended_at for sessions where SessionEnd hook was never fired.
@@ -466,12 +469,17 @@ def session_backfill_ended_at(
     --max-age-hours. Sets ended_at = last_activity_at for each eligible row.
     Safe default is --dry-run; pass --apply to commit changes.
     """
-    from ..core.project import find_git_root
+    from ..core.project import find_git_root, get_project
     from ..db import get_db
 
     repo_path = find_git_root()
     if not repo_path:
         console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    project = get_project(repo_path)
+    if not project:
+        console.print("[yellow]Not initialized. Run 'ec init'.[/yellow]")
         raise typer.Exit(1)
 
     conn = get_db(repo_path)
@@ -505,13 +513,26 @@ def session_backfill_ended_at(
             console.print("[dim]Dry-run mode — no changes made. Use --apply to commit.[/dim]")
             return
 
+        # Optimistic concurrency: re-check ended_at IS NULL and last_activity_at unchanged
+        # to avoid clobbering sessions closed or resumed between SELECT and UPDATE.
+        updated = 0
         for row in rows:
-            conn.execute(
-                "UPDATE sessions SET ended_at = last_activity_at WHERE id = ?",
-                (row["id"],),
+            cursor = conn.execute(
+                "UPDATE sessions SET ended_at = last_activity_at"
+                " WHERE id = ? AND ended_at IS NULL AND last_activity_at = ?",
+                (row["id"], row["last_activity_at"]),
             )
+            updated += cursor.rowcount
         conn.commit()
-        console.print(f"[green]Updated {len(rows)} session(s).[/green]")
+
+        skipped = len(rows) - updated
+        if skipped > 0:
+            console.print(
+                f"[green]Updated {updated} session(s).[/green]"
+                f" [dim]({skipped} skipped due to concurrent activity)[/dim]"
+            )
+        else:
+            console.print(f"[green]Updated {updated} session(s).[/green]")
     finally:
         conn.close()
 

--- a/tests/test_session_cmds.py
+++ b/tests/test_session_cmds.py
@@ -169,11 +169,21 @@ class TestSessionBackfillEndedAt:
             result = runner.invoke(app, ["session", "backfill-ended-at"])
             assert result.exit_code == 1
 
+    def test_not_initialized(self):
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value=None),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at"])
+            assert result.exit_code == 1
+            assert "init" in result.output.lower()
+
     def test_no_eligible_rows(self):
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchall.return_value = []
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at"])
@@ -188,6 +198,7 @@ class TestSessionBackfillEndedAt:
         ]
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at"])
@@ -203,8 +214,10 @@ class TestSessionBackfillEndedAt:
             {"id": "sess-old-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
         ]
         mock_conn.execute.return_value.fetchall.return_value = eligible
+        mock_conn.execute.return_value.rowcount = 1
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at", "--apply"])
@@ -218,12 +231,43 @@ class TestSessionBackfillEndedAt:
         mock_conn.execute.return_value.fetchall.return_value = []
         with (
             patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
             patch("entirecontext.db.get_db", return_value=mock_conn),
         ):
             result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "2"])
             assert result.exit_code == 0
             call_args = mock_conn.execute.call_args
             assert "-2 hours" in call_args[0][1]
+
+    def test_max_age_hours_zero_rejected(self):
+        result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "0"])
+        assert result.exit_code != 0
+
+    def test_max_age_hours_negative_rejected(self):
+        result = runner.invoke(app, ["session", "backfill-ended-at", "--max-age-hours", "-5"])
+        assert result.exit_code != 0
+
+    def test_apply_skips_concurrent_modification(self):
+        """UPDATE WHERE re-checks ended_at IS NULL and last_activity_at; rowcount=0 = skipped."""
+        mock_conn = MagicMock()
+        eligible = [
+            {"id": "sess-001-uuid", "last_activity_at": "2025-01-01T09:00:00"},
+            {"id": "sess-002-uuid", "last_activity_at": "2025-01-02T10:00:00"},
+        ]
+        select_cursor = MagicMock()
+        select_cursor.fetchall.return_value = eligible
+        update_cursor = MagicMock()
+        update_cursor.rowcount = 0
+        mock_conn.execute.side_effect = [select_cursor, update_cursor, update_cursor]
+        with (
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.get_project", return_value={"id": "proj-1"}),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+        ):
+            result = runner.invoke(app, ["session", "backfill-ended-at", "--apply"])
+            assert result.exit_code == 0
+            assert "Updated 0 session(s)" in result.output
+            assert "2 skipped" in result.output
 
 
 class TestSessionCurrent:


### PR DESCRIPTION
## Summary

Addresses all 4 review comments on #134 (`backfill-ended-at` CLI). Merge this into `feat/v070-debt-b1-b3` to update #134.

## Fixes

| # | Reviewer | Issue | Fix |
|---|----------|-------|-----|
| 1 | claude | `--max-age-hours` accepts `0`/negative, breaking the 1h safety window | `min=1` on the Typer Option |
| 2 | chatgpt-codex-connector | Missing init guard → `OperationalError: no such table: sessions` | `get_project` check matching other session commands |
| 3 | chatgpt-codex-connector | UPDATE-by-id can clobber a session a `SessionEnd` hook just closed | `AND ended_at IS NULL` in UPDATE WHERE |
| 4 | chatgpt-codex-connector | UPDATE doesn't re-check staleness; can close a resumed session | Optimistic concurrency: `AND last_activity_at = ?` against the SELECT-time value |

When a row is skipped due to concurrent activity, the output now reports `Updated N session(s). (M skipped due to concurrent activity)`.

## Test plan

- [x] 4 new tests added (`test_not_initialized`, `test_max_age_hours_zero_rejected`, `test_max_age_hours_negative_rejected`, `test_apply_skips_concurrent_modification`)
- [x] Existing 5 tests updated to mock `get_project` and `rowcount`
- [x] `uv run pytest tests/test_session_cmds.py -v` → 22/22 passed
- [x] `uv run ruff format` + `uv run ruff check` clean

https://claude.ai/code/session_01AGAnfCNYoctsJZxKJEqqh7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAnfCNYoctsJZxKJEqqh7)_