### PR TITLE
docs(research): PR-D0 hook contract spike — UserPromptSubmit additionalContext confirmed

### DIFF
--- a/docs/research/v0-7-0-hook-contract-spike.md
+++ b/docs/research/v0-7-0-hook-contract-spike.md
@@ -5,8 +5,8 @@ Verifies that `UserPromptSubmit` hook stdout is captured as `additionalContext` 
 
 ## Status
 
+- [x] **CONFIRMED** (2026-05-20) — proceed to PR-D / PR-E
 - [ ] PENDING (not yet tested)
-- [ ] CONFIRMED — proceed to PR-D / PR-E
 - [ ] REJECTED — scope PDI to v0.7.1; v0.7.0 = PR-A/B/C only
 
 ---
@@ -65,11 +65,12 @@ The existing `ec hook handle` entry stays — add the probe alongside it:
 
 ## Results
 
-### If CONFIRMED
+### If CONFIRMED ✓
 
-- Exact JSON key path that Claude Code reads: `hookSpecificOutput.additionalContext`
-- How injected context is presented (system-reminder? prepended to prompt? separate section?): TBD
-- Is the entire `additionalContext` string included verbatim, or truncated?
+- Exact JSON key path: `hookSpecificOutput.additionalContext`
+- How injected: appears as `<system-reminder>` tag prefixed with `UserPromptSubmit hook additional context:`
+- Full string verbatim — no truncation observed
+- Verified 2026-05-20: spike probe text appeared in Claude Code system context on next prompt
 
 ### If REJECTED
 

--- a/docs/research/v0-7-0-hook-contract-spike.md
+++ b/docs/research/v0-7-0-hook-contract-spike.md
@@ -1,0 +1,100 @@
+# PR-D0: UserPromptSubmit Hook Contract Spike
+
+Blocking gate for PDI (Proactive Decision Injection, PR-E).
+Verifies that `UserPromptSubmit` hook stdout is captured as `additionalContext` by Claude Code.
+
+## Status
+
+- [ ] PENDING (not yet tested)
+- [ ] CONFIRMED — proceed to PR-D / PR-E
+- [ ] REJECTED — scope PDI to v0.7.1; v0.7.0 = PR-A/B/C only
+
+---
+
+## Probe Script
+
+`scripts/spike_probe.py` — reads stdin (hook protocol), writes probe JSON to stdout:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "<SPIKE_PROBE: ...>"
+  }
+}
+```
+
+---
+
+## Registration
+
+Add as a **second** hook entry under `UserPromptSubmit` in `.claude/settings.local.json`.
+The existing `ec hook handle` entry stays — add the probe alongside it:
+
+```json
+"UserPromptSubmit": [
+  {
+    "matcher": "",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "/Users/teslamint/.local/share/uv/tools/entirecontext/bin/ec hook handle --type UserPromptSubmit",
+        "timeout": 5
+      },
+      {
+        "type": "command",
+        "command": "uv run --project /Users/teslamint/workspace/entirecontext python scripts/spike_probe.py",
+        "timeout": 5
+      }
+    ]
+  }
+]
+```
+
+---
+
+## Verification Procedure
+
+1. Add probe entry to `settings.local.json` (see Registration above).
+2. **Restart Claude Code** (MCP server reload required).
+3. Submit any user prompt (e.g., "hello").
+4. Check if the string `<SPIKE_PROBE` appears in a `<system-reminder>` or similar injected context in the **same or next turn**.
+5. Record result below.
+
+---
+
+## Results
+
+### If CONFIRMED
+
+- Exact JSON key path that Claude Code reads: `hookSpecificOutput.additionalContext`
+- How injected context is presented (system-reminder? prepended to prompt? separate section?): TBD
+- Is the entire `additionalContext` string included verbatim, or truncated?
+
+### If REJECTED
+
+- Did hook stdout emit correctly (check with `echo '{}' | uv run python scripts/spike_probe.py`)?
+- Alternatives tested:
+  - [ ] Raw markdown stdout (no JSON wrapper)
+  - [ ] `output` key instead of `hookSpecificOutput`
+  - [ ] `decision` key
+- Conclusion: PDI must wait for a confirmed contract or use fallback path only
+
+---
+
+## Decision Gate
+
+| Spike Result | PR-D / PR-E Action |
+|---|---|
+| CONFIRMED | Proceed: extract `rank_decisions_for_prompt`, implement sync stdout path |
+| REJECTED | Defer PDI to v0.7.1; v0.7.0 ships PR-A/B/C only (B1+B2+B3 debt cleanup) |
+
+If rejected but raw markdown stdout works, PR-E can be redesigned to use markdown fallback as the **primary** path — document exact working format here.
+
+---
+
+## Notes
+
+- The `additionalContext` design assumption originates in `docs/superpowers/specs/2026-04-04-decision-hooks-design.md:60`.
+- F4 (async worker writing `.entirecontext/decisions-context-prompt-*.md`) was adopted precisely because this contract was unverified at v0.4.0.
+- This spike resolves that open assumption before committing 5+ days of PDI work.

--- a/scripts/spike_probe.py
+++ b/scripts/spike_probe.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""PR-D0 spike: verify UserPromptSubmit hook stdout → additionalContext contract.
+
+Temporary script. Delete once spike is resolved (see docs/research/v0-7-0-hook-contract-spike.md).
+
+Registration (add as second hook in .claude/settings.local.json):
+  {
+    "type": "command",
+    "command": "uv run --project /path/to/entirecontext python scripts/spike_probe.py",
+    "timeout": 5
+  }
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+sys.stdin.read()
+
+json.dump(
+    {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": (
+                "<SPIKE_PROBE: If you can read this text in the conversation context, "
+                "the UserPromptSubmit→additionalContext contract is CONFIRMED. "
+                "EntireContext PR-D0 spike result: PASS.>"
+            ),
+        }
+    },
+    sys.stdout,
+)


### PR DESCRIPTION
## Summary

- Minimal spike probe script outputs `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<SPIKE_PROBE>"}}` to stdout
- Verified: Claude Code injects it as `<system-reminder>` tagged "UserPromptSubmit hook additional context:" verbatim in the next turn
- Documents exact JSON schema, injection format, and no-truncation behavior

## Why this matters

PR-E (PDI core) places additionalContext injection on the critical path. This spike was a blocking gate before building on that contract (plan §PR-D0).

## Result

**CONFIRMED** — `additionalContext` appears verbatim in system-reminder. PR-E is unblocked.

Spike probe script (`scripts/spike_probe.py`) is included for auditability but not wired into production hooks.

## Test plan

- [x] `scripts/spike_probe.py` runs and outputs valid JSON
- [x] `docs/research/v0-7-0-hook-contract-spike.md` documents confirmed contract + exact injection format

🤖 Generated with [Claude Code](https://claude.ai/code)