### PR TITLE
perf(decisions): PR-D PDI baseline measurement — p95@1000=61.8ms, default inject ON

### DIFF
--- a/docs/perf/v0-7-0-pdi-baseline.md
+++ b/docs/perf/v0-7-0-pdi-baseline.md
@@ -1,0 +1,29 @@
+# PDI Performance Baseline — v0.7.0
+
+Measured with 20 repetitions per corpus size.
+Input: 10 file paths + simulated diff (2 hunks) + 10 commit SHAs.
+
+## Results
+
+| Corpus size | p50 (ms) | p95 (ms) | Gate (< 250ms) |
+|---|---|---|---|
+| 100 | 4.5 | 5.5 | PASS ✓ |
+| 500 | 21.1 | 25.3 | PASS ✓ |
+| 1,000 | 43.8 | 61.8 | PASS ✓ |
+
+## Decision
+
+**`inject_on_user_prompt` default: `true`**
+
+p95 < 250ms at 1000 decisions → sync PDI path is fast enough for default-ON.
+
+## Raw Timings (ms)
+
+### 100 decisions
+4.2, 4.2, 4.3, 4.3, 4.3, 4.4, 4.4, 4.4, 4.4, 4.5, 4.5, 4.6, 4.6, 4.8, 5.0, 5.1, 5.1, 5.3, 5.4, 5.5
+
+### 500 decisions
+20.2, 20.3, 20.3, 20.4, 20.5, 20.5, 20.5, 20.8, 20.8, 21.1, 21.1, 21.2, 21.3, 21.4, 21.5, 21.7, 21.8, 23.1, 23.2, 25.4
+
+### 1,000 decisions
+41.1, 41.6, 41.7, 42.0, 42.1, 42.2, 42.9, 42.9, 43.1, 43.7, 43.8, 43.8, 44.1, 44.3, 44.8, 45.0, 47.4, 49.9, 56.3, 62.1

--- a/tests/fixtures/perf_decisions.py
+++ b/tests/fixtures/perf_decisions.py
@@ -1,0 +1,94 @@
+"""Synthetic decision corpus for PDI performance measurement (PR-D).
+
+Seeds an in-memory SQLite DB with N decisions covering a realistic
+distribution of scopes, file associations, and staleness statuses.
+Call `seed_perf_db(conn, n)` after bootstrapping the schema.
+"""
+
+from __future__ import annotations
+
+import random
+import sqlite3
+from uuid import uuid4
+
+_FILE_POOL = [
+    "src/entirecontext/core/decisions.py",
+    "src/entirecontext/core/decision_extraction.py",
+    "src/entirecontext/core/decision_prompt_surfacing.py",
+    "src/entirecontext/hooks/handler.py",
+    "src/entirecontext/hooks/turn_capture.py",
+    "src/entirecontext/hooks/session_lifecycle.py",
+    "src/entirecontext/cli/session_cmds.py",
+    "src/entirecontext/cli/decision_cmds.py",
+    "src/entirecontext/db/migration.py",
+    "src/entirecontext/db/connection.py",
+    "src/entirecontext/core/config.py",
+    "src/entirecontext/core/context.py",
+    "src/entirecontext/core/search.py",
+    "src/entirecontext/core/telemetry.py",
+    "src/entirecontext/core/export.py",
+    "tests/test_decisions.py",
+    "tests/test_handler.py",
+    "tests/test_decision_extraction.py",
+    "pyproject.toml",
+    "CHANGELOG.md",
+]
+
+_TITLES_KO = [
+    "결정 추출 신뢰도 임계값 설정",
+    "SessionEnd 훅 타임아웃 정책",
+    "accepted_boost 대칭 경로 도입",
+    "FTS5 전문 검색 인덱스 설계",
+    "PDI 동기 경로 기본값 결정",
+    "outcome 피드백 lookback 기간",
+    "SQLite WAL 모드 적용 이유",
+    "turn content JSONL 하이브리드 저장",
+    "MCP 서버 재시작 정책",
+    "랭킹 가중치 기본값 캘리브레이션",
+]
+_TITLES_EN = [
+    "Ranker weight calibration for file-signal dominance",
+    "Decision scope taxonomy — three tiers",
+    "Supersede chain collapse policy",
+    "Rejected-alternative normalization format",
+    "Context budget optimizer token heuristic",
+    "FTS5 rank signal weight vs file-match signal",
+    "Hook protocol: stdin JSON, stdout JSON",
+    "Schema version policy — migration-only forward",
+    "Confidence score clamp at [0, 1]",
+    "Staleness factor multiplicative vs additive",
+]
+_SCOPES = ["core", "hooks", "cli", "db", "config", "testing", "docs", "mcp", "sync"]
+_STATUSES = ["fresh"] * 7 + ["stale"] * 2 + ["superseded"] * 1
+
+
+def seed_perf_db(conn: sqlite3.Connection, n: int, *, rng_seed: int = 0) -> list[str]:
+    """Insert n synthetic decisions; return list of inserted IDs."""
+    rng = random.Random(rng_seed)
+    titles = _TITLES_KO + _TITLES_EN
+    ids: list[str] = []
+
+    for i in range(n):
+        did = str(uuid4())
+        title = f"{rng.choice(titles)} #{i}"
+        rationale = f"Rationale for decision {i}. " * rng.randint(2, 6)
+        scope = rng.choice(_SCOPES)
+        status = rng.choice(_STATUSES)
+        ts = f"2026-0{rng.randint(1, 5)}-{rng.randint(1, 28):02d}T{rng.randint(0, 23):02d}:00:00Z"
+        conn.execute(
+            """INSERT INTO decisions (
+                id, title, rationale, scope, staleness_status,
+                rejected_alternatives, supporting_evidence, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (did, title, rationale, scope, status, "[]", "[]", ts, ts),
+        )
+        # Link 0–3 files per decision
+        for fp in rng.sample(_FILE_POOL, rng.randint(0, 3)):
+            conn.execute(
+                "INSERT INTO decision_files (decision_id, file_path, added_at) VALUES (?, ?, ?)",
+                (did, fp, ts),
+            )
+        ids.append(did)
+
+    conn.commit()
+    return ids

--- a/tests/test_hooks_performance.py
+++ b/tests/test_hooks_performance.py
@@ -1,0 +1,170 @@
+"""PR-D: PDI performance baseline measurement.
+
+Measures rank_related_decisions p50/p95 across 100/500/1000 decision corpora.
+Gate: p95 < 250ms at 1000 decisions → default inject_on_user_prompt = true.
+
+Results are written to docs/perf/v0-7-0-pdi-baseline.md when the env var
+RECORD_PERF=1 is set (CI skips writing; local measurement run produces the doc).
+
+Usage:
+    RECORD_PERF=1 uv run pytest tests/test_hooks_performance.py -s -v
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from statistics import median, quantiles
+
+import pytest
+
+from tests.fixtures.perf_decisions import seed_perf_db
+
+REPO_ROOT = Path(__file__).parent.parent
+PERF_DOC = REPO_ROOT / "docs" / "perf" / "v0-7-0-pdi-baseline.md"
+
+_SAMPLE_DIFF = """\
+diff --git a/src/entirecontext/hooks/handler.py b/src/entirecontext/hooks/handler.py
+index abc1234..def5678 100644
+--- a/src/entirecontext/hooks/handler.py
++++ b/src/entirecontext/hooks/handler.py
+@@ -90,6 +90,28 @@ def _handle_user_prompt(data: dict) -> int:
++    # PDI sync path: rank decisions and inject as additionalContext
++    from .turn_capture import on_user_prompt
++    on_user_prompt(data)
++    return 0
+diff --git a/src/entirecontext/core/decisions.py b/src/entirecontext/core/decisions.py
+index 1234567..abcdef0 100644
+--- a/src/entirecontext/core/decisions.py
++++ b/src/entirecontext/core/decisions.py
+@@ -1308,6 +1308,8 @@ def rank_related_decisions(
++    # New: extract rank_decisions_for_prompt for PDI sync path
++    pass
+"""
+
+_SAMPLE_FILES = [
+    "src/entirecontext/hooks/handler.py",
+    "src/entirecontext/core/decisions.py",
+    "src/entirecontext/core/decision_prompt_surfacing.py",
+    "src/entirecontext/hooks/turn_capture.py",
+    "src/entirecontext/cli/session_cmds.py",
+    "src/entirecontext/db/migration.py",
+    "src/entirecontext/core/config.py",
+    "src/entirecontext/core/context.py",
+    "tests/test_handler.py",
+    "tests/test_decisions.py",
+]
+
+_SAMPLE_COMMITS = [f"abc{i:04x}def{i:04x}0000000000000000" for i in range(10)]
+
+_REPETITIONS = 20
+_SIZES = [100, 500, 1000]
+
+
+def _make_perf_db(n: int):
+    from entirecontext.db.connection import get_memory_db
+    from entirecontext.db.migration import bootstrap_schema
+
+    conn = get_memory_db()
+    bootstrap_schema(conn)
+    seed_perf_db(conn, n)
+    return conn
+
+
+def _measure(conn) -> list[float]:
+    from entirecontext.core.decisions import rank_related_decisions
+
+    timings: list[float] = []
+    for _ in range(_REPETITIONS):
+        t0 = time.perf_counter()
+        rank_related_decisions(
+            conn,
+            file_paths=_SAMPLE_FILES,
+            diff_text=_SAMPLE_DIFF,
+            commit_shas=_SAMPLE_COMMITS,
+            assessment_ids=[],
+            limit=10,
+            include_contradicted=False,
+        )
+        timings.append((time.perf_counter() - t0) * 1000)
+    return timings
+
+
+class TestPDIPerformanceBaseline:
+    """Quantitative gate: rank_related_decisions must stay under 250ms p95 at 1000 decisions."""
+
+    @pytest.fixture(scope="class")
+    def results(self):
+        data: dict[int, dict] = {}
+        for n in _SIZES:
+            conn = _make_perf_db(n)
+            timings = _measure(conn)
+            conn.close()
+            timings_sorted = sorted(timings)
+            p50 = median(timings_sorted)
+            p95 = quantiles(timings_sorted, n=20)[18]  # 95th percentile
+            data[n] = {"p50": p50, "p95": p95, "timings": timings_sorted}
+        return data
+
+    def test_p95_under_250ms_at_100(self, results):
+        p95 = results[100]["p95"]
+        assert p95 < 250, f"p95@100={p95:.1f}ms ≥ 250ms"
+
+    def test_p95_under_250ms_at_500(self, results):
+        p95 = results[500]["p95"]
+        assert p95 < 250, f"p95@500={p95:.1f}ms ≥ 250ms"
+
+    def test_p95_under_250ms_at_1000(self, results):
+        p95 = results[1000]["p95"]
+        assert p95 < 250, f"p95@1000={p95:.1f}ms ≥ 250ms — default inject_on_user_prompt should be false"
+
+    def test_record_results(self, results):
+        """Write markdown results doc when RECORD_PERF=1."""
+        if not os.getenv("RECORD_PERF"):
+            pytest.skip("Set RECORD_PERF=1 to record results to docs/perf/")
+
+        lines = [
+            "# PDI Performance Baseline — v0.7.0",
+            "",
+            f"Measured with {_REPETITIONS} repetitions per corpus size.",
+            "Input: 10 file paths + simulated diff (2 hunks) + 10 commit SHAs.",
+            "",
+            "## Results",
+            "",
+            "| Corpus size | p50 (ms) | p95 (ms) | Gate (< 250ms) |",
+            "|---|---|---|---|",
+        ]
+        default_on = True
+        for n in _SIZES:
+            p50 = results[n]["p50"]
+            p95 = results[n]["p95"]
+            gate = "PASS ✓" if p95 < 250 else "FAIL ✗"
+            if n == 1000 and p95 >= 250:
+                default_on = False
+            lines.append(f"| {n:,} | {p50:.1f} | {p95:.1f} | {gate} |")
+
+        lines += [
+            "",
+            "## Decision",
+            "",
+            f"**`inject_on_user_prompt` default: `{'true' if default_on else 'false'}`**",
+            "",
+            (
+                "p95 < 250ms at 1000 decisions → sync PDI path is fast enough for default-ON."
+                if default_on
+                else "p95 ≥ 250ms at 1000 decisions → default-OFF; operator opt-in via config."
+            ),
+            "",
+            "## Raw Timings (ms)",
+            "",
+        ]
+        for n in _SIZES:
+            ts = results[n]["timings"]
+            lines.append(f"### {n:,} decisions")
+            lines.append(", ".join(f"{t:.1f}" for t in ts))
+            lines.append("")
+
+        PERF_DOC.parent.mkdir(parents=True, exist_ok=True)
+        PERF_DOC.write_text("\n".join(lines), encoding="utf-8")
+        print(f"\nWrote perf baseline to {PERF_DOC}")


### PR DESCRIPTION
## Summary

- Synthetic decision fixture (`tests/fixtures/perf_decisions.py`): seeds 100/500/1000 decisions with realistic variety (Korean/English titles, 9 scopes, fresh/stale/superseded mix)
- Performance test (`tests/test_hooks_performance.py`): 20-rep p50/p95 measurement at each scale
- Results recorded in `docs/perf/v0-7-0-pdi-baseline.md`

## Results

| N | p50 | p95 | Gate (< 250ms) |
|---|-----|-----|----------------|
| 100 | 4.5ms | 5.5ms | ✅ PASS |
| 500 | 21.1ms | 25.3ms | ✅ PASS |
| 1000 | 43.8ms | 61.8ms | ✅ PASS |

**Decision: `inject_on_user_prompt = true` (default ON)**

All three scale points pass the p95 < 250ms gate by 4× margin at the 1000-decision level.

## Test plan

- [x] `uv run pytest tests/test_hooks_performance.py -v` → 3 gate tests + 1 record test pass
- [x] `docs/perf/v0-7-0-pdi-baseline.md` written with full measurement table
- [x] `uv run ruff format` + `uv run ruff check` clean

🤖 Generated with [Claude Code](https://claude.ai/code)