### PR TITLE
release: v0.7.0 — Proactive Decision Injection + debt clearance (B1/B2/B3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,12 +219,22 @@ Stored decisions are inputs to judgment, not blind rules. Follow relevant fresh 
 #### Pattern: Hook-Driven Automation
 The hook system captures development activity automatically:
 - **SessionStart** → creates/resumes session tracking
-- **UserPromptSubmit** → captures each user prompt as a turn
+- **UserPromptSubmit** → captures each user prompt as a turn; **also injects top-k relevant decisions into `additionalContext`** (Proactive Decision Injection, v0.7.0+)
 - **PostToolUse** → tracks tools and files touched
 - **Stop** → captures assistant response summary
 - **SessionEnd** → generates summaries, triggers auto-sync/embed/distill
 - **PostCommit** (git hook) → creates checkpoint on each commit
 - **pre-push** (git hook) → triggers `ec sync --if-enabled`
+
+#### Proactive Memory Reuse (v0.7.0+)
+
+Starting with v0.7.0, the `UserPromptSubmit` hook is the **default delivery channel** for relevant decisions. On every user prompt, EntireContext synchronously ranks top-k decisions and injects them as `additionalContext` so Claude Code receives decision guidance before generating each response.
+
+**What this means for agents working in this repo**: relevant decisions now appear automatically as `<system-reminder>` context tagged "UserPromptSubmit hook additional context:". You do not need to call `ec_decision_related` or `ec search` for routine decision lookup — the hook pre-populates relevant decisions. Use explicit MCP/CLI retrieval only when:
+- you need decisions beyond the injected top-k (more breadth)
+- you need to filter by staleness, file, or outcome
+- PDI was skipped (no session, capture disabled, or timeout exceeded)
+- you want to record usage or outcomes
 
 ### Adding New CLI Commands
 When adding a new CLI command:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-20
+
+v0.7.0 makes EntireContext proactive: the `UserPromptSubmit` hook now injects the top-k most relevant decisions directly into Claude Code's context on every prompt turn. Three debt items are also closed: `ended_at NULL` backfill CLI (B1), `unverified_changes.patch` removal (B3), and `accepted_boost` confidence scoring (B2).
+
+**Breaking change (default-on)**: `[decisions.injection] inject_on_user_prompt = true` is the default. Operators who want to disable injection must set it to `false` in `.entirecontext/config.toml`.
+
+### Added
+
+- **Proactive Decision Injection (PDI)** — `UserPromptSubmit` hook synchronously ranks top-k decisions, trims to token budget, and outputs `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "<md>"}}` to stdout. Claude Code injects the markdown into the next turn as a `<system-reminder>` so relevant decisions surface without any agent query.
+- **`[decisions.injection]` config section** — `inject_on_user_prompt` (bool, default true), `top_k` (int, default 5), `max_tokens` (int, default 800), `min_confidence` (float, default 0.4), `inject_timeout_ms` (int, default 250).
+- **`rank_decisions_for_prompt()`** in `core/decision_prompt_surfacing.py` — pure ranking function (no side effects) reused by both sync PDI path and async fallback worker.
+- **`optimize_for_context_budget()`** — min_confidence cut → top_k slice → cumulative token trim (low-score first) → single-entry rationale truncation.
+- **`ec session backfill-ended-at`** — CLI to recover sessions with `ended_at IS NULL` from hook miss (5s timeout/SIGKILL). Options: `--dry-run`/`--apply`, `--max-age-hours` (min 1). Uses optimistic concurrency (`AND last_activity_at = ?`) to skip sessions with new activity between SELECT and UPDATE.
+- **PDI performance baseline** (`docs/perf/v0-7-0-pdi-baseline.md`) — 100/500/1000-decision p50/p95 gate measurement. p95@1000 = 61.8ms (gate: 250ms). Default ON.
+- **Hook contract research** (`docs/research/v0-7-0-hook-contract-spike.md`) — confirmed `additionalContext` appears verbatim in `<system-reminder>` tagged "UserPromptSubmit hook additional context:".
+
+### Changed
+
+- **`accepted_boost` (B2)** — `apply_outcome_feedback_to_confidence` boosts confidence by `accepted_boost_amount` (default 0.10) when: penalty not applied, `scored_total >= 2`, `accepted / scored_total > accepted_boost_threshold` (default 0.6). Closes ec decision `3a1ccb19`.
+- **`_coerce_extraction_nonneg_float`** — now also rejects non-finite values (`inf`, `nan`). `accepted_boost_threshold` uses `_coerce_extraction_nonneg_float` (was `_coerce_extraction_float`; negative threshold made boost unconditionally true).
+- **`get_memory_db()`** — adds `check_same_thread=False` so in-memory test connections can be passed to worker threads.
+
+### Removed
+
+- **`unverified_changes.patch`** (B3) — duplicate of already-committed docs files (docs/documentation_in_prs_proposal.md, docs/tiered_review_policy_proposal.md).
+
 ## [0.6.1] - 2026-05-20
 
 v0.6.1 hardens the rejected-alternatives data shape for decision memory. Legacy string entries are normalized to structured objects; a new `ec decision alternatives` sub-command group provides audit, normalize, and set operations. Extraction prompts now request structured reasons without inventing them.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ auto_promotion_contradicted_threshold = 2
 
 Decision retrieval does not have to be query-only. EntireContext can surface relevant past decisions automatically when you start a task, when you edit decision-linked files mid-session, and through a single MCP convenience call.
 
+### Proactive Decision Injection (UserPromptSubmit hook)
+
+Starting with v0.7.0, the `UserPromptSubmit` hook ranks top-k decisions against every user prompt and injects them directly into Claude Code's context as `additionalContext` — no agent query needed:
+
+```
+## Related Decisions
+
+### 1. Use SQLite WAL mode for agent memory
+  ID: `aaaabbbb-cccc`
+  Status: fresh
+  Score: 0.87
+
+  WAL mode allows concurrent readers without blocking writes, critical for hook throughput.
+```
+
+The injection is synchronous with a hard wall-clock timeout (default 250 ms). If ranking exceeds the deadline, the hook returns without output and the async fallback path takes over.
+
+**Configuration** (`.entirecontext/config.toml`):
+
+```toml
+[decisions.injection]
+inject_on_user_prompt = true   # default ON; set false to disable
+top_k = 5                      # max decisions to surface
+max_tokens = 800               # context budget (heuristic UTF-8 ÷ 3)
+min_confidence = 0.4           # minimum relevance score
+inject_timeout_ms = 250        # hard wall-clock cap for the sync path
+```
+
 ### Mid-session surfacing (PostToolUse hook)
 
 Enable the hook so that decisions linked to just-edited files appear inline after every file edit:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,6 +168,18 @@ Theme: clean up the rejected-alternatives data shape without mutating existing r
 - [x] Tighten extraction prompts to request rejected-alternative reasons only when source text contains enough evidence; parser and candidate-confirmation paths share the same normalizer
 - [x] Tests: legacy string compatibility, malformed JSON detection, mixed arrays, empty alternatives, empty reasons, audit categories, normalization idempotency, manual set behavior
 
+## v0.7.0 — Proactive Decision Injection + Debt Clearance
+
+Theme: make retrieval default behavior, close three deferred debt items.
+
+- [x] **PDI: `rank_decisions_for_prompt()`** — pure ranking function extracted from async worker, reusable by both sync and async paths
+- [x] **PDI: `optimize_for_context_budget()`** — min_confidence cut → top_k slice → token trim → rationale truncation
+- [x] **PDI: `UserPromptSubmit` hook stdout JSON** — `additionalContext` injection with `inject_timeout_ms` hard cap (default 250ms, `shutdown(wait=False)`)
+- [x] **PDI: `[decisions.injection]` config section** — `inject_on_user_prompt=true` default (p95@1000=61.8ms < 250ms gate)
+- [x] **B1: `ec session backfill-ended-at`** — recover `ended_at IS NULL` rows with optimistic concurrency and 1h safety gate
+- [x] **B2: `accepted_boost`** — `accepted_boost_amount`/`accepted_boost_threshold` in `ExtractionWeights`; finishes ec decision `3a1ccb19`
+- [x] **B3: Remove `unverified_changes.patch`** — duplicate of already-committed docs files
+
 ## Hardening Backlog
 
 Structural debt outside the "decision memory depth" wedge. The three items previously listed here (`confirm_candidate` atomicity, `LEGACY_TRANSACTION_CONTROL`, review-bot noise) have been absorbed into v0.5.0 — see S1, S2, S4 above. New items go here as they are surfaced.
@@ -194,8 +206,6 @@ Structural debt outside the "decision memory depth" wedge. The three items previ
 ## Exploration
 
 Items below have been evaluated in the 2026-04-27 ideation session ([docs/ideation/2026-04-27-product-roadmap-ideation.md](docs/ideation/2026-04-27-product-roadmap-ideation.md)) and promoted to concrete candidates. Items marked "moved from v0.6.0" were initially proposed for the breaking track but fall outside the outcome-lifecycle scope defined in `docs/brainstorms/v0-6-0-roadmap-plan.md`.
-
-- **Proactive Decision Injection** — `UserPromptSubmit` hook auto-pushes top-k relevant decisions into `additionalContext` without agent query; Context Budget Optimizer (token cap + confidence threshold) gates noise. Highest-leverage retrieval improvement — converts AGENTS.md policy from opt-in to default behavior. _(Confidence 92%, Medium complexity)_ Plan reference: `docs/brainstorms/proactive-decision-injection.md`.
 
 - **Temporal Query Language (TQL)** — `--at <ref>`, `since:`, `between:` syntax for all search/retrieval commands; queries evaluate against memory state at a specific git commit or date. Exploits EC's unique moat (git-anchored time-travel) — no competitor offers this. _(Confidence 88%, Medium complexity)_ Plan reference: `docs/brainstorms/temporal-query-language.md`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "entirecontext"
-version = "0.6.1"
+version = "0.7.0"
 description = "Time-travel searchable agent memory anchored to your codebase"
 readme = "README.md"
 authors = [

--- a/scripts/spike_probe.py
+++ b/scripts/spike_probe.py
@@ -10,6 +10,7 @@ Registration (add as second hook in .claude/settings.local.json):
     "timeout": 5
   }
 """
+
 from __future__ import annotations
 
 import json

--- a/src/entirecontext/__init__.py
+++ b/src/entirecontext/__init__.py
@@ -1,3 +1,3 @@
 """EntireContext — Time-travel searchable agent memory anchored to your codebase."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ nvtx = [
 
 [[package]]
 name = "entirecontext"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygments" },


### PR DESCRIPTION
## Summary

- Version bump: 0.6.1 → 0.7.0
- CHANGELOG v0.7.0 entry
- ROADMAP v0.7.0 section (moved PDI from Exploration to Done)
- README: Proactive Decision Injection section with config table
- AGENTS.md: Proactive Memory Reuse section (v0.7.0+)
- uv.lock refresh

## What shipped in this release (via prior PRs)

| PR | Feature |
|----|---------|
| #137 | PR-D0: hook contract spike — additionalContext CONFIRMED |
| #138 | PR-D: PDI performance baseline (p95@1000=61.8ms → default ON) |
| #139 | PR-E: PDI core — `rank_decisions_for_prompt`, `optimize_for_context_budget`, `UserPromptSubmit` JSON stdout |
| #135 | B2: `accepted_boost` confidence scoring |
| #134 | B1: `ec session backfill-ended-at` + B3: patch removal |

## Breaking change

`[decisions.injection] inject_on_user_prompt = true` is now the default. Set `false` to opt out.

## Test plan

- [x] `uv run pytest` → 1595 passed, 93 skipped
- [x] `uv run ruff format` + `uv run ruff check` clean
- [x] `pyproject.toml version` == `__version__` == `"0.7.0"`

🤖 Generated with [Claude Code](https://claude.ai/code)