### PR TITLE
fix(hooks): address PDI review comments — timeout, double probe, per-session gate, budget overflow

### DIFF
--- a/src/entirecontext/core/decision_prompt_surfacing.py
+++ b/src/entirecontext/core/decision_prompt_surfacing.py
@@ -249,6 +249,9 @@ def optimize_for_context_budget(
         d = {**trimmed[0]}
         if d.get("rationale") and len(d["rationale"]) > 100:
             d["rationale"] = d["rationale"][:100] + "…"
+        # Second-pass: if still over budget because of a long title, truncate it too.
+        if _tokens_for([d]) > max_tokens and d.get("title") and len(d["title"]) > 80:
+            d["title"] = d["title"][:80] + "…"
         trimmed = [d]
 
     return trimmed

--- a/src/entirecontext/hooks/handler.py
+++ b/src/entirecontext/hooks/handler.py
@@ -88,23 +88,24 @@ def _handle_session_start(data: dict[str, Any]) -> int:
 
 
 def _handle_user_prompt(data: dict[str, Any]) -> int:
+    import threading
+
+    from ..core.project import find_git_root
     from .turn_capture import on_user_prompt
 
-    on_user_prompt(data)
-
     cwd = data.get("cwd", ".")
-    prompt_text = data.get("prompt", "")
+    # Resolve git root once — pass to on_user_prompt to avoid a second probe.
+    repo_path = find_git_root(cwd)
+
+    on_user_prompt(data, _resolved_repo_path=repo_path)
+
     session_id = data.get("session_id")
-    if not session_id:
+    if not session_id or not repo_path:
         return 0
 
+    prompt_text = data.get("prompt", "")
+
     try:
-        from ..core.project import find_git_root
-
-        repo_path = find_git_root(cwd)
-        if not repo_path:
-            return 0
-
         from ..core.config import load_config
 
         config = load_config(repo_path)
@@ -116,12 +117,30 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
         if not inject_cfg.get("inject_on_user_prompt", True):
             return 0
 
+        from ..db import get_db
+
+        # Per-session capture_disabled check — mirrors turn_capture skip semantics so
+        # sessions with capture explicitly disabled also suppress decision injection.
+        session_conn = get_db(repo_path)
+        try:
+            session_row = session_conn.execute(
+                "SELECT metadata FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if session_row and session_row[0]:
+                try:
+                    meta = json.loads(session_row[0])
+                    if meta.get("capture_disabled"):
+                        return 0
+                except (ValueError, TypeError):
+                    pass
+        finally:
+            session_conn.close()
+
         from ..core.decision_prompt_surfacing import (
             _format_decision_entry,
             optimize_for_context_budget,
             rank_decisions_for_prompt,
         )
-        from ..db import get_db
 
         timeout_s = int(inject_cfg.get("inject_timeout_ms", 250)) / 1000
 
@@ -132,19 +151,29 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
             finally:
                 conn.close()
 
-        import concurrent.futures
+        _result: list[Any] = []
+        _exc: list[BaseException] = []
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(_rank_in_thread)
-        timed_out = False
-        try:
-            surfaced, _ = future.result(timeout=timeout_s)
-        except concurrent.futures.TimeoutError:
-            timed_out = True
-        finally:
-            executor.shutdown(wait=False)
-        if timed_out:
+        def _rank_wrapper() -> None:
+            try:
+                _result.append(_rank_in_thread())
+            except Exception as e:
+                _exc.append(e)
+
+        # daemon=True so a timed-out ranking thread never blocks process exit.
+        t = threading.Thread(target=_rank_wrapper, daemon=True)
+        t.start()
+        t.join(timeout=timeout_s)
+        if t.is_alive():
+            return 0  # hard cap: timed out, daemon thread is abandoned
+
+        if _exc:
+            raise _exc[0]
+
+        if not _result:
             return 0
+
+        surfaced, _ = _result[0]
 
         trimmed = optimize_for_context_budget(
             surfaced,

--- a/src/entirecontext/hooks/turn_capture.py
+++ b/src/entirecontext/hooks/turn_capture.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 
 from .session_lifecycle import _find_git_root
 
+_GIT_ROOT_UNSET = object()  # sentinel: caller did not pre-resolve the git root
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -129,8 +131,12 @@ def _maybe_launch_prompt_surfacing_worker(
                 pass
 
 
-def on_user_prompt(data: dict[str, Any]) -> None:
-    """Handle UserPromptSubmit — record turn start with user message."""
+def on_user_prompt(data: dict[str, Any], *, _resolved_repo_path: object = _GIT_ROOT_UNSET) -> None:
+    """Handle UserPromptSubmit — record turn start with user message.
+
+    Pass ``_resolved_repo_path`` to skip the git-root subprocess probe when the
+    caller has already done the lookup (avoids a double probe in handler.py).
+    """
     session_id = data.get("session_id")
     cwd = data.get("cwd", ".")
     prompt = data.get("prompt", "")
@@ -138,7 +144,10 @@ def on_user_prompt(data: dict[str, Any]) -> None:
     if not session_id:
         return
 
-    repo_path = _find_git_root(cwd)
+    if _resolved_repo_path is _GIT_ROOT_UNSET:
+        repo_path: str | None = _find_git_root(cwd)
+    else:
+        repo_path = _resolved_repo_path  # type: ignore[assignment]
     if not repo_path:
         return
 

--- a/tests/test_pdi_handler.py
+++ b/tests/test_pdi_handler.py
@@ -220,3 +220,48 @@ class TestPDIHandlerSyncPath:
         payload = json.loads(captured.out.strip())
         ctx = payload["hookSpecificOutput"]["additionalContext"]
         assert "aabbccdd" in ctx, "Expected decision ID prefix in additionalContext"
+
+    def test_session_capture_disabled_skips_pdi(self, capsys):
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = (
+            '{"capture_disabled": true}',
+        )
+        with (
+            patch("entirecontext.hooks.turn_capture.on_user_prompt"),
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/repo"),
+            patch("entirecontext.core.config.load_config", return_value=_INJECTION_CONFIG),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+            patch("entirecontext.core.decision_prompt_surfacing.rank_decisions_for_prompt") as mock_rank,
+        ):
+            result = _handle_user_prompt(_HOOK_DATA)
+
+        assert result == 0
+        mock_rank.assert_not_called()
+        captured = capsys.readouterr()
+        assert not captured.out.strip()
+
+    def test_on_user_prompt_receives_pre_resolved_repo_path(self):
+        """handler.py resolves git root once and forwards it to on_user_prompt."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = None
+        captured_kwargs: list[dict] = []
+
+        def _capture_call(data, **kwargs):
+            captured_kwargs.append(kwargs)
+
+        with (
+            patch("entirecontext.hooks.turn_capture.on_user_prompt", side_effect=_capture_call),
+            patch("entirecontext.core.project.find_git_root", return_value="/tmp/repo") as mock_find,
+            patch("entirecontext.core.config.load_config", return_value=_INJECTION_CONFIG),
+            patch("entirecontext.db.get_db", return_value=mock_conn),
+            patch(
+                "entirecontext.core.decision_prompt_surfacing.rank_decisions_for_prompt",
+                return_value=([], []),
+            ),
+        ):
+            _handle_user_prompt(_HOOK_DATA)
+
+        # find_git_root called exactly once — not twice
+        assert mock_find.call_count == 1
+        # pre-resolved path forwarded via _resolved_repo_path kwarg
+        assert captured_kwargs[0].get("_resolved_repo_path") == "/tmp/repo"

--- a/tests/test_pdi_optimizer.py
+++ b/tests/test_pdi_optimizer.py
@@ -52,6 +52,13 @@ class TestOptimizeForContextBudget:
         assert len(result) == 1
         assert len(result[0].get("rationale", "")) <= 105
 
+    def test_single_entry_long_title_truncated_when_over_budget(self):
+        long_title = "T" * 200
+        ranked = [_d(long_title, 0.9, rank=1, rationale="Short rationale.")]
+        result = optimize_for_context_budget(ranked, top_k=5, max_tokens=10, min_confidence=0.0)
+        assert len(result) == 1
+        assert len(result[0].get("title", "")) <= 84  # 80 chars + "…"
+
     def test_empty_input_returns_empty(self):
         assert optimize_for_context_budget([], top_k=5, max_tokens=800, min_confidence=0.4) == []
 


### PR DESCRIPTION
Addresses all open review comments from #139 (Proactive Decision Injection):

- P1: Replace ThreadPoolExecutor with threading.Thread(daemon=True) for a true hard timeout cap
- P2a: Resolve git root once in _handle_user_prompt, pass via _resolved_repo_path sentinel to on_user_prompt (eliminates double subprocess probe)
- P2b: Add per-session capture_disabled DB gate before PDI ranking thread
- P2c: optimize_for_context_budget: truncate long title as second pass after rationale truncation

Generated with [Claude Code](https://claude.ai/code)