### PR TITLE
fix(hooks): share one DB connection for PDI capture_disabled gate and ranking

### DIFF
--- a/src/entirecontext/hooks/handler.py
+++ b/src/entirecontext/hooks/handler.py
@@ -117,36 +117,29 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
         if not inject_cfg.get("inject_on_user_prompt", True):
             return 0
 
-        from ..db import get_db
-
-        # Per-session capture_disabled check — mirrors turn_capture skip semantics so
-        # sessions with capture explicitly disabled also suppress decision injection.
-        session_conn = get_db(repo_path)
-        try:
-            session_row = session_conn.execute(
-                "SELECT metadata FROM sessions WHERE id = ?", (session_id,)
-            ).fetchone()
-            if session_row and session_row[0]:
-                try:
-                    meta = json.loads(session_row[0])
-                    if meta.get("capture_disabled"):
-                        return 0
-                except (ValueError, TypeError):
-                    pass
-        finally:
-            session_conn.close()
-
         from ..core.decision_prompt_surfacing import (
             _format_decision_entry,
             optimize_for_context_budget,
             rank_decisions_for_prompt,
         )
+        from ..db import get_db
 
         timeout_s = int(inject_cfg.get("inject_timeout_ms", 250)) / 1000
 
-        def _rank_in_thread() -> tuple[list[Any], list[str]]:
+        # Per-session capture_disabled check is performed inside the thread on the
+        # same connection used for ranking, so the disabled gate and ranking share
+        # one connection rather than opening two.
+        def _rank_in_thread() -> tuple[list[Any], list[str]] | None:
             conn = get_db(repo_path)
             try:
+                session_row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+                if session_row and session_row[0]:
+                    try:
+                        meta = json.loads(session_row[0])
+                        if meta.get("capture_disabled"):
+                            return None
+                    except (ValueError, TypeError):
+                        pass
                 return rank_decisions_for_prompt(conn, repo_path=repo_path, prompt_text=prompt_text, config=config)
             finally:
                 conn.close()
@@ -170,7 +163,7 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
         if _exc:
             raise _exc[0]
 
-        if not _result:
+        if not _result or _result[0] is None:
             return 0
 
         surfaced, _ = _result[0]


### PR DESCRIPTION
## Summary

Fixes the CI failure on PR #141 (`test (3.12)` and `test (3.13)`):

```
FAILED tests/test_e2e_pdi.py::TestE2EPDI::test_prompt_to_stdout_json
E       AssertionError: Expected JSON on stdout
E        +      where '' = CaptureResult(out='', err='EntireContext PDI error: Cannot operate on a closed database.\n').out
```

## Root cause

The per-session `capture_disabled` gate added in `a524255` opened a fresh DB connection before spawning the ranking thread, then closed it. The ranking thread then opened a second connection.

In `test_e2e_pdi.py`, `entirecontext.db.get_db` is patched to return one shared in-memory SQLite connection (in-memory DBs can't be reopened by path). When the gate closed the shared connection, the ranking thread received the now-closed connection and `rank_decisions_for_prompt` raised `sqlite3.ProgrammingError: Cannot operate on a closed database`. The handler caught the exception and wrote nothing to stdout, so the JSON assertion failed.

`test_no_matching_decisions_no_stdout` triggered the same code path but asserted only that stdout was empty, so it passed vacuously.

In production each `get_db()` returns a fresh connection, so the bug was invisible outside this test.

## Fix

Move the `capture_disabled` gate inside `_rank_in_thread` so the gate and `rank_decisions_for_prompt` share one connection. This:

1. Fixes the CI failure naturally — only one `close()` happens per call.
2. Halves DB connections opened per `UserPromptSubmit` in production.
3. Preserves the original skip semantics: when `capture_disabled`, the thread returns `None` and the handler short-circuits (now handled by `if not _result or _result[0] is None: return 0`).

## Test plan

- [x] `uv run pytest tests/test_e2e_pdi.py tests/test_pdi_handler.py tests/test_hooks_performance.py tests/test_decision_hooks.py` — 102 passed, 1 skipped
- [x] `uv run pytest` (full suite) — 1598 passed, 93 skipped
- [x] `uv run ruff format --check` + `uv run ruff check` — clean
- [x] Confirm CI `test (3.12)` and `test (3.13)` pass on PR after merge into #141 branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr9vtaU2s4ZgkjSx9RX4Nf)_