### PR TITLE
feat(distill): v0.8.0 auto-assess automation

### DIFF
--- a/docs/superpowers/plans/2026-06-06-distill-automation.md
+++ b/docs/superpowers/plans/2026-06-06-distill-automation.md
@@ -1,0 +1,673 @@
+# v0.8.0 Distill Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Break the 3-sprint distill=0 streak by auto-creating assessments on every checkpoint, with LLM enrichment and git-evidence feedback as complementary quality layers.
+
+**Non-goal:** Maturity ≥75 — current ceiling is constrained by retrieve (17/25) and intervene (5/20), which this PR does not address. Maturity ≥75 requires separate work on those dimensions.
+
+**Architecture:** 3-tier trigger (sync create → SessionEnd backfill+enrich → SessionStart catch-up). Rule-based verdict from conventional commit parsing. LLM enrichment via CLI backend (`claude -p`, headless confirmed). Git-evidence feedback as API-free fallback. All auto-assess logic in a new `core/auto_assess.py` module, wired into existing hook lifecycle.
+
+**Tech Stack:** Python 3.12, SQLite, Typer CLI, existing LLM backend infrastructure (`core/llm.py`)
+
+---
+
+## Design Corrections (from advisor + code exploration)
+
+1. **Call sites:** No MCP checkpoint-create tool exists. `sync/coordinator.py:372` calls `create_checkpoint()` but MUST be excluded (imported commits reference non-local git state). Tier 1 sites: CLI `checkpoint_cmds.py`, `_maybe_create_auto_checkpoint()`, `on_post_commit()`.
+2. **Async enrichment:** LLM enrichment in SessionEnd MUST use background worker (`launch_worker` + `pid_name="worker-assess"`) — synchronous calls would block the hook for N×120s.
+3. **Feedback validation:** `VALID_FEEDBACKS = ("agree", "disagree")` in `futures.py:13`. Use `feedback_reason` for detail: `"auto:llm-confirmed"`, `"auto:revised:neutral->expand"`, `"auto:committed"`.
+4. **model_name accuracy:** CLI backend ignores model param. Write `model_name="claude-cli"` (or `"codex-cli"`) for enriched assessments, not the configured model string.
+
+## File Structure
+
+**New files:**
+- `src/entirecontext/core/auto_assess.py` — all distill automation logic
+- `tests/test_auto_assess.py` — unit tests
+- `tests/test_distill_automation.py` — integration tests
+
+**Modified files:**
+- `core/config.py` — new config keys, default_backend change
+- `core/git_utils.py` — `get_commit_messages()` helper
+- `core/dashboard.py` — `enriched_rate` metric
+- `hooks/session_lifecycle.py` — Tier 1/2/3 hook wiring
+- `cli/checkpoint_cmds.py` — Tier 1 CLI path
+- `cli/futures_cmds.py` — `enrich-backlog` command
+
+---
+
+### Task 1: `get_commit_messages()` in git_utils.py
+
+**Files:**
+- Modify: `src/entirecontext/core/git_utils.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_get_commit_messages_returns_list(git_repo):
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: add API"], cwd=git_repo, capture_output=True)
+    msgs = get_commit_messages(str(git_repo), from_commit=None, to_commit="HEAD")
+    # from_commit=None -> empty list (no range)
+    assert msgs == []
+
+def test_get_commit_messages_with_range(git_repo):
+    r1 = subprocess.run(["git", "rev-parse", "HEAD"], cwd=git_repo, capture_output=True, text=True)
+    base = r1.stdout.strip()
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: add login"], cwd=git_repo, capture_output=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "fix: typo"], cwd=git_repo, capture_output=True)
+    msgs = get_commit_messages(str(git_repo), from_commit=base, to_commit="HEAD")
+    assert "fix: typo" in msgs
+    assert "feat: add login" in msgs
+    assert len(msgs) == 2
+
+def test_get_commit_messages_invalid_range(git_repo):
+    msgs = get_commit_messages(str(git_repo), from_commit="deadbeef", to_commit="HEAD")
+    assert msgs == []
+
+def test_get_commit_messages_same_commit(git_repo):
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=git_repo, capture_output=True, text=True)
+    sha = r.stdout.strip()
+    msgs = get_commit_messages(str(git_repo), from_commit=sha, to_commit=sha)
+    assert msgs == []
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `uv run pytest tests/test_auto_assess.py::test_get_commit_messages_returns_list -v`
+
+- [ ] **Step 3: Implement**
+
+```python
+def get_commit_messages(repo_path: str, from_commit: str | None, to_commit: str = "HEAD") -> list[str]:
+    if not from_commit:
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%s", f"{from_commit}..{to_commit}"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [line for line in result.stdout.strip().splitlines() if line.strip()]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return []
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/git_utils.py tests/test_auto_assess.py
+git commit -m "feat(git): add get_commit_messages helper for commit range parsing"
+```
+
+---
+
+### Task 2: Rule-based verdict logic in auto_assess.py
+
+**Files:**
+- Create: `src/entirecontext/core/auto_assess.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+from entirecontext.core.auto_assess import compute_rule_verdict
+
+def test_verdict_feat():
+    assert compute_rule_verdict(["feat: add API"]) == "expand"
+
+def test_verdict_feat_scoped():
+    assert compute_rule_verdict(["feat(auth): add SSO"]) == "expand"
+
+def test_verdict_revert():
+    assert compute_rule_verdict(["revert: undo feature"]) == "narrow"
+
+def test_verdict_fix():
+    assert compute_rule_verdict(["fix: null check"]) == "neutral"
+
+def test_verdict_mixed_feat_revert():
+    assert compute_rule_verdict(["feat: add", "revert: undo"]) == "neutral"
+
+def test_verdict_empty():
+    assert compute_rule_verdict([]) == "neutral"
+
+def test_verdict_case_insensitive():
+    assert compute_rule_verdict(["FEAT: big thing"]) == "expand"
+
+def test_verdict_non_conventional():
+    assert compute_rule_verdict(["Update README"]) == "neutral"
+
+def test_verdict_merge_commit():
+    assert compute_rule_verdict(["Merge branch 'feature' into 'main'"]) == "neutral"
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+```python
+from __future__ import annotations
+
+import re
+
+_EXPAND_RE = re.compile(r"^feat[\s(:]", re.IGNORECASE)
+_NARROW_RE = re.compile(r"^revert[\s(:]", re.IGNORECASE)
+
+
+def compute_rule_verdict(commit_messages: list[str]) -> str:
+    has_expand = any(_EXPAND_RE.match(m.strip()) for m in commit_messages)
+    has_narrow = any(_NARROW_RE.match(m.strip()) for m in commit_messages)
+    if has_expand and has_narrow:
+        return "neutral"
+    if has_expand:
+        return "expand"
+    if has_narrow:
+        return "narrow"
+    return "neutral"
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py tests/test_auto_assess.py
+git commit -m "feat(assess): add rule-based verdict from conventional commits"
+```
+
+---
+
+### Task 3: `auto_assess_checkpoint()` core function
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_assess.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_auto_assess_creates_assessment(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    # Make a feat commit
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: add endpoint"], cwd=ec_repo, capture_output=True)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    result = auto_assess_checkpoint(ec_db, cp["id"], str(ec_repo), session_id)
+    assert result is not None
+    assert result["verdict"] == "expand"
+    assert result["model_name"] == "rule-based"
+
+def test_auto_assess_no_prior_returns_neutral(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    result = auto_assess_checkpoint(ec_db, cp["id"], str(ec_repo), session_id)
+    assert result is not None
+    assert result["verdict"] == "neutral"
+
+def test_auto_assess_never_raises(ec_repo, ec_db):
+    result = auto_assess_checkpoint(ec_db, "nonexistent", "/bad/path", "bad-session")
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+`auto_assess_checkpoint(conn, checkpoint_id, repo_path, session_id)`:
+1. Get checkpoint record → extract `git_commit_hash`
+2. Find previous checkpoint in same session → get its `git_commit_hash` as `from_commit`
+3. Fallback: session metadata `start_git_commit`
+4. `get_commit_messages(repo_path, from_commit, to_commit)`
+5. `compute_rule_verdict(messages)`
+6. Build impact_summary from first commit message (truncate 120 chars) or `"Auto-assessed checkpoint"`
+7. `create_assessment(conn, checkpoint_id=checkpoint_id, verdict=verdict, impact_summary=impact_summary, diff_summary=checkpoint_diff_summary, model_name="rule-based")`
+8. Wrap entire body in try/except → return None on any error
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py tests/test_auto_assess.py
+git commit -m "feat(assess): auto_assess_checkpoint with commit-based verdict"
+```
+
+---
+
+### Task 4: Backfill + enrichment candidate queries
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_assess.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_backfill_creates_missing_assessments(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    cp1 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    cp2 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    # cp1 has assessment, cp2 does not
+    create_assessment(ec_db, checkpoint_id=cp1["id"], verdict="neutral")
+    count = backfill_unassessed_checkpoints(ec_db, str(ec_repo), session_id=session_id)
+    assert count == 1  # only cp2
+
+def test_backfill_respects_window(ec_repo, ec_db):
+    # checkpoint with old created_at should not be backfilled
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    ec_db.execute("UPDATE checkpoints SET created_at = datetime('now', '-30 days') WHERE id = ?", (cp["id"],))
+    count = backfill_unassessed_checkpoints(ec_db, str(ec_repo), window_days=7)
+    assert count == 0
+
+def test_get_enrichment_candidates_only_rule_based(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    create_assessment(ec_db, checkpoint_id=None, verdict="expand", model_name="gpt-4o-mini")
+    candidates = get_enrichment_candidates(ec_db)
+    assert len(candidates) == 1
+    assert candidates[0]["model_name"] == "rule-based"
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+`backfill_unassessed_checkpoints(conn, repo_path, session_id=None, window_days=7)`:
+- Query: `checkpoints LEFT JOIN assessments WHERE a.id IS NULL AND created_at >= window`
+- Optional session_id filter, LIMIT 50
+- For each: call `auto_assess_checkpoint()`, count successes
+
+`get_enrichment_candidates(conn, session_id=None, window_days=7, limit=10)`:
+- Query: `assessments a JOIN checkpoints c ON a.checkpoint_id = c.id WHERE a.model_name = 'rule-based' AND a.created_at >= window`
+- Returns list of dicts with assessment + checkpoint info
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py tests/test_auto_assess.py
+git commit -m "feat(assess): backfill and enrichment candidate queries"
+```
+
+---
+
+### Task 5: Git-evidence feedback
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_assess.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_git_evidence_feedback(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    # Make a commit after checkpoint
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "fix: something"], cwd=ec_repo, capture_output=True)
+    count = apply_git_evidence_feedback(ec_db, str(ec_repo), session_id=session_id)
+    assert count == 1
+    row = ec_db.execute("SELECT feedback, feedback_reason FROM assessments WHERE checkpoint_id = ?", (cp["id"],)).fetchone()
+    assert row["feedback"] == "agree"
+    assert "committed" in row["feedback_reason"]
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+`apply_git_evidence_feedback(conn, repo_path, session_id=None, window_days=7)`:
+- Query: assessments WHERE `feedback IS NULL AND model_name = 'rule-based'` AND within window
+- For each: check `git log --format=%H {checkpoint_commit}..HEAD` returns commits
+- If yes: `add_feedback(conn, a_id, "agree", feedback_reason="auto:committed")`
+- Return count
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py tests/test_auto_assess.py
+git commit -m "feat(assess): git-evidence feedback for API-free environments"
+```
+
+---
+
+### Task 6: LLM enrichment function
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_assess.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_enrich_assessment_updates_model_name(ec_repo, ec_db, monkeypatch):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    a = create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+
+    # Mock LLM backend
+    mock_response = json.dumps({"verdict": "expand", "impact_summary": "Added new feature", "roadmap_alignment": "Aligns with v0.8", "tidy_suggestion": "None"})
+    monkeypatch.setattr("entirecontext.core.auto_assess.get_backend", lambda *a, **kw: type("B", (), {"complete": lambda s, sys, usr: mock_response})())
+
+    config = {"futures": {"default_backend": "claude", "default_model": ""}}
+    ok = enrich_assessment(ec_db, a, str(ec_repo), config)
+    assert ok is True
+    row = ec_db.execute("SELECT model_name, verdict, feedback, feedback_reason FROM assessments WHERE id = ?", (a["id"],)).fetchone()
+    assert row["model_name"] != "rule-based"
+    assert row["verdict"] == "expand"
+    assert row["feedback"] == "disagree"
+    assert "revised" in row["feedback_reason"]
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+`enrich_assessment(conn, assessment, repo_path, config)`:
+1. Load backend from `config["futures"]["default_backend"]`
+2. Build prompt: `ASSESS_SYSTEM_PROMPT` + ROADMAP.md + diff_summary
+3. Call `backend.complete(system, user)`, parse JSON
+4. Validate verdict against `VALID_VERDICTS`
+5. Compare LLM verdict with `assessment["verdict"]` (rule-based)
+6. UPDATE: verdict, impact_summary, roadmap_alignment, tidy_suggestion, `model_name=f"{backend_name}-cli"`
+7. `add_feedback()`: `"agree"` + `"auto:llm-confirmed"` if same, `"disagree"` + `f"auto:revised:{old}->{new}"` if different
+8. Return True/False, never raises
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py tests/test_auto_assess.py
+git commit -m "feat(assess): LLM enrichment with auto-feedback generation"
+```
+
+---
+
+### Task 7: Config changes
+
+**Files:**
+- Modify: `src/entirecontext/core/config.py`
+- Test: `tests/test_auto_assess.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_config_defaults():
+    from entirecontext.core.config import DEFAULT_CONFIG
+    futures = DEFAULT_CONFIG["futures"]
+    assert futures["default_backend"] == "claude"
+    assert futures["assess_enrich"] is True
+    assert futures["assess_backfill_window_days"] == 7
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Implement**
+
+In `DEFAULT_CONFIG["futures"]`:
+- Change `"default_backend": "openai"` → `"default_backend": "claude"`
+- Add `"assess_enrich": True`
+- Add `"assess_backfill_window_days": 7`
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Run existing config tests for regression**
+
+Run: `uv run pytest tests/ -k "config" -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/config.py tests/test_auto_assess.py
+git commit -m "feat(config): add assess_enrich, backfill window; default backend to claude"
+```
+
+---
+
+### Task 8: Tier 1 — hook wiring (post-commit + auto-checkpoint + CLI)
+
+**Files:**
+- Modify: `src/entirecontext/hooks/session_lifecycle.py`
+- Modify: `src/entirecontext/cli/checkpoint_cmds.py`
+- Test: `tests/test_distill_automation.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+def test_post_commit_creates_assessment(ec_repo, ec_db):
+    """on_post_commit creates checkpoint AND assessment."""
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: endpoint"], cwd=ec_repo, capture_output=True)
+    on_post_commit({"cwd": str(ec_repo)})
+    checkpoints = list_checkpoints(ec_db)
+    assert len(checkpoints) >= 1
+    cp_id = checkpoints[0]["id"]
+    a = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp_id,)).fetchone()
+    assert a is not None
+    assert a["model_name"] == "rule-based"
+```
+
+- [ ] **Step 2: Run test, verify failure**
+- [ ] **Step 3: Wire Tier 1 into `on_post_commit()` (session_lifecycle.py:517)**
+
+After `create_checkpoint()` call, capture return value and call `auto_assess_checkpoint()`.
+Pattern: try/except wrapping, `_record_hook_warning` on failure.
+
+- [ ] **Step 4: Wire Tier 1 into `_maybe_create_auto_checkpoint()` (session_lifecycle.py:459)**
+
+Same pattern: capture `create_checkpoint()` return value, call `auto_assess_checkpoint()`.
+
+- [ ] **Step 5: Wire Tier 1 into `checkpoint_cmds.py` CLI**
+
+After `create_checkpoint()`, call `auto_assess_checkpoint()` and print verdict.
+
+- [ ] **Step 6: Run integration test, verify pass**
+- [ ] **Step 7: Run existing checkpoint/hook tests for regression**
+
+Run: `uv run pytest tests/test_checkpoint_cmds.py tests/test_post_commit_hook.py tests/test_hooks.py -v`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/entirecontext/hooks/session_lifecycle.py src/entirecontext/cli/checkpoint_cmds.py tests/test_distill_automation.py
+git commit -m "feat(hooks): wire Tier 1 auto-assess into post-commit, auto-checkpoint, CLI"
+```
+
+---
+
+### Task 9: Tier 2 — SessionEnd backfill + enrichment worker
+
+**Files:**
+- Modify: `src/entirecontext/hooks/session_lifecycle.py`
+- Modify: `src/entirecontext/cli/futures_cmds.py`
+- Test: `tests/test_distill_automation.py`
+
+- [ ] **Step 1: Write integration tests**
+
+```python
+def test_session_end_backfills_unassessed(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    # No assessment exists
+    on_session_end({"session_id": session_id, "cwd": str(ec_repo)})
+    a = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp["id"],)).fetchone()
+    assert a is not None
+
+def test_enrichment_worker_launched_by_default(ec_repo, ec_db, monkeypatch):
+    """assess_enrich=True by default, worker should launch."""
+    launched = []
+    monkeypatch.setattr("entirecontext.hooks.session_lifecycle.launch_worker", lambda *a, **kw: launched.append(1))
+    monkeypatch.setattr("entirecontext.hooks.session_lifecycle.worker_status", lambda *a, **kw: {"running": False})
+    session_id = _create_test_session(ec_db)
+    create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    on_session_end({"session_id": session_id, "cwd": str(ec_repo)})
+    assert len(launched) >= 1
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+- [ ] **Step 3: Add `_maybe_backfill_assessments()` to session_lifecycle.py**
+
+Insert after `_maybe_create_auto_checkpoint()` at line 280, before `_maybe_trigger_auto_sync()`.
+Synchronous: backfill rule-based assessments + git-evidence feedback.
+Async: launch `worker-assess` if `assess_enrich=True`.
+
+- [ ] **Step 4: Add `futures enrich-backlog` CLI command**
+
+New command in `futures_cmds.py` that the background worker runs:
+- Load config, get enrichment candidates
+- For each: call `enrich_assessment()`
+- If LLM fails: fall back to `apply_git_evidence_feedback()`
+
+- [ ] **Step 5: Run tests, verify pass**
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/hooks/session_lifecycle.py src/entirecontext/cli/futures_cmds.py tests/test_distill_automation.py
+git commit -m "feat(hooks): Tier 2 SessionEnd backfill + async enrichment worker"
+```
+
+---
+
+### Task 10: Tier 3 — SessionStart catch-up
+
+**Files:**
+- Modify: `src/entirecontext/hooks/session_lifecycle.py`
+- Test: `tests/test_distill_automation.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+def test_session_start_catches_up(ec_repo, ec_db):
+    # Simulate crashed session: checkpoint exists, no assessment, session ended
+    old_session = _create_test_session(ec_db, ended=True)
+    cp = create_checkpoint(ec_db, old_session, _get_head(ec_repo))
+    # Start new session
+    new_session = str(uuid4())
+    on_session_start({"session_id": new_session, "cwd": str(ec_repo)})
+    a = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp["id"],)).fetchone()
+    assert a is not None
+    assert a["model_name"] == "rule-based"
+```
+
+- [ ] **Step 2: Run test, verify failure**
+- [ ] **Step 3: Add `_maybe_catchup_assessments()` to on_session_start()**
+
+At end of `on_session_start()` (after line 131), add catch-up call.
+Only synchronous rule-based backfill (no LLM at SessionStart — keep it fast).
+Scoped by `assess_backfill_window_days`.
+
+- [ ] **Step 4: Run test, verify pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/hooks/session_lifecycle.py tests/test_distill_automation.py
+git commit -m "feat(hooks): Tier 3 SessionStart catch-up for crashed sessions"
+```
+
+---
+
+### Task 11: Dashboard enriched_rate
+
+**Files:**
+- Modify: `src/entirecontext/core/dashboard.py`
+- Test: `tests/test_dashboard.py` (extend existing)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_enriched_rate(ec_db):
+    create_assessment(ec_db, verdict="neutral", model_name="rule-based")
+    create_assessment(ec_db, verdict="expand", model_name="gpt-4o-mini")
+    create_assessment(ec_db, verdict="neutral", model_name="mcp-agent")
+    stats = get_dashboard_stats(ec_db)
+    assert stats["assessments"]["enriched_rate"] == pytest.approx(2 / 3)
+```
+
+- [ ] **Step 2: Run test, verify failure**
+- [ ] **Step 3: Implement**
+
+Add to `get_dashboard_stats()` in the assessments section:
+
+```python
+enriched = conn.execute(
+    "SELECT COUNT(*) FROM assessments WHERE model_name IS NOT NULL AND model_name != 'rule-based'"
+).fetchone()[0]
+total_a = conn.execute("SELECT COUNT(*) FROM assessments").fetchone()[0]
+enriched_rate = enriched / total_a if total_a > 0 else 0.0
+```
+
+Add `"enriched_count": enriched, "enriched_rate": enriched_rate` to returned dict.
+
+- [ ] **Step 4: Run test, verify pass**
+- [ ] **Step 5: Run full dashboard tests**
+
+Run: `uv run pytest tests/test_dashboard.py -v`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/dashboard.py tests/test_dashboard.py
+git commit -m "feat(dashboard): add enriched_rate metric for assessment quality tracking"
+```
+
+---
+
+### Task 12: Regression + full suite verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+uv run pytest --timeout=30 -x
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+uv run ruff check src/entirecontext/core/auto_assess.py src/entirecontext/core/git_utils.py src/entirecontext/hooks/session_lifecycle.py src/entirecontext/cli/checkpoint_cmds.py src/entirecontext/cli/futures_cmds.py src/entirecontext/core/dashboard.py src/entirecontext/core/config.py
+uv run ruff format --check .
+```
+
+- [ ] **Step 3: Manual smoke test (use temp repo, not dogfooding DB)**
+
+```bash
+cd $(mktemp -d) && git init && git commit --allow-empty -m "init"
+ec init
+ec checkpoint create -m "test auto-assess"
+ec futures list  # Should show rule-based assessment
+ec dashboard     # Should show enriched_rate
+```
+
+- [ ] **Step 4: Verify maturity regression protection**
+
+```bash
+# In the real repo: compare maturity before/after
+ec dashboard  # Record maturity_breakdown BEFORE
+# Run a session cycle with auto-assess enabled
+ec dashboard  # Verify distill did not decrease
+```
+
+- [ ] **Step 5: Verify sync import path excluded**
+
+```bash
+# sync/coordinator.py:372 must NOT call auto_assess_checkpoint
+grep -n "auto_assess" src/entirecontext/sync/coordinator.py  # Should return nothing
+```
+
+- [ ] **Step 6: Commit any fixes, then final pass**
+
+```bash
+uv run pytest --timeout=30
+```
+
+---
+
+## Verification Summary
+
+| Check | Command |
+|-------|---------|
+| Unit tests | `uv run pytest tests/test_auto_assess.py -v` |
+| Integration tests | `uv run pytest tests/test_distill_automation.py -v` |
+| Checkpoint regression | `uv run pytest tests/test_checkpoint_cmds.py tests/test_post_commit_hook.py -v` |
+| Hook regression | `uv run pytest tests/test_hooks.py tests/test_session_lifecycle_ordering.py -v` |
+| Dashboard regression | `uv run pytest tests/test_dashboard.py -v` |
+| Full suite | `uv run pytest --timeout=30` |
+| Lint | `uv run ruff check . && uv run ruff format --check .` |
+| Smoke test | `ec checkpoint create -m "test" && ec futures list && ec dashboard` |

--- a/src/entirecontext/cli/checkpoint_cmds.py
+++ b/src/entirecontext/cli/checkpoint_cmds.py
@@ -72,6 +72,14 @@ def checkpoint_create(
             diff_summary=diff_summary,
             parent_checkpoint_id=parent,
         )
+        try:
+            from ..core.auto_assess import auto_assess_checkpoint
+
+            assessment = auto_assess_checkpoint(conn, cp["id"], repo_path, session_id)
+            if assessment:
+                console.print(f"  Verdict: {assessment['verdict']}")
+        except Exception:
+            pass
     finally:
         conn.close()
 

--- a/src/entirecontext/cli/futures_cmds.py
+++ b/src/entirecontext/cli/futures_cmds.py
@@ -262,7 +262,7 @@ def futures_lessons(
 @futures_app.command("enrich-backlog")
 def futures_enrich_backlog():
     """Enrich rule-based assessments with LLM analysis. Fallback: git-evidence feedback."""
-    from ..core.auto_assess import apply_git_evidence_feedback, enrich_assessment, get_enrichment_candidates
+    from ..core.auto_assess import enrich_assessment, get_enrichment_candidates
     from ..core.config import load_config
     from ..core.project import find_git_root
     from ..db import get_db
@@ -283,11 +283,30 @@ def futures_enrich_backlog():
             return
 
         enriched = 0
+        failed_ids = []
         for candidate in candidates:
             if enrich_assessment(conn, candidate, repo_path, config):
                 enriched += 1
+            else:
+                failed_ids.append(candidate["id"])
 
-        fallback = apply_git_evidence_feedback(conn, repo_path, window_days=window_days)
+        fallback = 0
+        if failed_ids:
+            from ..core.futures import add_feedback
+            from ..core.git_utils import get_commit_messages
+
+            for aid in failed_ids:
+                row = conn.execute(
+                    "SELECT a.feedback, c.git_commit_hash FROM assessments a"
+                    " JOIN checkpoints c ON a.checkpoint_id = c.id WHERE a.id = ?",
+                    (aid,),
+                ).fetchone()
+                if row and row["feedback"] is None:
+                    msgs = get_commit_messages(repo_path, row["git_commit_hash"], "HEAD")
+                    if msgs:
+                        add_feedback(conn, aid, "agree", feedback_reason="auto:committed")
+                        fallback += 1
+
         console.print(f"[green]Enriched: {enriched}[/green], [yellow]Fallback (git-evidence): {fallback}[/yellow]")
     finally:
         conn.close()

--- a/src/entirecontext/cli/futures_cmds.py
+++ b/src/entirecontext/cli/futures_cmds.py
@@ -259,6 +259,44 @@ def futures_lessons(
     console.print(f"[green]Written {len(lessons)} lessons to {output}[/green]")
 
 
+@futures_app.command("enrich-backlog")
+def futures_enrich_backlog():
+    """Enrich rule-based assessments with LLM analysis. Fallback: git-evidence feedback."""
+    from ..core.auto_assess import apply_git_evidence_feedback, enrich_assessment, get_enrichment_candidates
+    from ..core.config import load_config
+    from ..core.project import find_git_root
+    from ..db import get_db
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    config = load_config(repo_path)
+    window_days = config.get("futures", {}).get("assess_backfill_window_days", 7)
+
+    conn = get_db(repo_path)
+    try:
+        candidates = get_enrichment_candidates(conn, window_days=window_days)
+        if not candidates:
+            console.print("[dim]No assessments to enrich.[/dim]")
+            return
+
+        enriched = 0
+        fallback = 0
+        for candidate in candidates:
+            ok = enrich_assessment(conn, candidate, repo_path, config)
+            if ok:
+                enriched += 1
+            else:
+                apply_git_evidence_feedback(conn, repo_path, window_days=window_days)
+                fallback += 1
+
+        console.print(f"[green]Enriched: {enriched}[/green], [yellow]Fallback (git-evidence): {fallback}[/yellow]")
+    finally:
+        conn.close()
+
+
 @futures_app.command("relate")
 def futures_relate(
     source_id: str = typer.Argument(..., help="Source assessment ID (supports prefix)"),

--- a/src/entirecontext/cli/futures_cmds.py
+++ b/src/entirecontext/cli/futures_cmds.py
@@ -283,15 +283,11 @@ def futures_enrich_backlog():
             return
 
         enriched = 0
-        fallback = 0
         for candidate in candidates:
-            ok = enrich_assessment(conn, candidate, repo_path, config)
-            if ok:
+            if enrich_assessment(conn, candidate, repo_path, config):
                 enriched += 1
-            else:
-                apply_git_evidence_feedback(conn, repo_path, window_days=window_days)
-                fallback += 1
 
+        fallback = apply_git_evidence_feedback(conn, repo_path, window_days=window_days)
         console.print(f"[green]Enriched: {enriched}[/green], [yellow]Fallback (git-evidence): {fallback}[/yellow]")
     finally:
         conn.close()

--- a/src/entirecontext/core/async_worker.py
+++ b/src/entirecontext/core/async_worker.py
@@ -77,6 +77,7 @@ def launch_worker(repo_path: str, cmd: list[str], pid_name: str = "worker") -> i
 
     proc = subprocess.Popen(
         cmd,
+        cwd=repo_path,
         start_new_session=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -35,9 +35,10 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         # Find previous checkpoint's commit
         from_commit = None
         prev = list_checkpoints(conn, session_id=session_id, limit=100)
-        for cp in prev:
-            if cp["id"] != checkpoint_id:
-                from_commit = cp["git_commit_hash"]
+        for i, cp in enumerate(prev):
+            if cp[id] == checkpoint_id:
+                if i + 1 < len(prev):
+                    from_commit = prev[i + 1]["git_commit_hash"]
                 break
 
         if not from_commit:

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -29,7 +29,9 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         from .futures import create_assessment
         from .git_utils import get_commit_messages
 
-        row = conn.execute("SELECT git_commit_hash, diff_summary FROM checkpoints WHERE id = ?", (checkpoint_id,)).fetchone()
+        row = conn.execute(
+            "SELECT git_commit_hash, diff_summary FROM checkpoints WHERE id = ?", (checkpoint_id,)
+        ).fetchone()
         if not row:
             return None
         to_commit = row["git_commit_hash"]
@@ -96,9 +98,7 @@ def backfill_unassessed_checkpoints(conn, repo_path: str, session_id: str | None
     return count
 
 
-def get_enrichment_candidates(
-    conn, session_id: str | None = None, window_days: int = 7, limit: int = 10
-) -> list[dict]:
+def get_enrichment_candidates(conn, session_id: str | None = None, window_days: int = 7, limit: int = 10) -> list[dict]:
     query = """
         SELECT a.id, a.checkpoint_id, a.verdict, a.model_name, a.impact_summary,
                c.git_commit_hash, c.diff_summary, c.session_id

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import json
 import re
-
-from .futures import ASSESS_SYSTEM_PROMPT, VALID_VERDICTS, add_feedback
-from .llm import get_backend, strip_markdown_fences
 
 _EXPAND_RE = re.compile(r"^feat[\s(:]", re.IGNORECASE)
 _NARROW_RE = re.compile(r"^revert[\s(:]", re.IGNORECASE)
@@ -118,6 +114,11 @@ def get_enrichment_candidates(conn, session_id: str | None = None, window_days: 
 
 def enrich_assessment(conn, assessment: dict, repo_path: str, config: dict) -> bool:
     try:
+        import json
+
+        from .futures import ASSESS_SYSTEM_PROMPT, VALID_VERDICTS, add_feedback
+        from .llm import get_backend, strip_markdown_fences
+
         futures_config = config["futures"]
         backend_key = futures_config["default_backend"]
         backend = get_backend(backend_key, futures_config.get("default_model"))

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
 import re
+
+from .futures import ASSESS_SYSTEM_PROMPT, VALID_VERDICTS, add_feedback
+from .llm import get_backend, strip_markdown_fences
 
 _EXPAND_RE = re.compile(r"^feat[\s(:]", re.IGNORECASE)
 _NARROW_RE = re.compile(r"^revert[\s(:]", re.IGNORECASE)
@@ -110,6 +114,55 @@ def get_enrichment_candidates(
     params.append(limit)
 
     return [dict(row) for row in conn.execute(query, params).fetchall()]
+
+
+def enrich_assessment(conn, assessment: dict, repo_path: str, config: dict) -> bool:
+    try:
+        futures_config = config["futures"]
+        backend_key = futures_config["default_backend"]
+        backend = get_backend(backend_key, futures_config.get("default_model"))
+        user_prompt = (
+            f"Repository path: {repo_path}\n"
+            f"Rule-based verdict: {assessment.get('verdict', 'neutral')}\n"
+            f"Rule-based impact summary: {assessment.get('impact_summary') or ''}\n"
+            f"Diff summary:\n{assessment.get('diff_summary') or ''}"
+        )
+        response = backend.complete(ASSESS_SYSTEM_PROMPT, user_prompt)
+        payload = json.loads(strip_markdown_fences(response))
+
+        original_verdict = assessment["verdict"]
+        new_verdict = payload.get("verdict", original_verdict)
+        if new_verdict not in VALID_VERDICTS:
+            new_verdict = original_verdict
+
+        impact_summary = payload.get("impact_summary", assessment.get("impact_summary"))
+        roadmap_alignment = payload.get("roadmap_alignment", assessment.get("roadmap_alignment"))
+        tidy_suggestion = payload.get("tidy_suggestion", assessment.get("tidy_suggestion"))
+        backend_name = f"{backend_key}-cli"
+
+        conn.execute(
+            """
+            UPDATE assessments
+            SET verdict = ?, impact_summary = ?, roadmap_alignment = ?, tidy_suggestion = ?, model_name = ?
+            WHERE id = ?
+            """,
+            (
+                new_verdict,
+                impact_summary,
+                roadmap_alignment,
+                tidy_suggestion,
+                backend_name,
+                assessment["id"],
+            ),
+        )
+
+        if new_verdict == original_verdict:
+            add_feedback(conn, assessment["id"], "agree", "auto:llm-confirmed")
+        else:
+            add_feedback(conn, assessment["id"], "disagree", f"auto:revised:{original_verdict}->{new_verdict}")
+        return True
+    except Exception:
+        return False
 
 
 def apply_git_evidence_feedback(conn, repo_path: str, session_id: str | None = None, window_days: int = 7) -> int:

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -110,3 +110,34 @@ def get_enrichment_candidates(
     params.append(limit)
 
     return [dict(row) for row in conn.execute(query, params).fetchall()]
+
+
+def apply_git_evidence_feedback(conn, repo_path: str, session_id: str | None = None, window_days: int = 7) -> int:
+    try:
+        from .futures import add_feedback
+        from .git_utils import get_commit_messages
+
+        query = """
+            SELECT a.id, a.checkpoint_id, c.git_commit_hash
+            FROM assessments a
+            JOIN checkpoints c ON a.checkpoint_id = c.id
+            WHERE a.feedback IS NULL
+              AND a.model_name = 'rule-based'
+              AND a.created_at >= datetime('now', ?)
+        """
+        params: list = [f"-{window_days} days"]
+        if session_id:
+            query += " AND c.session_id = ?"
+            params.append(session_id)
+        query += " LIMIT 50"
+
+        rows = conn.execute(query, params).fetchall()
+        count = 0
+        for row in rows:
+            messages = get_commit_messages(repo_path, row["git_commit_hash"], "HEAD")
+            if messages:
+                add_feedback(conn, row["id"], "agree", feedback_reason="auto:committed")
+                count += 1
+        return count
+    except Exception:
+        return 0

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import re
+
+_EXPAND_RE = re.compile(r"^feat[\s(:]", re.IGNORECASE)
+_NARROW_RE = re.compile(r"^revert[\s(:]", re.IGNORECASE)
+
+
+def compute_rule_verdict(commit_messages: list[str]) -> str:
+    has_expand = any(_EXPAND_RE.match(m.strip()) for m in commit_messages)
+    has_narrow = any(_NARROW_RE.match(m.strip()) for m in commit_messages)
+    if has_expand and has_narrow:
+        return "neutral"
+    if has_expand:
+        return "expand"
+    if has_narrow:
+        return "narrow"
+    return "neutral"
+
+
+def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id: str) -> dict | None:
+    """Create a rule-based assessment for a checkpoint. Never raises."""
+    try:
+        from .checkpoint import list_checkpoints
+        from .futures import create_assessment
+        from .git_utils import get_commit_messages
+
+        row = conn.execute("SELECT git_commit_hash, diff_summary FROM checkpoints WHERE id = ?", (checkpoint_id,)).fetchone()
+        if not row:
+            return None
+        to_commit = row["git_commit_hash"]
+
+        # Find previous checkpoint's commit
+        from_commit = None
+        prev = list_checkpoints(conn, session_id=session_id, limit=100)
+        for cp in prev:
+            if cp["id"] != checkpoint_id:
+                from_commit = cp["git_commit_hash"]
+                break
+
+        if not from_commit:
+            # Fallback: session metadata start_git_commit
+            import json
+
+            session_row = conn.execute("SELECT metadata FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if session_row and session_row["metadata"]:
+                try:
+                    meta = (
+                        json.loads(session_row["metadata"])
+                        if isinstance(session_row["metadata"], str)
+                        else session_row["metadata"]
+                    )
+                    from_commit = meta.get("start_git_commit")
+                except Exception:
+                    pass
+
+        messages = get_commit_messages(repo_path, from_commit, to_commit)
+        verdict = compute_rule_verdict(messages)
+
+        impact = messages[0][:120] if messages else "Auto-assessed checkpoint"
+
+        return create_assessment(
+            conn,
+            checkpoint_id=checkpoint_id,
+            verdict=verdict,
+            impact_summary=impact,
+            diff_summary=row["diff_summary"],
+            model_name="rule-based",
+        )
+    except Exception:
+        return None
+
+
+def backfill_unassessed_checkpoints(conn, repo_path: str, session_id: str | None = None, window_days: int = 7) -> int:
+    query = """
+        SELECT c.id, c.session_id FROM checkpoints c
+        LEFT JOIN assessments a ON a.checkpoint_id = c.id
+        WHERE a.id IS NULL AND c.created_at >= datetime('now', ?)
+    """
+    params: list = [f"-{window_days} days"]
+    if session_id:
+        query += " AND c.session_id = ?"
+        params.append(session_id)
+    query += " LIMIT 50"
+
+    rows = conn.execute(query, params).fetchall()
+    count = 0
+    for row in rows:
+        result = auto_assess_checkpoint(conn, row["id"], repo_path, row["session_id"])
+        if result:
+            count += 1
+    return count
+
+
+def get_enrichment_candidates(
+    conn, session_id: str | None = None, window_days: int = 7, limit: int = 10
+) -> list[dict]:
+    query = """
+        SELECT a.id, a.checkpoint_id, a.verdict, a.model_name, a.impact_summary,
+               c.git_commit_hash, c.diff_summary, c.session_id
+        FROM assessments a
+        JOIN checkpoints c ON a.checkpoint_id = c.id
+        WHERE a.model_name = 'rule-based' AND a.created_at >= datetime('now', ?)
+    """
+    params: list = [f"-{window_days} days"]
+    if session_id:
+        query += " AND c.session_id = ?"
+        params.append(session_id)
+    query += " ORDER BY a.created_at DESC LIMIT ?"
+    params.append(limit)
+
+    return [dict(row) for row in conn.execute(query, params).fetchall()]

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -21,25 +21,25 @@ def compute_rule_verdict(commit_messages: list[str]) -> str:
 def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id: str) -> dict | None:
     """Create a rule-based assessment for a checkpoint. Never raises."""
     try:
-        from .checkpoint import list_checkpoints
         from .futures import create_assessment
         from .git_utils import get_commit_messages
 
         row = conn.execute(
-            "SELECT git_commit_hash, diff_summary FROM checkpoints WHERE id = ?", (checkpoint_id,)
+            "SELECT git_commit_hash, diff_summary, created_at FROM checkpoints WHERE id = ?", (checkpoint_id,)
         ).fetchone()
         if not row:
             return None
         to_commit = row["git_commit_hash"]
 
-        # Find previous checkpoint's commit
         from_commit = None
-        prev = list_checkpoints(conn, session_id=session_id, limit=100)
-        for i, cp in enumerate(prev):
-            if cp["id"] == checkpoint_id:
-                if i + 1 < len(prev):
-                    from_commit = prev[i + 1]["git_commit_hash"]
-                break
+        pred = conn.execute(
+            "SELECT git_commit_hash FROM checkpoints"
+            " WHERE session_id = ? AND (created_at < ? OR (created_at = ? AND rowid < (SELECT rowid FROM checkpoints WHERE id = ?)))"
+            " ORDER BY created_at DESC, rowid DESC LIMIT 1",
+            (session_id, row["created_at"], row["created_at"], checkpoint_id),
+        ).fetchone()
+        if pred:
+            from_commit = pred["git_commit_hash"]
 
         if not from_commit:
             # Fallback: session metadata start_git_commit

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sqlite3
 
 _EXPAND_RE = re.compile(r"^feat[\s(:]", re.IGNORECASE)
 _NARROW_RE = re.compile(r"^revert[\s(:]", re.IGNORECASE)
@@ -18,7 +19,9 @@ def compute_rule_verdict(commit_messages: list[str]) -> str:
     return "neutral"
 
 
-def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id: str) -> dict | None:
+def auto_assess_checkpoint(
+    conn: sqlite3.Connection, checkpoint_id: str, repo_path: str, session_id: str
+) -> dict | None:
     """Create a rule-based assessment for a checkpoint. Never raises."""
     try:
         from .futures import create_assessment
@@ -74,7 +77,9 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         return None
 
 
-def backfill_unassessed_checkpoints(conn, repo_path: str, session_id: str | None = None, window_days: int = 7) -> int:
+def backfill_unassessed_checkpoints(
+    conn: sqlite3.Connection, repo_path: str, session_id: str | None = None, window_days: int = 7
+) -> int:
     query = """
         SELECT c.id, c.session_id FROM checkpoints c
         LEFT JOIN assessments a ON a.checkpoint_id = c.id
@@ -95,7 +100,9 @@ def backfill_unassessed_checkpoints(conn, repo_path: str, session_id: str | None
     return count
 
 
-def get_enrichment_candidates(conn, session_id: str | None = None, window_days: int = 7, limit: int = 10) -> list[dict]:
+def get_enrichment_candidates(
+    conn: sqlite3.Connection, session_id: str | None = None, window_days: int = 7, limit: int = 10
+) -> list[dict]:
     query = """
         SELECT a.id, a.checkpoint_id, a.verdict, a.model_name, a.impact_summary,
                c.git_commit_hash, c.diff_summary, c.session_id
@@ -113,7 +120,7 @@ def get_enrichment_candidates(conn, session_id: str | None = None, window_days: 
     return [dict(row) for row in conn.execute(query, params).fetchall()]
 
 
-def enrich_assessment(conn, assessment: dict, repo_path: str, config: dict) -> bool:
+def enrich_assessment(conn: sqlite3.Connection, assessment: dict, repo_path: str, config: dict) -> bool:
     try:
         import json
 
@@ -167,7 +174,9 @@ def enrich_assessment(conn, assessment: dict, repo_path: str, config: dict) -> b
         return False
 
 
-def apply_git_evidence_feedback(conn, repo_path: str, session_id: str | None = None, window_days: int = 7) -> int:
+def apply_git_evidence_feedback(
+    conn: sqlite3.Connection, repo_path: str, session_id: str | None = None, window_days: int = 7
+) -> int:
     try:
         from .futures import add_feedback
         from .git_utils import get_commit_messages

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -25,7 +25,7 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         from .git_utils import get_commit_messages
 
         row = conn.execute(
-            "SELECT git_commit_hash, diff_summary, created_at FROM checkpoints WHERE id = ?", (checkpoint_id,)
+            "SELECT git_commit_hash, diff_summary FROM checkpoints WHERE id = ?", (checkpoint_id,)
         ).fetchone()
         if not row:
             return None
@@ -34,9 +34,9 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         from_commit = None
         pred = conn.execute(
             "SELECT git_commit_hash FROM checkpoints"
-            " WHERE session_id = ? AND (created_at < ? OR (created_at = ? AND rowid < (SELECT rowid FROM checkpoints WHERE id = ?)))"
-            " ORDER BY created_at DESC, rowid DESC LIMIT 1",
-            (session_id, row["created_at"], row["created_at"], checkpoint_id),
+            " WHERE session_id = ? AND rowid < (SELECT rowid FROM checkpoints WHERE id = ?)"
+            " ORDER BY rowid DESC LIMIT 1",
+            (session_id, checkpoint_id),
         ).fetchone()
         if pred:
             from_commit = pred["git_commit_hash"]

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -36,7 +36,7 @@ def auto_assess_checkpoint(conn, checkpoint_id: str, repo_path: str, session_id:
         from_commit = None
         prev = list_checkpoints(conn, session_id=session_id, limit=100)
         for i, cp in enumerate(prev):
-            if cp[id] == checkpoint_id:
+            if cp["id"] == checkpoint_id:
                 if i + 1 < len(prev):
                     from_commit = prev[i + 1]["git_commit_hash"]
                 break

--- a/src/entirecontext/core/checkpoint.py
+++ b/src/entirecontext/core/checkpoint.py
@@ -87,7 +87,7 @@ def list_checkpoints(
         query += " WHERE session_id = ?"
         params.append(session_id)
 
-    query += " ORDER BY created_at DESC LIMIT ?"
+    query += " ORDER BY created_at DESC, rowid DESC LIMIT ?"
     params.append(limit)
 
     rows = conn.execute(query, params).fetchall()

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -63,8 +63,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "futures": {
         "auto_distill": False,
         "lessons_output": "LESSONS.md",
-        "default_backend": "openai",
-        "default_model": "gpt-4o-mini",
+        "default_backend": "claude",
+        "default_model": "",
+        "assess_enrich": True,
+        "assess_backfill_window_days": 7,
     },
     "decisions": {
         "auto_stale_check": False,

--- a/src/entirecontext/core/dashboard.py
+++ b/src/entirecontext/core/dashboard.py
@@ -153,6 +153,16 @@ def get_dashboard_stats(
     )
     checkpoint_anchored_assessment_rate = anchored_assessment_count / asmt_total if asmt_total > 0 else 0.0
 
+    enriched_count = (
+        conn.execute(
+            "SELECT COUNT(*) AS total FROM assessments WHERE model_name IS NOT NULL AND model_name != 'rule-based'"
+            + (" AND created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+    enriched_rate = enriched_count / asmt_total if asmt_total > 0 else 0.0
+
     retrieval_events_total = (
         conn.execute(
             f"SELECT COUNT(*) AS total FROM retrieval_events{since_clause_ca}",
@@ -327,6 +337,8 @@ def get_dashboard_stats(
             "feedback_rate": feedback_rate,
             "with_checkpoint": anchored_assessment_count,
             "checkpoint_anchored_assessment_rate": checkpoint_anchored_assessment_rate,
+            "enriched_count": enriched_count,
+            "enriched_rate": enriched_rate,
             "recent": [dict(r) for r in recent_assessments],
         },
         "telemetry": {

--- a/src/entirecontext/core/git_utils.py
+++ b/src/entirecontext/core/git_utils.py
@@ -62,6 +62,24 @@ def get_diff_stat(repo_path: str, from_commit: str | None = None) -> str | None:
     return None
 
 
+def get_commit_messages(repo_path: str, from_commit: str | None, to_commit: str = "HEAD") -> list[str]:
+    if not from_commit:
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%s", f"{from_commit}..{to_commit}"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [line for line in result.stdout.strip().splitlines() if line.strip()]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return []
+
+
 def get_tracked_files_snapshot(repo_path: str) -> dict[str, str]:
     """Get snapshot of tracked files as {path: hash} via git ls-files -s."""
     try:

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -456,7 +456,7 @@ def _maybe_create_auto_checkpoint(repo_path: str, session_id: str) -> None:
 
             diff_summary = get_diff_stat(repo_path, from_commit=from_commit)
 
-            create_checkpoint(
+            cp = create_checkpoint(
                 conn,
                 session_id=session_id,
                 git_commit_hash=git_commit,
@@ -464,6 +464,12 @@ def _maybe_create_auto_checkpoint(repo_path: str, session_id: str) -> None:
                 diff_summary=diff_summary,
                 metadata={"source": "auto_session_end"},
             )
+            try:
+                from ..core.auto_assess import auto_assess_checkpoint
+
+                auto_assess_checkpoint(conn, cp["id"], repo_path, session_id)
+            except Exception as exc:
+                _record_hook_warning(repo_path, "auto_checkpoint_assess", exc)
         finally:
             conn.close()
     except Exception as exc:
@@ -514,7 +520,7 @@ def on_post_commit(data: dict[str, Any]) -> None:
 
             diff_summary = get_diff_stat(repo_path, from_commit=from_commit)
 
-            create_checkpoint(
+            cp = create_checkpoint(
                 conn,
                 session_id=session_id,
                 git_commit_hash=git_commit,
@@ -522,6 +528,12 @@ def on_post_commit(data: dict[str, Any]) -> None:
                 diff_summary=diff_summary,
                 metadata={"source": "post_commit"},
             )
+            try:
+                from ..core.auto_assess import auto_assess_checkpoint
+
+                auto_assess_checkpoint(conn, cp["id"], repo_path, session_id)
+            except Exception as exc:
+                _record_hook_warning(repo_path, "post_commit_assess", exc)
         finally:
             conn.close()
     except Exception as exc:

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -278,6 +278,7 @@ def on_session_end(data: dict[str, Any]) -> None:
 
     _maybe_auto_cleanup_no_changes(repo_path, session_id)
     _maybe_create_auto_checkpoint(repo_path, session_id)
+    _maybe_backfill_assessments(repo_path, session_id)
     _maybe_trigger_auto_sync(repo_path)
     _maybe_trigger_auto_distill(repo_path)
     _maybe_trigger_auto_embed(repo_path)
@@ -474,6 +475,35 @@ def _maybe_create_auto_checkpoint(repo_path: str, session_id: str) -> None:
             conn.close()
     except Exception as exc:
         _record_hook_warning(repo_path, "auto_checkpoint", exc)
+
+
+def _maybe_backfill_assessments(repo_path: str, session_id: str) -> None:
+    """Backfill unassessed checkpoints and apply git-evidence feedback. Never crashes."""
+    try:
+        from ..core.auto_assess import apply_git_evidence_feedback, backfill_unassessed_checkpoints
+        from ..core.config import load_config
+        from ..db import get_db
+
+        config = load_config(repo_path)
+        window_days = config.get("futures", {}).get("assess_backfill_window_days", 7)
+
+        conn = get_db(repo_path)
+        try:
+            backfill_unassessed_checkpoints(conn, repo_path, session_id=session_id, window_days=window_days)
+            apply_git_evidence_feedback(conn, repo_path, session_id=session_id, window_days=window_days)
+        finally:
+            conn.close()
+
+        if config.get("futures", {}).get("assess_enrich", True):
+            import sys
+
+            from ..core.async_worker import launch_worker, worker_status
+
+            if not worker_status(repo_path, pid_name="worker-assess").get("running"):
+                cmd = [sys.executable, "-m", "entirecontext.cli", "futures", "enrich-backlog"]
+                launch_worker(repo_path, cmd, pid_name="worker-assess")
+    except Exception as exc:
+        _record_hook_warning(repo_path, "backfill_assessments", exc)
 
 
 def on_post_commit(data: dict[str, Any]) -> None:

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -130,6 +130,8 @@ def on_session_start(data: dict[str, Any]) -> None:
     finally:
         conn.close()
 
+    _maybe_catchup_assessments(repo_path)
+
 
 def _populate_session_summary(conn, session_id: str) -> None:
     """Generate session title/summary from turns if not already set."""
@@ -504,6 +506,25 @@ def _maybe_backfill_assessments(repo_path: str, session_id: str) -> None:
                 launch_worker(repo_path, cmd, pid_name="worker-assess")
     except Exception as exc:
         _record_hook_warning(repo_path, "backfill_assessments", exc)
+
+
+def _maybe_catchup_assessments(repo_path: str) -> None:
+    """Catch up unassessed checkpoints from prior sessions. Never crashes."""
+    try:
+        from ..core.auto_assess import backfill_unassessed_checkpoints
+        from ..core.config import load_config
+        from ..db import get_db
+
+        config = load_config(repo_path)
+        window_days = config.get("futures", {}).get("assess_backfill_window_days", 7)
+
+        conn = get_db(repo_path)
+        try:
+            backfill_unassessed_checkpoints(conn, repo_path, window_days=window_days)
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "catchup_assessments", exc)
 
 
 def on_post_commit(data: dict[str, Any]) -> None:

--- a/tests/test_async_worker.py
+++ b/tests/test_async_worker.py
@@ -119,6 +119,14 @@ class TestLaunchWorker:
         # start_new_session=True detaches the child from the parent's TTY/group
         assert kwargs.get("start_new_session") is True
 
+    def test_popen_runs_in_repo_directory(self, tmp_path):
+        """Worker must run with cwd=repo_path so find_git_root() works."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 1
+        with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            launch_worker(str(tmp_path), ["echo"])
+        assert mock_popen.call_args.kwargs.get("cwd") == str(tmp_path)
+
 
 # ---------------------------------------------------------------------------
 # stop_worker

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from uuid import uuid4
+
+from entirecontext.core.auto_assess import (
+    auto_assess_checkpoint,
+    backfill_unassessed_checkpoints,
+    compute_rule_verdict,
+    get_enrichment_candidates,
+)
+from entirecontext.core.checkpoint import create_checkpoint
+from entirecontext.core.futures import create_assessment
+from entirecontext.core.git_utils import get_commit_messages
+
+
+def test_get_commit_messages_returns_empty_when_no_from(git_repo):
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: add API"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    msgs = get_commit_messages(str(git_repo), from_commit=None, to_commit="HEAD")
+    assert msgs == []
+
+
+def test_get_commit_messages_with_range(git_repo):
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    base = result.stdout.strip()
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: add login"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "fix: typo"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    msgs = get_commit_messages(str(git_repo), from_commit=base, to_commit="HEAD")
+    assert "fix: typo" in msgs
+    assert "feat: add login" in msgs
+    assert len(msgs) == 2
+
+
+def test_get_commit_messages_invalid_range(git_repo):
+    msgs = get_commit_messages(str(git_repo), from_commit="deadbeef", to_commit="HEAD")
+    assert msgs == []
+
+
+def test_get_commit_messages_same_commit(git_repo):
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip()
+    msgs = get_commit_messages(str(git_repo), from_commit=sha, to_commit=sha)
+    assert msgs == []
+
+
+
+def test_verdict_feat():
+    assert compute_rule_verdict(["feat: add API"]) == "expand"
+
+
+def test_verdict_feat_scoped():
+    assert compute_rule_verdict(["feat(auth): add SSO"]) == "expand"
+
+
+def test_verdict_revert():
+    assert compute_rule_verdict(["revert: undo feature"]) == "narrow"
+
+
+def test_verdict_fix():
+    assert compute_rule_verdict(["fix: null check"]) == "neutral"
+
+
+def test_verdict_mixed_feat_revert():
+    assert compute_rule_verdict(["feat: add", "revert: undo"]) == "neutral"
+
+
+def test_verdict_empty():
+    assert compute_rule_verdict([]) == "neutral"
+
+
+def test_verdict_case_insensitive():
+    assert compute_rule_verdict(["FEAT: big thing"]) == "expand"
+
+
+def test_verdict_non_conventional():
+    assert compute_rule_verdict(["Update README"]) == "neutral"
+
+
+def test_verdict_merge_commit():
+    assert compute_rule_verdict(["Merge branch 'feature' into 'main'"]) == "neutral"
+
+
+def _get_head(repo_path):
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, text=True)
+    return r.stdout.strip()
+
+
+def _create_test_session(conn, repo_path=None):
+    sid = str(uuid4())
+    now = __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat()
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    meta = None
+    if repo_path:
+        head = _get_head(repo_path)
+        meta = json.dumps({"start_git_commit": head})
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, project_id, "claude", "/tmp", now, now, meta),
+    )
+    return sid
+
+
+def test_auto_assess_creates_assessment(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db, str(ec_repo))
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: add endpoint"], cwd=ec_repo, capture_output=True)
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    result = auto_assess_checkpoint(ec_db, cp["id"], str(ec_repo), session_id)
+    assert result is not None
+    assert result["verdict"] == "expand"
+    assert result["model_name"] == "rule-based"
+
+
+def test_auto_assess_no_prior_returns_neutral(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    result = auto_assess_checkpoint(ec_db, cp["id"], str(ec_repo), session_id)
+    assert result is not None
+    assert result["verdict"] == "neutral"
+
+
+def test_auto_assess_never_raises(ec_repo, ec_db):
+    result = auto_assess_checkpoint(ec_db, "nonexistent", "/bad/path", "bad-session")
+    assert result is None
+
+
+def test_backfill_creates_missing_assessments(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    head = _get_head(ec_repo)
+    cp1 = create_checkpoint(ec_db, session_id, head)
+    create_checkpoint(ec_db, session_id, head)
+    create_assessment(ec_db, checkpoint_id=cp1["id"], verdict="neutral")
+    count = backfill_unassessed_checkpoints(ec_db, str(ec_repo), session_id=session_id)
+    assert count == 1
+
+
+def test_backfill_respects_window(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    ec_db.execute("UPDATE checkpoints SET created_at = datetime('now', '-30 days') WHERE id = ?", (cp["id"],))
+    count = backfill_unassessed_checkpoints(ec_db, str(ec_repo), window_days=7)
+    assert count == 0
+
+
+def test_get_enrichment_candidates_only_rule_based(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db)
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    create_assessment(ec_db, verdict="expand", model_name="gpt-4o-mini")
+    candidates = get_enrichment_candidates(ec_db)
+    assert len(candidates) == 1
+    assert candidates[0]["model_name"] == "rule-based"

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -283,3 +283,12 @@ def test_enrich_assessment_agree_when_same_verdict(ec_repo, ec_db, monkeypatch):
     ).fetchone()
     assert row["feedback"] == "agree"
     assert "confirmed" in row["feedback_reason"]
+
+
+def test_config_defaults():
+    from entirecontext.core.config import DEFAULT_CONFIG
+
+    futures = DEFAULT_CONFIG["futures"]
+    assert futures["default_backend"] == "claude"
+    assert futures["assess_enrich"] is True
+    assert futures["assess_backfill_window_days"] == 7

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -5,6 +5,7 @@ import subprocess
 from uuid import uuid4
 
 from entirecontext.core.auto_assess import (
+    apply_git_evidence_feedback,
     auto_assess_checkpoint,
     backfill_unassessed_checkpoints,
     compute_rule_verdict,
@@ -169,6 +170,46 @@ def test_backfill_respects_window(ec_repo, ec_db):
     cp = create_checkpoint(ec_db, session_id, head)
     ec_db.execute("UPDATE checkpoints SET created_at = datetime('now', '-30 days') WHERE id = ?", (cp["id"],))
     count = backfill_unassessed_checkpoints(ec_db, str(ec_repo), window_days=7)
+    assert count == 0
+
+
+def test_git_evidence_feedback(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db, str(ec_repo))
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "fix: something"],
+        cwd=ec_repo,
+        check=True,
+        capture_output=True,
+    )
+    count = apply_git_evidence_feedback(ec_db, str(ec_repo), session_id=session_id)
+    assert count == 1
+    row = ec_db.execute(
+        "SELECT feedback, feedback_reason FROM assessments WHERE checkpoint_id = ?",
+        (cp["id"],),
+    ).fetchone()
+    assert row["feedback"] == "agree"
+    assert "committed" in row["feedback_reason"]
+
+
+def test_git_evidence_feedback_skips_already_feedbacked(ec_repo, ec_db):
+    session_id = _create_test_session(ec_db, str(ec_repo))
+    head = _get_head(ec_repo)
+    cp = create_checkpoint(ec_db, session_id, head)
+    assessment = create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    ec_db.execute(
+        "UPDATE assessments SET feedback = ?, feedback_reason = ? WHERE id = ?",
+        ("agree", "manual", assessment["id"]),
+    )
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "fix: something else"],
+        cwd=ec_repo,
+        check=True,
+        capture_output=True,
+    )
+    count = apply_git_evidence_feedback(ec_db, str(ec_repo), session_id=session_id)
     assert count == 0
 
 

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -149,6 +149,23 @@ def test_auto_assess_no_prior_returns_neutral(ec_repo, ec_db):
     assert result["verdict"] == "neutral"
 
 
+def test_auto_assess_backfill_uses_correct_predecessor(ec_repo, ec_db):
+    """When backfilling an older checkpoint, from_commit must be the predecessor, not the newest."""
+    session_id = _create_test_session(ec_db, str(ec_repo))
+    # cp1 at initial HEAD
+    cp1 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    # feat commit, then cp2
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: first"], cwd=ec_repo, capture_output=True, check=True)
+    cp2 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    # fix commit, then cp3
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "fix: second"], cwd=ec_repo, capture_output=True, check=True)
+    create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    # Backfill cp2 (not the newest) — should see "feat: first" between cp1 and cp2
+    result = auto_assess_checkpoint(ec_db, cp2["id"], str(ec_repo), session_id)
+    assert result is not None
+    assert result["verdict"] == "expand"
+
+
 def test_auto_assess_never_raises(ec_repo, ec_db):
     result = auto_assess_checkpoint(ec_db, "nonexistent", "/bad/path", "bad-session")
     assert result is None

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -237,7 +237,7 @@ def test_enrich_assessment_updates_model_name(ec_repo, ec_db, monkeypatch):
         }
     )
     monkeypatch.setattr(
-        "entirecontext.core.auto_assess.get_backend",
+        "entirecontext.core.llm.get_backend",
         lambda *args, **kwargs: type("B", (), {"complete": lambda self, system, user: mock_response})(),
     )
     config = {"futures": {"default_backend": "claude", "default_model": ""}}
@@ -268,7 +268,7 @@ def test_enrich_assessment_agree_when_same_verdict(ec_repo, ec_db, monkeypatch):
         }
     )
     monkeypatch.setattr(
-        "entirecontext.core.auto_assess.get_backend",
+        "entirecontext.core.llm.get_backend",
         lambda *args, **kwargs: type("B", (), {"complete": lambda self, system, user: mock_response})(),
     )
     config = {"futures": {"default_backend": "claude", "default_model": ""}}

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -153,12 +153,16 @@ def test_auto_assess_backfill_uses_correct_predecessor(ec_repo, ec_db):
     """When backfilling an older checkpoint, from_commit must be the predecessor, not the newest."""
     session_id = _create_test_session(ec_db, str(ec_repo))
     # cp1 at initial HEAD
-    cp1 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    create_checkpoint(ec_db, session_id, _get_head(ec_repo))
     # feat commit, then cp2
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "feat: first"], cwd=ec_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: first"], cwd=ec_repo, capture_output=True, check=True
+    )
     cp2 = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
     # fix commit, then cp3
-    subprocess.run(["git", "commit", "--allow-empty", "-m", "fix: second"], cwd=ec_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "fix: second"], cwd=ec_repo, capture_output=True, check=True
+    )
     create_checkpoint(ec_db, session_id, _get_head(ec_repo))
     # Backfill cp2 (not the newest) — should see "feat: first" between cp1 and cp2
     result = auto_assess_checkpoint(ec_db, cp2["id"], str(ec_repo), session_id)

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -73,7 +73,6 @@ def test_get_commit_messages_same_commit(git_repo):
     assert msgs == []
 
 
-
 def test_verdict_feat():
     assert compute_rule_verdict(["feat: add API"]) == "expand"
 

--- a/tests/test_auto_assess.py
+++ b/tests/test_auto_assess.py
@@ -9,6 +9,7 @@ from entirecontext.core.auto_assess import (
     auto_assess_checkpoint,
     backfill_unassessed_checkpoints,
     compute_rule_verdict,
+    enrich_assessment,
     get_enrichment_candidates,
 )
 from entirecontext.core.checkpoint import create_checkpoint
@@ -222,3 +223,63 @@ def test_get_enrichment_candidates_only_rule_based(ec_repo, ec_db):
     candidates = get_enrichment_candidates(ec_db)
     assert len(candidates) == 1
     assert candidates[0]["model_name"] == "rule-based"
+
+
+def test_enrich_assessment_updates_model_name(ec_repo, ec_db, monkeypatch):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    assessment = create_assessment(ec_db, checkpoint_id=cp["id"], verdict="neutral", model_name="rule-based")
+    mock_response = json.dumps(
+        {
+            "verdict": "expand",
+            "impact_summary": "Added new feature",
+            "roadmap_alignment": "Aligns with v0.8",
+            "tidy_suggestion": "None",
+        }
+    )
+    monkeypatch.setattr(
+        "entirecontext.core.auto_assess.get_backend",
+        lambda *args, **kwargs: type("B", (), {"complete": lambda self, system, user: mock_response})(),
+    )
+    config = {"futures": {"default_backend": "claude", "default_model": ""}}
+
+    ok = enrich_assessment(ec_db, assessment, str(ec_repo), config)
+
+    assert ok is True
+    row = ec_db.execute(
+        "SELECT model_name, verdict, feedback, feedback_reason FROM assessments WHERE id = ?",
+        (assessment["id"],),
+    ).fetchone()
+    assert row["model_name"] != "rule-based"
+    assert row["verdict"] == "expand"
+    assert row["feedback"] == "disagree"
+    assert "revised" in row["feedback_reason"]
+
+
+def test_enrich_assessment_agree_when_same_verdict(ec_repo, ec_db, monkeypatch):
+    session_id = _create_test_session(ec_db)
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    assessment = create_assessment(ec_db, checkpoint_id=cp["id"], verdict="expand", model_name="rule-based")
+    mock_response = json.dumps(
+        {
+            "verdict": "expand",
+            "impact_summary": "Added new feature",
+            "roadmap_alignment": "Aligns with v0.8",
+            "tidy_suggestion": "None",
+        }
+    )
+    monkeypatch.setattr(
+        "entirecontext.core.auto_assess.get_backend",
+        lambda *args, **kwargs: type("B", (), {"complete": lambda self, system, user: mock_response})(),
+    )
+    config = {"futures": {"default_backend": "claude", "default_model": ""}}
+
+    ok = enrich_assessment(ec_db, assessment, str(ec_repo), config)
+
+    assert ok is True
+    row = ec_db.execute(
+        "SELECT feedback, feedback_reason FROM assessments WHERE id = ?",
+        (assessment["id"],),
+    ).fetchone()
+    assert row["feedback"] == "agree"
+    assert "confirmed" in row["feedback_reason"]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -213,6 +213,23 @@ class TestGetDashboardStats:
         assert stats["since"] == "2025-01-01"
         assert stats["limit"] == 5
 
+    def test_enriched_rate(self, ec_repo, ec_db):
+        import pytest
+
+        ec_db.execute(
+            "INSERT INTO assessments (id, verdict, model_name, created_at) VALUES ('er-1', 'neutral', 'rule-based', datetime('now'))"
+        )
+        ec_db.execute(
+            "INSERT INTO assessments (id, verdict, model_name, created_at) VALUES ('er-2', 'expand', 'gpt-4o-mini', datetime('now'))"
+        )
+        ec_db.execute(
+            "INSERT INTO assessments (id, verdict, model_name, created_at) VALUES ('er-3', 'neutral', 'claude-cli', datetime('now'))"
+        )
+        ec_db.commit()
+        stats = get_dashboard_stats(ec_db)
+        assert stats["assessments"]["enriched_count"] == 2
+        assert stats["assessments"]["enriched_rate"] == pytest.approx(2 / 3)
+
     def test_by_verdict_always_has_all_three_keys(self, ec_repo, ec_db):
         # Only expand assessments
         from entirecontext.core.project import get_project

--- a/tests/test_distill_automation.py
+++ b/tests/test_distill_automation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import subprocess
+from unittest.mock import patch
 from uuid import uuid4
 
 from entirecontext.core.checkpoint import list_checkpoints
@@ -11,6 +12,20 @@ from entirecontext.core.checkpoint import list_checkpoints
 def _get_head(repo_path):
     r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, text=True, check=True)
     return r.stdout.strip()
+
+
+def _create_test_session(conn, repo_path=None):
+    sid = str(uuid4())
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    meta = None
+    if repo_path:
+        meta = json.dumps({"start_git_commit": _get_head(repo_path)})
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, project_id, "claude", "/tmp", now, now, meta),
+    )
+    return sid
 
 
 def test_post_commit_creates_assessment(ec_repo, ec_db):
@@ -43,3 +58,73 @@ def test_post_commit_creates_assessment(ec_repo, ec_db):
     assessment = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp_id,)).fetchone()
     assert assessment is not None
     assert assessment["model_name"] == "rule-based"
+
+
+def test_session_end_backfills_unassessed(ec_repo, ec_db):
+    from entirecontext.core.checkpoint import create_checkpoint
+    from entirecontext.hooks.session_lifecycle import _maybe_backfill_assessments
+
+    session_id = _create_test_session(ec_db, str(ec_repo))
+
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: add endpoint"],
+        cwd=ec_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cp = create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "fix: follow-up"],
+        cwd=ec_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    with patch(
+        "entirecontext.core.config.load_config",
+        return_value={"futures": {"assess_backfill_window_days": 7, "assess_enrich": False}},
+    ):
+        _maybe_backfill_assessments(str(ec_repo), session_id)
+
+    assessment = ec_db.execute(
+        "SELECT model_name, feedback, feedback_reason FROM assessments WHERE checkpoint_id = ?",
+        (cp["id"],),
+    ).fetchone()
+    assert assessment is not None
+    assert assessment["model_name"] == "rule-based"
+    assert assessment["feedback"] == "agree"
+    assert "committed" in assessment["feedback_reason"]
+
+
+def test_enrichment_worker_launched_by_default(ec_repo, ec_db):
+    from entirecontext.core.checkpoint import create_checkpoint
+    from entirecontext.hooks.session_lifecycle import _maybe_backfill_assessments
+
+    session_id = _create_test_session(ec_db, str(ec_repo))
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: add endpoint"],
+        cwd=ec_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    create_checkpoint(ec_db, session_id, _get_head(ec_repo))
+
+    with (
+        patch(
+            "entirecontext.core.config.load_config",
+            return_value={"futures": {"assess_backfill_window_days": 7, "assess_enrich": True}},
+        ),
+        patch("entirecontext.core.async_worker.worker_status", return_value={"running": False, "pid": None}),
+        patch("entirecontext.core.async_worker.launch_worker") as mock_launch,
+    ):
+        _maybe_backfill_assessments(str(ec_repo), session_id)
+
+    mock_launch.assert_called_once()
+    args = mock_launch.call_args.args
+    kwargs = mock_launch.call_args.kwargs
+    assert args[0] == str(ec_repo)
+    assert args[1][1:] == ["-m", "entirecontext.cli", "futures", "enrich-backlog"]
+    assert kwargs["pid_name"] == "worker-assess"

--- a/tests/test_distill_automation.py
+++ b/tests/test_distill_automation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import datetime
+import json
+import subprocess
+from uuid import uuid4
+
+from entirecontext.core.checkpoint import list_checkpoints
+
+
+def _get_head(repo_path):
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, text=True, check=True)
+    return r.stdout.strip()
+
+
+def test_post_commit_creates_assessment(ec_repo, ec_db):
+    """on_post_commit creates checkpoint AND assessment."""
+    from entirecontext.core.session import create_session
+    from entirecontext.hooks.session_lifecycle import on_post_commit
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    session_id = create_session(ec_db, project_id, session_id=str(uuid4()), workspace_path=str(ec_repo))["id"]
+    head = _get_head(ec_repo)
+    meta = json.dumps({"start_git_commit": head})
+    ec_db.execute(
+        "UPDATE sessions SET started_at = ?, last_activity_at = ?, metadata = ? WHERE id = ?",
+        (now, now, meta, session_id),
+    )
+
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "feat: endpoint"],
+        cwd=ec_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    on_post_commit({"cwd": str(ec_repo)})
+
+    checkpoints = list_checkpoints(ec_db)
+    assert len(checkpoints) >= 1
+    cp_id = checkpoints[0]["id"]
+    assessment = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp_id,)).fetchone()
+    assert assessment is not None
+    assert assessment["model_name"] == "rule-based"

--- a/tests/test_distill_automation.py
+++ b/tests/test_distill_automation.py
@@ -128,3 +128,34 @@ def test_enrichment_worker_launched_by_default(ec_repo, ec_db):
     assert args[0] == str(ec_repo)
     assert args[1][1:] == ["-m", "entirecontext.cli", "futures", "enrich-backlog"]
     assert kwargs["pid_name"] == "worker-assess"
+
+
+def test_session_start_catches_up(ec_repo, ec_db):
+    """SessionStart backfills unassessed checkpoints from prior sessions."""
+    import datetime
+    import json
+
+    from entirecontext.core.checkpoint import create_checkpoint
+    from entirecontext.hooks.session_lifecycle import on_session_start
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    old_session_id = str(uuid4())
+    head = _get_head(ec_repo)
+    meta = json.dumps({"start_git_commit": head})
+    ec_db.execute(
+        "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at, ended_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (old_session_id, project_id, "claude", str(ec_repo), now, now, now, meta),
+    )
+    cp = create_checkpoint(ec_db, old_session_id, head)
+
+    assessment = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp["id"],)).fetchone()
+    assert assessment is None
+
+    new_session_id = str(uuid4())
+    on_session_start({"session_id": new_session_id, "cwd": str(ec_repo)})
+
+    assessment = ec_db.execute("SELECT * FROM assessments WHERE checkpoint_id = ?", (cp["id"],)).fetchone()
+    assert assessment is not None
+    assert assessment["model_name"] == "rule-based"


### PR DESCRIPTION
## Summary
- **3-tier auto-assess**: checkpoint 생성 시 rule-based verdict 자동 생성(Tier 1), SessionEnd에서 미평가 checkpoint 백필 + LLM enrichment worker 실행(Tier 2), SessionStart에서 과거 세션의 누락 checkpoint catch-up(Tier 3)
- **Rule-based verdict**: conventional commit 메시지 파싱 (`feat:` → expand, `revert:` → narrow, else → neutral)
- **LLM enrichment**: `claude -p` CLI 백엔드(기본 ON), rule-based verdict와 비교하여 agree/disagree 자동 feedback 생성
- **Git-evidence feedback**: API 없이도 post-checkpoint commit 존재 시 `agree` feedback 자동 등록 — feedback_rate 유지
- **Config**: `default_backend`를 `openai` → `claude`로 변경, `assess_enrich=True`, `assess_backfill_window_days=7` 추가
- **Dashboard**: `enriched_rate` 지표 추가로 enrichment 파이프라인 효과 모니터링

## Motivation
v0.7.0 retro에서 distill=0이 3스프린트 연속 발생. Will-based 접근이 반복 실패하여 구조적 자동화로 전환.

## Files changed (11)
| File | Change |
|------|--------|
| `core/auto_assess.py` | NEW — rule verdict, auto-assess, backfill, enrich, git-evidence |
| `core/git_utils.py` | `get_commit_messages()` 추가 |
| `core/config.py` | futures 섹션 config key 변경/추가 |
| `core/dashboard.py` | `enriched_rate` 지표 추가 |
| `hooks/session_lifecycle.py` | Tier 1/2/3 hook wiring |
| `cli/checkpoint_cmds.py` | CLI checkpoint create에 verdict 출력 |
| `cli/futures_cmds.py` | `futures enrich-backlog` CLI 명령 추가 |
| `tests/test_auto_assess.py` | NEW — 24 unit tests |
| `tests/test_distill_automation.py` | NEW — 4 integration tests |
| `tests/test_dashboard.py` | enriched_rate test 추가 |
| `docs/superpowers/plans/...` | 구현 계획서 |

## Test plan
- [x] `uv run pytest` — 1649 passed, 93 skipped
- [x] `uv run ruff check` — All checks passed
- [x] `uv run ruff format --check .` — 206 files already formatted
- [ ] Smoke test: temp repo에서 `ec checkpoint create` → verdict 출력 확인
- [ ] Dogfooding: 실제 세션에서 auto-assess 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)