### PR TITLE
feat: v0.8.0 AAR, Signal B, Signal C foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-assess on checkpoint create** — `auto_assess_checkpoint()` creates a rule-based assessment (expand/narrow/neutral from conventional commit parsing) synchronously on every `ec checkpoint create`. SessionEnd backfills missed checkpoints; SessionStart catches up crashed sessions. 3-tier safety net breaks the three-sprint distill=0 streak.
+- **After-Action Report (AAR)** — SessionEnd hook emits a structured JSON summary (`.entirecontext/aar-{session_id}.json`) and human-readable stdout: decisions surfaced, PDI retrieve→intervene delta, assessments created. Config: `[capture] emit_aar` (default true).
+- **Signal B: working-file inference** — `rank_decisions_for_prompt()` now includes file paths from recent commits (up to 5) alongside uncommitted diff paths, improving decision relevance when the diff is clean but recent commits touch decision-linked files.
+- **Decision embedding foundation (Signal C)** — `_build_decision_embed_text()`, `semantic_search_decisions()`, and decision embedding in `generate_embeddings()` (`source_type='decision'`). Auto-embed on `create_decision()` gated by `[decisions] auto_embed` (default false, requires `entirecontext[semantic]`).
+- **Git-evidence feedback** — `apply_git_evidence_feedback()` auto-marks rule-based assessments as `feedback="agree"` when commits exist after the checkpoint. Scoped fallback in `ec futures enrich-backlog`.
+- **LLM enrichment** — `enrich_assessment()` upgrades rule-based assessments via `CLIBackend` (`claude -p`). Default backend changed from `openai` to `claude`.
+
+### Changed
+
+- **`[futures] default_backend`** — changed from `"openai"` to `"claude"`.
+- **`[futures] assess_enrich`** — new config key (default true) enabling LLM enrichment.
+- **`[futures] assess_backfill_window_days`** — new config key (default 7).
+- **`[decisions] auto_embed`** — new config key (default false).
+- **Dashboard** — `enriched_count` and `enriched_rate` added to assessments section.
+- **`launch_worker`** — now passes `cwd=repo_path` to `Popen` so detached workers find the git root.
+- **`list_checkpoints`** — added `rowid DESC` tiebreaker to ORDER BY for deterministic ordering.
+
 ## [0.7.0] - 2026-05-20
 
 v0.7.0 makes EntireContext proactive: the `UserPromptSubmit` hook now injects the top-k most relevant decisions directly into Claude Code's context on every prompt turn. Three debt items are also closed: `ended_at NULL` backfill CLI (B1), `unverified_changes.patch` removal (B3), and `accepted_boost` confidence scoring (B2).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -199,14 +199,14 @@ The `capture→distill→retrieve→intervene` loop has stalled at `distill=0` f
 
 ### Distill Automation
 
-- [ ] **Auto-assess on checkpoint create** (primary trigger) — `ec checkpoint create` automatically triggers `ec futures assess` (or inserts a structured assessment record) before the command returns; no session ends with a checkpoint and zero assessments
-- [ ] **SessionEnd safety net + AAR** — SessionEnd hook backfills un-assessed checkpoints (safety net), then emits a structured AAR (After-Action Report): new decisions extracted, prior decisions surfaced, PDI retrieve→intervene delta. AAR consumers: developer retrospective + metrics dashboard (not for agent consumption — PDI already covers retrieval)
-- [ ] **Maturity ≥75 (Closed Loop)** — distill automation brings `distill` off zero; sustained dogfooding target is restored
+- [x] **Auto-assess on checkpoint create** (primary trigger) — `ec checkpoint create` automatically triggers `auto_assess_checkpoint()` (rule-based assessment) before the command returns; no session ends with a checkpoint and zero assessments. PR #157.
+- [x] **SessionEnd safety net + AAR** — SessionEnd hook backfills un-assessed checkpoints (safety net via `_maybe_backfill_assessments`), SessionStart catches up crashed sessions (`_maybe_catchup_assessments`), then emits a structured AAR (After-Action Report): decisions surfaced, PDI retrieve→intervene delta, assessments created. AAR written to `.entirecontext/aar-{session_id}.json` and printed to stdout. Config: `[capture] emit_aar` (default true).
+- [ ] **Maturity ≥75 (Closed Loop)** — distill automation brings `distill` off zero (achieved: distill=25); sustained dogfooding target requires measurement over multiple sessions
 
 ### Signal Assembly
 
-- [ ] **Signal B: working-file inference** — infer active file paths from uncommitted diff + recent commit file lists; pass to `rank_related_decisions()` alongside Signal A paths. Compensates for UserPromptSubmit hook not exposing open-file information
-- [ ] **Signal C: semantic similarity** — async 2-pass architecture: 1st pass uses existing FTS + file signals within 250ms PDI timeout; 2nd pass runs semantic ranking in background, results feed into next prompt's PDI. SessionStart pre-warm kicks off semantic ranking from uncommitted diff + recent commits so the first prompt has coverage. Requires `sentence-transformers` (already optional dep) + embedding pre-indexing on decision create/update
+- [x] **Signal B: working-file inference** — `_get_recent_commit_file_paths()` extracts file paths from recent commits via `git log --name-only`; merged into `rank_decisions_for_prompt()` alongside Signal A (uncommitted diff) paths. Decisions linked to recently-committed files now surface even when the working tree is clean.
+- [~] **Signal C: semantic similarity** — v0.8.0 ships the foundation: `_build_decision_embed_text()`, `semantic_search_decisions()`, and decision embedding in `generate_embeddings()` (source_type='decision'). Auto-embed on `create_decision()` gated by `[decisions] auto_embed` (default false, requires `entirecontext[semantic]`). Full 2-pass async architecture (background ranking feeding next prompt's PDI, SessionStart pre-warm) deferred to v0.9.0.
 
 ## v1.0 — Loop Completes Autonomously
 

--- a/src/entirecontext/cli/decisions_cmds.py
+++ b/src/entirecontext/cli/decisions_cmds.py
@@ -22,9 +22,9 @@ def decision_create(
 ):
     from ..core.decisions import create_decision
 
-    conn, _ = get_repo_connection()
+    conn, repo_path = get_repo_connection()
     try:
-        decision = create_decision(conn, title=title, rationale=rationale, scope=scope)
+        decision = create_decision(conn, title=title, rationale=rationale, scope=scope, repo_path=repo_path)
     finally:
         conn.close()
     console.print(f"[green]Created decision:[/green] {decision['id']}")
@@ -773,7 +773,7 @@ def candidates_confirm(
 ):
     from ..core.decision_candidates import confirm_candidate
 
-    conn, _ = get_repo_connection()
+    conn, repo_path = get_repo_connection()
     try:
         result = confirm_candidate(
             conn,
@@ -781,6 +781,7 @@ def candidates_confirm(
             scope_override=scope,
             reviewer="cli",
             note=note,
+            repo_path=repo_path,
         )
     except ValueError as exc:
         console.print(f"[red]{exc}[/red]")

--- a/src/entirecontext/core/aar.py
+++ b/src/entirecontext/core/aar.py
@@ -7,11 +7,10 @@ import sqlite3
 from typing import Any
 
 
-def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> dict[str, Any]:
+def generate_aar(conn: sqlite3.Connection, session_id: str) -> dict[str, Any]:
     """Pure query function — returns structured AAR dict, no side effects."""
     generated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
-    # --- decisions extracted (confirmed candidates) ---
     extracted_count = conn.execute(
         "SELECT COUNT(*) FROM decision_candidates WHERE session_id = ? AND review_status = 'confirmed'",
         (session_id,),
@@ -31,7 +30,6 @@ def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> d
         ).fetchall()
         extracted_titles = [r["title"] for r in rows]
 
-    # --- decisions surfaced (via retrieval_selections) ---
     surfaced_count = conn.execute(
         "SELECT COUNT(DISTINCT result_id) FROM retrieval_selections WHERE session_id = ? AND result_type = 'decision'",
         (session_id,),
@@ -50,7 +48,6 @@ def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> d
         ).fetchall()
         surfaced_titles = [r["title"] for r in rows]
 
-    # --- PDI delta ---
     applied_count = conn.execute(
         """
         SELECT COUNT(DISTINCT rs.result_id) FROM context_applications ca
@@ -62,7 +59,6 @@ def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> d
 
     pdi_rate = applied_count / surfaced_count if surfaced_count > 0 else 0.0
 
-    # --- assessments ---
     new_assessments = conn.execute(
         """
         SELECT COUNT(*) FROM assessments a

--- a/src/entirecontext/core/aar.py
+++ b/src/entirecontext/core/aar.py
@@ -1,0 +1,119 @@
+"""After-Action Report (AAR) generation for session-end telemetry."""
+
+from __future__ import annotations
+
+import datetime
+import sqlite3
+from typing import Any
+
+
+def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> dict[str, Any]:
+    """Pure query function — returns structured AAR dict, no side effects."""
+    generated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    # --- decisions extracted (confirmed candidates) ---
+    extracted_count = conn.execute(
+        "SELECT COUNT(*) FROM decision_candidates WHERE session_id = ? AND review_status = 'confirmed'",
+        (session_id,),
+    ).fetchone()[0]
+
+    extracted_titles: list[str] = []
+    if extracted_count > 0:
+        rows = conn.execute(
+            """
+            SELECT d.title
+            FROM decision_candidates dc
+            JOIN decisions d ON d.id = dc.promoted_decision_id
+            WHERE dc.session_id = ? AND dc.review_status = 'confirmed'
+              AND dc.promoted_decision_id IS NOT NULL
+            """,
+            (session_id,),
+        ).fetchall()
+        extracted_titles = [r["title"] for r in rows]
+
+    # --- decisions surfaced (via retrieval_selections) ---
+    surfaced_count = conn.execute(
+        "SELECT COUNT(DISTINCT result_id) FROM retrieval_selections WHERE session_id = ? AND result_type = 'decision'",
+        (session_id,),
+    ).fetchone()[0]
+
+    surfaced_titles: list[str] = []
+    if surfaced_count > 0:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT d.title
+            FROM retrieval_selections rs
+            JOIN decisions d ON d.id = rs.result_id
+            WHERE rs.session_id = ? AND rs.result_type = 'decision'
+            """,
+            (session_id,),
+        ).fetchall()
+        surfaced_titles = [r["title"] for r in rows]
+
+    # --- PDI delta ---
+    applied_count = conn.execute(
+        """
+        SELECT COUNT(*) FROM context_applications
+        WHERE retrieval_selection_id IN (
+            SELECT id FROM retrieval_selections WHERE session_id = ?
+        )
+        """,
+        (session_id,),
+    ).fetchone()[0]
+
+    pdi_rate = applied_count / surfaced_count if surfaced_count > 0 else 0.0
+
+    # --- assessments ---
+    new_assessments = conn.execute(
+        """
+        SELECT COUNT(*) FROM assessments a
+        JOIN checkpoints c ON a.checkpoint_id = c.id
+        WHERE c.session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()[0]
+
+    return {
+        "session_id": session_id,
+        "generated_at": generated_at,
+        "decisions_extracted": {
+            "count": extracted_count,
+            "titles": extracted_titles,
+            "note": "(extraction worker may still be running)",
+        },
+        "decisions_surfaced": {
+            "count": surfaced_count,
+            "titles": surfaced_titles,
+        },
+        "pdi_delta": {
+            "surfaced": surfaced_count,
+            "applied": applied_count,
+            "rate": pdi_rate,
+        },
+        "assessments": {
+            "new_count": new_assessments,
+        },
+    }
+
+
+def format_aar_summary(aar: dict[str, Any]) -> str:
+    """Human-readable AAR text for hook stdout."""
+    sid_short = aar["session_id"][:8]
+    extracted = aar["decisions_extracted"]
+    surfaced = aar["decisions_surfaced"]
+    pdi = aar["pdi_delta"]
+    assessments = aar["assessments"]
+
+    rate_pct = f"{pdi['rate'] * 100:.1f}%"
+    pdi_line = (
+        f"{pdi['applied']}/{pdi['surfaced']} applied ({rate_pct})" if pdi["surfaced"] > 0 else "no decisions surfaced"
+    )
+
+    lines = [
+        f"[EntireContext AAR] Session {sid_short}",
+        f"  Decisions extracted: {extracted['count']} {extracted['note']}",
+        f"  Decisions surfaced: {surfaced['count']}",
+        f"  PDI delta: {pdi_line}",
+        f"  Assessments created: {assessments['new_count']}",
+    ]
+    return "\n".join(lines)

--- a/src/entirecontext/core/aar.py
+++ b/src/entirecontext/core/aar.py
@@ -53,10 +53,9 @@ def generate_aar(conn: sqlite3.Connection, session_id: str, repo_path: str) -> d
     # --- PDI delta ---
     applied_count = conn.execute(
         """
-        SELECT COUNT(*) FROM context_applications
-        WHERE retrieval_selection_id IN (
-            SELECT id FROM retrieval_selections WHERE session_id = ?
-        )
+        SELECT COUNT(DISTINCT rs.result_id) FROM context_applications ca
+        JOIN retrieval_selections rs ON rs.id = ca.retrieval_selection_id
+        WHERE rs.session_id = ? AND rs.result_type = 'decision'
         """,
         (session_id,),
     ).fetchone()[0]

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -121,6 +121,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "outcome_feedback_lookback_days": 60,
             "contradicted_penalty": 0.15,
         },
+        "auto_embed": False,
         "injection": {
             "inject_on_user_prompt": True,
             "top_k": 5,

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "checkpoint_on_session_end": False,
         "auto_cleanup_no_changes": False,
         "intent_summary": False,
+        "emit_aar": True,
         "exclusions": {
             "enabled": False,
             "content_patterns": [],

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -98,6 +98,7 @@ def confirm_candidate(
     scope_override: str | None = None,
     reviewer: str = "cli",
     note: str | None = None,
+    repo_path: str | None = None,
 ) -> dict[str, Any]:
     """Promote a candidate to a real decision with atomic concurrency safety.
 
@@ -231,6 +232,18 @@ def confirm_candidate(
             (_now_iso(), candidate["id"]),
         )
         raise
+
+    if repo_path:
+        try:
+            from .config import load_config
+
+            config = load_config(repo_path)
+            if config.get("decisions", {}).get("auto_embed", False):
+                from .embedding import generate_embeddings
+
+                generate_embeddings(conn, repo_path)
+        except Exception:
+            pass
 
     _record_event(
         conn,

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -241,7 +241,7 @@ def confirm_candidate(
             if config.get("decisions", {}).get("auto_embed", False):
                 from .embedding import generate_embeddings
 
-                generate_embeddings(conn, repo_path)
+                generate_embeddings(conn, repo_path, decisions_only=True)
         except Exception:
             pass
 

--- a/src/entirecontext/core/decision_prompt_surfacing.py
+++ b/src/entirecontext/core/decision_prompt_surfacing.py
@@ -296,7 +296,6 @@ def rank_decisions_for_prompt(
         file_paths = _parse_file_paths_from_diff(diff_text)
     commit_shas = _get_recent_commit_shas(repo_path, limit=5)
 
-    # Signal B: merge file paths from recent commits
     commit_file_paths = _get_recent_commit_file_paths(repo_path, limit=5)
     if commit_file_paths:
         seen = set(file_paths)

--- a/src/entirecontext/core/decision_prompt_surfacing.py
+++ b/src/entirecontext/core/decision_prompt_surfacing.py
@@ -127,6 +127,30 @@ def _get_recent_commit_shas(repo_path: str, limit: int = 5) -> list[str]:
     return []
 
 
+def _get_recent_commit_file_paths(repo_path: str, limit: int = 5) -> list[str]:
+    """Return deduplicated file paths touched by recent commits."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--name-only", "--format=", f"-{limit}"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            seen: set[str] = set()
+            paths: list[str] = []
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if line and line not in seen:
+                    seen.add(line)
+                    paths.append(line)
+            return paths
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return []
+
+
 def _fallback_name(session_id: str, turn_id: str) -> str:
     """Turn-scoped filename so concurrent prompts in one session don't race.
 
@@ -271,6 +295,15 @@ def rank_decisions_for_prompt(
     if not file_paths:
         file_paths = _parse_file_paths_from_diff(diff_text)
     commit_shas = _get_recent_commit_shas(repo_path, limit=5)
+
+    # Signal B: merge file paths from recent commits
+    commit_file_paths = _get_recent_commit_file_paths(repo_path, limit=5)
+    if commit_file_paths:
+        seen = set(file_paths)
+        for p in commit_file_paths:
+            if p not in seen:
+                seen.add(p)
+                file_paths.append(p)
 
     combined_diff = redacted
     if diff_text:

--- a/src/entirecontext/core/decision_prompt_surfacing.py
+++ b/src/entirecontext/core/decision_prompt_surfacing.py
@@ -131,7 +131,7 @@ def _get_recent_commit_file_paths(repo_path: str, limit: int = 5) -> list[str]:
     """Return deduplicated file paths touched by recent commits."""
     try:
         result = subprocess.run(
-            ["git", "log", "--name-only", "--format=", f"-{limit}"],
+            ["git", "-c", "core.quotePath=false", "log", "--name-only", "--format=", f"-{limit}"],
             cwd=repo_path,
             capture_output=True,
             text=True,

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -377,7 +377,7 @@ def create_decision(
             if config.get("decisions", {}).get("auto_embed", False):
                 from .embedding import generate_embeddings
 
-                generate_embeddings(conn, repo_path)
+                generate_embeddings(conn, repo_path, decisions_only=True)
         except Exception:
             pass
 

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -348,6 +348,7 @@ def create_decision(
     staleness_status: str = "fresh",
     rejected_alternatives: list[dict[str, Any]] | list[str] | None = None,
     supporting_evidence: list[dict[str, Any]] | list[str] | None = None,
+    repo_path: str | None = None,
 ) -> dict:
     if staleness_status not in VALID_STALENESS:
         raise ValueError(
@@ -367,6 +368,19 @@ def create_decision(
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (decision_id, title, rationale, scope, staleness_status, rejected_json, evidence_json, now, now),
         )
+
+    if repo_path:
+        try:
+            from .config import load_config
+
+            config = load_config(repo_path)
+            if config.get("decisions", {}).get("auto_embed", False):
+                from .embedding import generate_embeddings
+
+                generate_embeddings(conn, repo_path)
+        except Exception:
+            pass
+
     return get_decision(conn, decision_id) or {}
 
 

--- a/src/entirecontext/core/embedding.py
+++ b/src/entirecontext/core/embedding.py
@@ -200,6 +200,7 @@ def generate_embeddings(
     repo_path: str,
     model_name: str = "all-MiniLM-L6-v2",
     force: bool = False,
+    decisions_only: bool = False,
 ) -> int:
     """Generate embeddings for turns/sessions without existing embeddings.
 
@@ -217,9 +218,16 @@ def generate_embeddings(
     model = SentenceTransformer(model_name)
     count = 0
 
-    if force:
+    if decisions_only:
         existing_turn_ids: set[str] = set()
         existing_session_ids: set[str] = set()
+        turns: list = []
+        sessions: list = []
+    elif force:
+        existing_turn_ids = set()
+        existing_session_ids = set()
+        turns = conn.execute("SELECT id, user_message, assistant_summary FROM turns").fetchall()
+        sessions = conn.execute("SELECT id, session_title, session_summary FROM sessions").fetchall()
     else:
         rows = conn.execute(
             "SELECT source_id FROM embeddings WHERE source_type = 'turn' AND model_name = ?",
@@ -233,8 +241,9 @@ def generate_embeddings(
         ).fetchall()
         existing_session_ids = {r[0] for r in rows}
 
-    turns = conn.execute("SELECT id, user_message, assistant_summary FROM turns").fetchall()
-    sessions = conn.execute("SELECT id, session_title, session_summary FROM sessions").fetchall()
+        turns = conn.execute("SELECT id, user_message, assistant_summary FROM turns").fetchall()
+        sessions = conn.execute("SELECT id, session_title, session_summary FROM sessions").fetchall()
+
     decisions = conn.execute("SELECT id, title, rationale, rejected_alternatives FROM decisions").fetchall()
 
     if force:

--- a/src/entirecontext/core/embedding.py
+++ b/src/entirecontext/core/embedding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 import struct
 from uuid import uuid4
@@ -146,6 +147,54 @@ def semantic_search(
     return results
 
 
+def _build_decision_embed_text(
+    title: str,
+    rationale: str | None,
+    rejected_alternatives_json: str | None,
+) -> str:
+    """Build embedding text from decision fields."""
+    parts = [title]
+    if rationale:
+        parts.append(rationale)
+    if rejected_alternatives_json:
+        try:
+            alts = json.loads(rejected_alternatives_json)
+            for alt in alts:
+                if isinstance(alt, dict):
+                    alt_text = alt.get("alternative", "")
+                    if alt_text:
+                        parts.append(alt_text)
+                elif isinstance(alt, str):
+                    parts.append(alt)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return " ".join(parts).strip()
+
+
+def semantic_search_decisions(
+    conn: sqlite3.Connection,
+    query: str,
+    limit: int = 10,
+    model_name: str = "all-MiniLM-L6-v2",
+) -> list[dict]:
+    """Search decisions by embedding similarity."""
+    query_embedding = embed_text(query, model_name)
+    rows = conn.execute(
+        "SELECT source_id, vector FROM embeddings WHERE source_type = 'decision' AND model_name = ?",
+        (model_name,),
+    ).fetchall()
+    scored = []
+    for row in rows:
+        score = cosine_similarity(query_embedding, row["vector"])
+        scored.append({"decision_id": row["source_id"], "score": round(score, 4)})
+    scored.sort(key=lambda x: x["score"], reverse=True)
+    results = scored[:limit]
+    for item in results:
+        dec_row = conn.execute("SELECT title FROM decisions WHERE id = ?", (item["decision_id"],)).fetchone()
+        item["title"] = dec_row["title"] if dec_row else "(deleted)"
+    return results
+
+
 def generate_embeddings(
     conn: sqlite3.Connection,
     repo_path: str,
@@ -186,6 +235,18 @@ def generate_embeddings(
 
     turns = conn.execute("SELECT id, user_message, assistant_summary FROM turns").fetchall()
     sessions = conn.execute("SELECT id, session_title, session_summary FROM sessions").fetchall()
+    decisions = conn.execute("SELECT id, title, rationale, rejected_alternatives FROM decisions").fetchall()
+
+    if force:
+        existing_decision_hashes: dict[str, tuple[str, int]] = {}
+    else:
+        rows = conn.execute(
+            "SELECT source_id, text_hash, COUNT(*) AS cnt"
+            " FROM embeddings WHERE source_type = 'decision' AND model_name = ?"
+            " GROUP BY source_id",
+            (model_name,),
+        ).fetchall()
+        existing_decision_hashes = {r["source_id"]: (r["text_hash"], r["cnt"]) for r in rows}
 
     # Skip the writer transaction when there is no DML to issue. Pre-S2a's
     # implicit-tx model deferred BEGIN to the first DML, so a force=False
@@ -203,7 +264,22 @@ def generate_embeddings(
         and f"{s['session_title'] or ''} {s['session_summary'] or ''}".strip()
         for s in sessions
     )
-    if not (turns_need_work or sessions_need_work):
+
+    def _decision_needs_work(d: dict) -> bool:
+        if force:
+            return bool(_build_decision_embed_text(d["title"], d["rationale"], d["rejected_alternatives"]).strip())
+        text = _build_decision_embed_text(d["title"], d["rationale"], d["rejected_alternatives"]).strip()
+        if not text:
+            return False
+        if d["id"] not in existing_decision_hashes:
+            return True
+        stored_hash, cnt = existing_decision_hashes[d["id"]]
+        if cnt > 1:
+            return True
+        return hashlib.md5(text.encode()).hexdigest() != stored_hash
+
+    decisions_need_work = any(_decision_needs_work(d) for d in decisions)
+    if not (turns_need_work or sessions_need_work or decisions_need_work):
         return 0
 
     with transaction(conn):
@@ -250,6 +326,36 @@ def generate_embeddings(
                 "INSERT INTO embeddings (id, source_type, source_id, model_name, vector, dimensions, text_hash) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (str(uuid4()), "session", session["id"], model_name, vector_bytes, len(vector), text_hash),
+            )
+            count += 1
+
+        for decision in decisions:
+            text = _build_decision_embed_text(
+                decision["title"], decision["rationale"], decision["rejected_alternatives"]
+            )
+            if not text:
+                continue
+            text_hash = hashlib.md5(text.encode()).hexdigest()
+
+            if not force:
+                stored_rows = conn.execute(
+                    "SELECT text_hash FROM embeddings WHERE source_type = 'decision' AND source_id = ? AND model_name = ?",
+                    (decision["id"], model_name),
+                ).fetchall()
+                if len(stored_rows) == 1 and stored_rows[0]["text_hash"] == text_hash:
+                    continue
+
+            vector = model.encode(text)
+            vector_bytes = vector.tobytes()
+
+            conn.execute(
+                "DELETE FROM embeddings WHERE source_type = 'decision' AND source_id = ? AND model_name = ?",
+                (decision["id"], model_name),
+            )
+            conn.execute(
+                "INSERT INTO embeddings (id, source_type, source_id, model_name, vector, dimensions, text_hash) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (str(uuid4()), "decision", decision["id"], model_name, vector_bytes, len(vector), text_hash),
             )
             count += 1
 

--- a/src/entirecontext/core/embedding.py
+++ b/src/entirecontext/core/embedding.py
@@ -62,7 +62,7 @@ def semantic_search(
     query_embedding = embed_text(query, model_name)
 
     rows = conn.execute(
-        "SELECT id, source_type, source_id, vector FROM embeddings WHERE model_name = ?",
+        "SELECT id, source_type, source_id, vector FROM embeddings WHERE model_name = ? AND source_type != 'decision'",
         (model_name,),
     ).fetchall()
 

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -383,7 +383,7 @@ def _maybe_emit_aar(repo_path: str, session_id: str) -> None:
 
         conn = get_db(repo_path)
         try:
-            aar = generate_aar(conn, session_id, repo_path)
+            aar = generate_aar(conn, session_id)
         finally:
             conn.close()
 

--- a/src/entirecontext/hooks/session_lifecycle.py
+++ b/src/entirecontext/hooks/session_lifecycle.py
@@ -287,6 +287,7 @@ def on_session_end(data: dict[str, Any]) -> None:
     _maybe_check_stale_decisions(repo_path)
     _maybe_extract_decisions(repo_path, session_id)
     _maybe_infer_ignored_decisions(repo_path, session_id)
+    _maybe_emit_aar(repo_path, session_id)
 
 
 def _maybe_infer_ignored_decisions(repo_path: str, session_id: str) -> None:
@@ -363,6 +364,40 @@ def _maybe_infer_ignored_decisions(repo_path: str, session_id: str) -> None:
             conn.close()
     except Exception as exc:
         _record_hook_warning(repo_path, "infer_ignored_decisions", exc)
+
+
+def _maybe_emit_aar(repo_path: str, session_id: str) -> None:
+    """Emit structured AAR if enabled. Never crashes the hook."""
+    try:
+        from ..core.config import load_config
+
+        config = load_config(repo_path)
+        if not config.get("capture", {}).get("emit_aar", True):
+            return
+
+        import json
+        from pathlib import Path
+
+        from ..core.aar import format_aar_summary, generate_aar
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            aar = generate_aar(conn, session_id, repo_path)
+        finally:
+            conn.close()
+
+        from ..core.decision_prompt_surfacing import _atomic_write_text, _sanitize_id_for_path
+
+        safe_id = _sanitize_id_for_path(session_id)
+        aar_dir = Path(repo_path) / ".entirecontext"
+        aar_dir.mkdir(parents=True, exist_ok=True)
+        aar_path = aar_dir / f"aar-{safe_id}.json"
+        _atomic_write_text(aar_path, json.dumps(aar, indent=2))
+
+        print(format_aar_summary(aar))
+    except Exception as exc:
+        _record_hook_warning(repo_path, "emit_aar", exc)
 
 
 def _session_has_change_signals(conn, session_id: str) -> bool:

--- a/src/entirecontext/mcp/tools/decision_candidates.py
+++ b/src/entirecontext/mcp/tools/decision_candidates.py
@@ -60,7 +60,7 @@ async def ec_decision_candidate_confirm(
     note: str | None = None,
 ) -> str:
     """Confirm a candidate: promote to a real decision with provenance links."""
-    (conn, _), error = runtime.resolve_repo()
+    (conn, repo_path), error = runtime.resolve_repo()
     if error:
         return error
     try:
@@ -72,6 +72,7 @@ async def ec_decision_candidate_confirm(
             scope_override=scope,
             reviewer="mcp",
             note=note,
+            repo_path=repo_path,
         )
         return json.dumps(result)
     except ValueError as exc:

--- a/src/entirecontext/mcp/tools/decisions.py
+++ b/src/entirecontext/mcp/tools/decisions.py
@@ -424,7 +424,7 @@ async def ec_decision_create(
         rejected_alternatives: List of alternatives that were considered and rejected
         supporting_evidence: Evidence supporting the decision
     """
-    (conn, _), error = runtime.resolve_repo()
+    (conn, repo_path), error = runtime.resolve_repo()
     if error:
         return error
     try:
@@ -440,6 +440,7 @@ async def ec_decision_create(
             scope=scope,
             rejected_alternatives=rejected_alternatives,
             supporting_evidence=supporting_evidence,
+            repo_path=repo_path,
         )
         return json.dumps(d)
     except ValueError as exc:

--- a/tests/test_aar.py
+++ b/tests/test_aar.py
@@ -121,6 +121,52 @@ def test_generate_aar_pdi_delta(ec_repo, ec_db):
     assert abs(aar["pdi_delta"]["rate"] - 1 / 3) < 0.01
 
 
+def test_generate_aar_pdi_delta_deduplicates_applications(ec_repo, ec_db):
+    """applied_count uses DISTINCT result_id — multiple applications for the same decision count as 1."""
+    sid = _create_test_session(ec_db, str(ec_repo))
+    dec_id = str(uuid4())
+    ec_db.execute("INSERT INTO decisions (id, title) VALUES (?, ?)", (dec_id, "D1"))
+    re_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, result_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (re_id, sid, "hook", "decision", "decisions", "q", 1),
+    )
+    rs_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id) VALUES (?, ?, ?, ?, ?)",
+        (rs_id, re_id, sid, "decision", dec_id),
+    )
+    for _ in range(3):
+        ec_db.execute(
+            "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
+            (str(uuid4()), sid, rs_id, "decision", dec_id, "lesson_applied"),
+        )
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["pdi_delta"]["applied"] == 1
+    assert aar["pdi_delta"]["rate"] <= 1.0
+
+
+def test_generate_aar_pdi_ignores_non_decision_applications(ec_repo, ec_db):
+    """Non-decision retrieval selections must not inflate applied_count."""
+    sid = _create_test_session(ec_db, str(ec_repo))
+    re_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, result_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (re_id, sid, "hook", "search", "turns", "q", 1),
+    )
+    rs_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id) VALUES (?, ?, ?, ?, ?)",
+        (rs_id, re_id, sid, "turn", str(uuid4())),
+    )
+    ec_db.execute(
+        "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
+        (str(uuid4()), sid, rs_id, "turn", str(uuid4()), "lesson_applied"),
+    )
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["pdi_delta"]["applied"] == 0
+
+
 def test_format_aar_summary():
     aar = {
         "session_id": "af44f9ee-1234-5678-9abc-def012345678",

--- a/tests/test_aar.py
+++ b/tests/test_aar.py
@@ -1,0 +1,179 @@
+"""Tests for After-Action Report (AAR) generation and hook integration."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+from entirecontext.core.aar import format_aar_summary, generate_aar
+from entirecontext.hooks.session_lifecycle import _maybe_emit_aar
+
+
+def _get_head(repo_path):
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, text=True)
+    return r.stdout.strip()
+
+
+def _create_test_session(conn, repo_path=None):
+    sid = str(uuid4())
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    meta = None
+    if repo_path:
+        head = _get_head(repo_path)
+        meta = json.dumps({"start_git_commit": head})
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, project_id, "claude", "/tmp", now, now, meta),
+    )
+    return sid
+
+
+def test_generate_aar_empty_session(ec_repo, ec_db):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["session_id"] == sid
+    assert aar["generated_at"]
+    assert aar["decisions_extracted"]["count"] == 0
+    assert aar["decisions_extracted"]["titles"] == []
+    assert "(extraction worker" in aar["decisions_extracted"]["note"]
+    assert aar["decisions_surfaced"]["count"] == 0
+    assert aar["pdi_delta"]["surfaced"] == 0
+    assert aar["pdi_delta"]["applied"] == 0
+    assert aar["pdi_delta"]["rate"] == 0.0
+    assert aar["assessments"]["new_count"] == 0
+
+
+def test_generate_aar_with_assessments(ec_repo, ec_db):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    head = _get_head(ec_repo)
+    cp_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash) VALUES (?, ?, ?)",
+        (cp_id, sid, head),
+    )
+    a_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict) VALUES (?, ?, ?)",
+        (a_id, cp_id, "expand"),
+    )
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["assessments"]["new_count"] == 1
+
+
+def test_generate_aar_with_retrieval(ec_repo, ec_db):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    # create a decision to reference
+    dec_id = str(uuid4())
+    ec_db.execute("INSERT INTO decisions (id, title) VALUES (?, ?)", (dec_id, "Use SQLite WAL"))
+    # retrieval event
+    re_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, result_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (re_id, sid, "hook", "decision", "decisions", "test query", 1),
+    )
+    # retrieval selection
+    rs_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id) VALUES (?, ?, ?, ?, ?)",
+        (rs_id, re_id, sid, "decision", dec_id),
+    )
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["decisions_surfaced"]["count"] == 1
+    assert "Use SQLite WAL" in aar["decisions_surfaced"]["titles"]
+
+
+def test_generate_aar_pdi_delta(ec_repo, ec_db):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    # create decisions
+    dec1 = str(uuid4())
+    dec2 = str(uuid4())
+    dec3 = str(uuid4())
+    for did, title in [(dec1, "D1"), (dec2, "D2"), (dec3, "D3")]:
+        ec_db.execute("INSERT INTO decisions (id, title) VALUES (?, ?)", (did, title))
+    # retrieval event
+    re_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, result_count) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (re_id, sid, "hook", "decision", "decisions", "query", 3),
+    )
+    # 3 selections
+    rs_ids = []
+    for did in [dec1, dec2, dec3]:
+        rs_id = str(uuid4())
+        rs_ids.append(rs_id)
+        ec_db.execute(
+            "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id) VALUES (?, ?, ?, ?, ?)",
+            (rs_id, re_id, sid, "decision", did),
+        )
+    # 1 application
+    ca_id = str(uuid4())
+    ec_db.execute(
+        "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
+        (ca_id, sid, rs_ids[0], "decision", dec1, "lesson_applied"),
+    )
+    aar = generate_aar(ec_db, sid, str(ec_repo))
+    assert aar["pdi_delta"]["surfaced"] == 3
+    assert aar["pdi_delta"]["applied"] == 1
+    assert abs(aar["pdi_delta"]["rate"] - 1 / 3) < 0.01
+
+
+def test_format_aar_summary():
+    aar = {
+        "session_id": "af44f9ee-1234-5678-9abc-def012345678",
+        "generated_at": "2026-06-07T00:00:00+00:00",
+        "decisions_extracted": {"count": 0, "titles": [], "note": "(extraction worker may still be running)"},
+        "decisions_surfaced": {"count": 3, "titles": ["A", "B", "C"]},
+        "pdi_delta": {"surfaced": 3, "applied": 1, "rate": 1 / 3},
+        "assessments": {"new_count": 2},
+    }
+    text = format_aar_summary(aar)
+    assert "Session af44f9ee" in text
+    assert "Decisions extracted: 0" in text
+    assert "extraction worker" in text
+    assert "Decisions surfaced: 3" in text
+    assert "1/3 applied" in text
+    assert "33.3%" in text
+    assert "Assessments created: 2" in text
+
+
+def test_format_aar_summary_no_surfaced():
+    aar = {
+        "session_id": "00000000-0000-0000-0000-000000000000",
+        "generated_at": "2026-06-07T00:00:00+00:00",
+        "decisions_extracted": {"count": 0, "titles": [], "note": "(extraction worker may still be running)"},
+        "decisions_surfaced": {"count": 0, "titles": []},
+        "pdi_delta": {"surfaced": 0, "applied": 0, "rate": 0.0},
+        "assessments": {"new_count": 0},
+    }
+    text = format_aar_summary(aar)
+    assert "no decisions surfaced" in text
+
+
+def test_maybe_emit_aar_writes_json(ec_repo, ec_db):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    _maybe_emit_aar(str(ec_repo), sid)
+    aar_files = list(Path(str(ec_repo)).glob(".entirecontext/aar-*.json"))
+    assert len(aar_files) == 1
+    data = json.loads(aar_files[0].read_text())
+    assert data["session_id"] == sid
+    assert "generated_at" in data
+
+
+def test_maybe_emit_aar_config_off(ec_repo, ec_db, monkeypatch):
+    sid = _create_test_session(ec_db, str(ec_repo))
+    monkeypatch.setattr(
+        "entirecontext.core.config.load_config",
+        lambda *a, **kw: {"capture": {"emit_aar": False}},
+    )
+    _maybe_emit_aar(str(ec_repo), sid)
+    aar_files = list(Path(str(ec_repo)).glob(".entirecontext/aar-*.json"))
+    assert len(aar_files) == 0
+
+
+def test_maybe_emit_aar_never_crashes():
+    # bad repo path and session id — must not raise
+    _maybe_emit_aar("/nonexistent/repo/path", "bad-session-id-!!!!")

--- a/tests/test_aar.py
+++ b/tests/test_aar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import sqlite3
 import subprocess
 from pathlib import Path
 from uuid import uuid4
@@ -12,12 +13,12 @@ from entirecontext.core.aar import format_aar_summary, generate_aar
 from entirecontext.hooks.session_lifecycle import _maybe_emit_aar
 
 
-def _get_head(repo_path):
+def _get_head(repo_path: str) -> str:
     r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, text=True)
     return r.stdout.strip()
 
 
-def _create_test_session(conn, repo_path=None):
+def _create_test_session(conn: sqlite3.Connection, repo_path: str | None = None) -> str:
     sid = str(uuid4())
     now = datetime.datetime.now(datetime.timezone.utc).isoformat()
     project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
@@ -34,7 +35,7 @@ def _create_test_session(conn, repo_path=None):
 
 def test_generate_aar_empty_session(ec_repo, ec_db):
     sid = _create_test_session(ec_db, str(ec_repo))
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["session_id"] == sid
     assert aar["generated_at"]
     assert aar["decisions_extracted"]["count"] == 0
@@ -60,7 +61,7 @@ def test_generate_aar_with_assessments(ec_repo, ec_db):
         "INSERT INTO assessments (id, checkpoint_id, verdict) VALUES (?, ?, ?)",
         (a_id, cp_id, "expand"),
     )
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["assessments"]["new_count"] == 1
 
 
@@ -81,7 +82,7 @@ def test_generate_aar_with_retrieval(ec_repo, ec_db):
         "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id) VALUES (?, ?, ?, ?, ?)",
         (rs_id, re_id, sid, "decision", dec_id),
     )
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["decisions_surfaced"]["count"] == 1
     assert "Use SQLite WAL" in aar["decisions_surfaced"]["titles"]
 
@@ -115,7 +116,7 @@ def test_generate_aar_pdi_delta(ec_repo, ec_db):
         "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
         (ca_id, sid, rs_ids[0], "decision", dec1, "lesson_applied"),
     )
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["pdi_delta"]["surfaced"] == 3
     assert aar["pdi_delta"]["applied"] == 1
     assert abs(aar["pdi_delta"]["rate"] - 1 / 3) < 0.01
@@ -141,7 +142,7 @@ def test_generate_aar_pdi_delta_deduplicates_applications(ec_repo, ec_db):
             "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
             (str(uuid4()), sid, rs_id, "decision", dec_id, "lesson_applied"),
         )
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["pdi_delta"]["applied"] == 1
     assert aar["pdi_delta"]["rate"] <= 1.0
 
@@ -163,7 +164,7 @@ def test_generate_aar_pdi_ignores_non_decision_applications(ec_repo, ec_db):
         "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type) VALUES (?, ?, ?, ?, ?, ?)",
         (str(uuid4()), sid, rs_id, "turn", str(uuid4()), "lesson_applied"),
     )
-    aar = generate_aar(ec_db, sid, str(ec_repo))
+    aar = generate_aar(ec_db, sid)
     assert aar["pdi_delta"]["applied"] == 0
 
 

--- a/tests/test_decision_embedding.py
+++ b/tests/test_decision_embedding.py
@@ -22,7 +22,7 @@ from entirecontext.core.embedding import (
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_model():
+def _make_mock_model() -> MagicMock:
     mock_model = MagicMock()
     fake_vector = MagicMock()
     fake_vector.tobytes.return_value = b"\x00" * 1536
@@ -31,7 +31,7 @@ def _make_mock_model():
     return mock_model
 
 
-def _patch_sentence_transformers(mock_model):
+def _patch_sentence_transformers(mock_model: MagicMock):
     mock_module = types.ModuleType("sentence_transformers")
     mock_module.SentenceTransformer = MagicMock(return_value=mock_model)
     return patch.dict(sys.modules, {"sentence_transformers": mock_module})

--- a/tests/test_decision_embedding.py
+++ b/tests/test_decision_embedding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import struct
 import sys
 import types
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -31,7 +32,7 @@ def _make_mock_model() -> MagicMock:
     return mock_model
 
 
-def _patch_sentence_transformers(mock_model: MagicMock):
+def _patch_sentence_transformers(mock_model: MagicMock) -> Any:
     mock_module = types.ModuleType("sentence_transformers")
     mock_module.SentenceTransformer = MagicMock(return_value=mock_model)
     return patch.dict(sys.modules, {"sentence_transformers": mock_module})

--- a/tests/test_decision_embedding.py
+++ b/tests/test_decision_embedding.py
@@ -1,0 +1,287 @@
+"""Tests for decision embedding: build text, semantic search, generate, auto-embed gate."""
+
+from __future__ import annotations
+
+import struct
+import sys
+import types
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+
+from entirecontext.core.decisions import create_decision
+from entirecontext.core.embedding import (
+    _build_decision_embed_text,
+    generate_embeddings,
+    semantic_search_decisions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reuse patterns from test_embedding.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_model():
+    mock_model = MagicMock()
+    fake_vector = MagicMock()
+    fake_vector.tobytes.return_value = b"\x00" * 1536
+    fake_vector.__len__ = lambda self: 384
+    mock_model.encode.return_value = fake_vector
+    return mock_model
+
+
+def _patch_sentence_transformers(mock_model):
+    mock_module = types.ModuleType("sentence_transformers")
+    mock_module.SentenceTransformer = MagicMock(return_value=mock_model)
+    return patch.dict(sys.modules, {"sentence_transformers": mock_module})
+
+
+def _make_float_vector(values: list[float]) -> bytes:
+    """Build a real float32 byte vector for cosine_similarity."""
+    return struct.pack(f"{len(values)}f", *values)
+
+
+# ---------------------------------------------------------------------------
+# _build_decision_embed_text
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDecisionEmbedText:
+    def test_title_only(self):
+        result = _build_decision_embed_text("Use Redis", None, None)
+        assert result == "Use Redis"
+
+    def test_title_and_rationale(self):
+        result = _build_decision_embed_text("Use Redis", "Fast caching", None)
+        assert result == "Use Redis Fast caching"
+
+    def test_title_rationale_and_alternatives(self):
+        import json
+
+        alts = [
+            {"alternative": "Memcached", "reason": "less features"},
+            {"alternative": "In-memory", "reason": "not persistent"},
+        ]
+        result = _build_decision_embed_text("Use Redis", "Fast caching", json.dumps(alts))
+        assert result == "Use Redis Fast caching Memcached In-memory"
+
+    def test_legacy_strings(self):
+        import json
+
+        alts = ["Memcached", "In-memory dict"]
+        result = _build_decision_embed_text("Use Redis", "Fast caching", json.dumps(alts))
+        assert result == "Use Redis Fast caching Memcached In-memory dict"
+
+    def test_invalid_json_ignored(self):
+        result = _build_decision_embed_text("Use Redis", None, "not valid json{{{")
+        assert result == "Use Redis"
+
+    def test_empty_title(self):
+        result = _build_decision_embed_text("", None, None)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# semantic_search_decisions
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_search_decisions(ec_db):
+    """Create 2 decisions, manually insert embedding rows, verify ranking."""
+    conn = ec_db
+
+    # Create two decisions
+    d1 = create_decision(conn, title="Use Redis for caching")
+    d2 = create_decision(conn, title="Use PostgreSQL for storage")
+
+    # Build vectors with known similarity properties:
+    # query vector close to d1, far from d2
+    dim = 4
+    query_vec = _make_float_vector([1.0, 0.0, 0.0, 0.0])
+    d1_vec = _make_float_vector([0.9, 0.1, 0.0, 0.0])  # high similarity to query
+    d2_vec = _make_float_vector([0.0, 0.0, 1.0, 0.0])  # low similarity to query
+
+    # Insert embedding rows manually
+    conn.execute(
+        "INSERT INTO embeddings (id, source_type, source_id, model_name, vector, dimensions, text_hash) "
+        "VALUES (?, 'decision', ?, 'all-MiniLM-L6-v2', ?, ?, 'hash1')",
+        (str(uuid4()), d1["id"], d1_vec, dim),
+    )
+    conn.execute(
+        "INSERT INTO embeddings (id, source_type, source_id, model_name, vector, dimensions, text_hash) "
+        "VALUES (?, 'decision', ?, 'all-MiniLM-L6-v2', ?, ?, 'hash2')",
+        (str(uuid4()), d2["id"], d2_vec, dim),
+    )
+    conn.commit()
+
+    # Mock embed_text to return our known query vector
+    with patch("entirecontext.core.embedding.embed_text", return_value=query_vec):
+        results = semantic_search_decisions(conn, "caching solution")
+
+    assert len(results) == 2
+    assert results[0]["decision_id"] == d1["id"]
+    assert results[1]["decision_id"] == d2["id"]
+    assert results[0]["score"] > results[1]["score"]
+    assert results[0]["title"] == "Use Redis for caching"
+    assert results[1]["title"] == "Use PostgreSQL for storage"
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings with decisions
+# ---------------------------------------------------------------------------
+
+
+def test_generate_embeddings_includes_decisions(ec_db):
+    conn = ec_db
+    create_decision(conn, title="Use WAL mode for SQLite")
+
+    mock_model = _make_mock_model()
+    with _patch_sentence_transformers(mock_model):
+        count = generate_embeddings(conn, "/tmp/test-repo")
+
+    assert count >= 1
+    rows = conn.execute("SELECT * FROM embeddings WHERE source_type = 'decision'").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["source_id"] is not None
+
+
+def test_generate_embeddings_skip_existing_decisions(ec_db):
+    conn = ec_db
+    create_decision(conn, title="Use WAL mode for SQLite")
+
+    mock_model = _make_mock_model()
+    with _patch_sentence_transformers(mock_model):
+        first_count = generate_embeddings(conn, "/tmp/test-repo")
+        assert first_count >= 1
+
+        second_count = generate_embeddings(conn, "/tmp/test-repo")
+        assert second_count == 0
+
+
+def test_generate_embeddings_no_writer_tx_when_all_embedded(ec_db, monkeypatch):
+    """When all turns/sessions/decisions are already embedded, generate_embeddings()
+    should return 0 WITHOUT opening a writer transaction."""
+    conn = ec_db
+    create_decision(conn, title="Use WAL mode for SQLite")
+
+    mock_model = _make_mock_model()
+    with _patch_sentence_transformers(mock_model):
+        first_count = generate_embeddings(conn, "/tmp/test-repo")
+        assert first_count >= 1
+
+        def _fail_transaction(conn):
+            raise AssertionError("transaction() must not be called when all embeddings already exist")
+
+        monkeypatch.setattr("entirecontext.core.embedding.transaction", _fail_transaction)
+
+        second_count = generate_embeddings(conn, "/tmp/test-repo")
+
+    assert second_count == 0
+
+
+# ---------------------------------------------------------------------------
+# create_decision auto-embed gate
+# ---------------------------------------------------------------------------
+
+
+def test_create_decision_auto_embed_gate(ec_repo, ec_db, monkeypatch):
+    conn = ec_db
+    repo_path = str(ec_repo)
+    mock_model = _make_mock_model()
+
+    # Test with auto_embed=True: embedding should be created
+    def _config_auto_embed_on(path=None):
+        return {"decisions": {"auto_embed": True}}
+
+    monkeypatch.setattr("entirecontext.core.config.load_config", _config_auto_embed_on)
+
+    with _patch_sentence_transformers(mock_model):
+        d1 = create_decision(conn, title="Auto-embedded decision", repo_path=repo_path)
+
+    rows = conn.execute("SELECT * FROM embeddings WHERE source_type = 'decision'").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["source_id"] == d1["id"]
+
+    # Clean up for next assertion
+    conn.execute("DELETE FROM embeddings WHERE source_type = 'decision'")
+    conn.commit()
+
+    # Test with auto_embed=False: no embedding should be created
+    def _config_auto_embed_off(path=None):
+        return {"decisions": {"auto_embed": False}}
+
+    monkeypatch.setattr("entirecontext.core.config.load_config", _config_auto_embed_off)
+
+    with _patch_sentence_transformers(mock_model):
+        create_decision(conn, title="Not auto-embedded", repo_path=repo_path)
+
+    rows = conn.execute("SELECT * FROM embeddings WHERE source_type = 'decision'").fetchall()
+    assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# stale re-embed and duplicate cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_generate_embeddings_re_embeds_stale_decision(ec_db):
+    """When a decision's content changes, the old embedding is replaced."""
+    conn = ec_db
+    d = create_decision(conn, title="Original title")
+
+    mock_model = _make_mock_model()
+    with _patch_sentence_transformers(mock_model):
+        count = generate_embeddings(conn, "/tmp/test-repo")
+    assert count >= 1
+
+    old_hash = conn.execute(
+        "SELECT text_hash FROM embeddings WHERE source_type = 'decision' AND source_id = ?",
+        (d["id"],),
+    ).fetchone()["text_hash"]
+
+    conn.execute("UPDATE decisions SET title = ? WHERE id = ?", ("Changed title", d["id"]))
+
+    with _patch_sentence_transformers(mock_model):
+        count = generate_embeddings(conn, "/tmp/test-repo")
+    assert count >= 1
+
+    rows = conn.execute(
+        "SELECT text_hash FROM embeddings WHERE source_type = 'decision' AND source_id = ?",
+        (d["id"],),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["text_hash"] != old_hash
+
+
+def test_generate_embeddings_deduplicates_decisions(ec_db):
+    """Pre-existing duplicate embeddings are cleaned up to exactly one row."""
+    conn = ec_db
+    d = create_decision(conn, title="Dedup target")
+
+    import hashlib
+
+    text = "Dedup target"
+    text_hash = hashlib.md5(text.encode()).hexdigest()
+    for _ in range(3):
+        conn.execute(
+            "INSERT INTO embeddings (id, source_type, source_id, model_name, vector, dimensions, text_hash) "
+            "VALUES (?, 'decision', ?, 'all-MiniLM-L6-v2', ?, 384, ?)",
+            (str(uuid4()), d["id"], b"\x00" * 1536, text_hash),
+        )
+
+    dupes = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM embeddings WHERE source_type = 'decision' AND source_id = ?",
+        (d["id"],),
+    ).fetchone()["cnt"]
+    assert dupes == 3
+
+    mock_model = _make_mock_model()
+    with _patch_sentence_transformers(mock_model):
+        generate_embeddings(conn, "/tmp/test-repo")
+
+    rows = conn.execute(
+        "SELECT * FROM embeddings WHERE source_type = 'decision' AND source_id = ?",
+        (d["id"],),
+    ).fetchall()
+    assert len(rows) == 1

--- a/tests/test_signal_b.py
+++ b/tests/test_signal_b.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 
 from entirecontext.core.decision_prompt_surfacing import (
@@ -13,7 +14,7 @@ from entirecontext.core.decisions import create_decision
 from entirecontext.core.config import DEFAULT_CONFIG
 
 
-def _commit_file(repo, name: str, content: str = "x") -> None:
+def _commit_file(repo: Path, name: str, content: str = "x") -> None:
     """Create, add, and commit a file in *repo*."""
     path = repo / name
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_signal_b.py
+++ b/tests/test_signal_b.py
@@ -1,0 +1,121 @@
+"""Tests for Signal B: working-file inference from recent commits."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+from entirecontext.core.decision_prompt_surfacing import (
+    _get_recent_commit_file_paths,
+    rank_decisions_for_prompt,
+)
+from entirecontext.core.decisions import create_decision
+from entirecontext.core.config import DEFAULT_CONFIG
+
+
+def _commit_file(repo, name: str, content: str = "x") -> None:
+    """Create, add, and commit a file in *repo*."""
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    subprocess.run(["git", "-C", str(repo), "add", name], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", f"add {name}"],
+        check=True,
+        capture_output=True,
+    )
+
+
+class TestGetRecentCommitFilePaths:
+    def test_returns_files(self, git_repo) -> None:
+        _commit_file(git_repo, "hello.py")
+        paths = _get_recent_commit_file_paths(str(git_repo))
+        assert "hello.py" in paths
+
+    def test_deduplicates(self, git_repo) -> None:
+        _commit_file(git_repo, "dup.py", "v1")
+        (git_repo / "dup.py").write_text("v2")
+        subprocess.run(["git", "-C", str(git_repo), "add", "dup.py"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(git_repo), "commit", "-m", "update dup.py"],
+            check=True,
+            capture_output=True,
+        )
+        paths = _get_recent_commit_file_paths(str(git_repo))
+        assert paths.count("dup.py") == 1
+
+    def test_empty_repo(self, git_repo) -> None:
+        # git_repo already has one --allow-empty commit; no files touched
+        paths = _get_recent_commit_file_paths(str(git_repo))
+        assert paths == []
+
+    def test_respects_limit(self, git_repo) -> None:
+        for i in range(10):
+            _commit_file(git_repo, f"file_{i}.py", str(i))
+        paths = _get_recent_commit_file_paths(str(git_repo), limit=3)
+        # limit=3 means only the 3 most recent commits are inspected
+        assert len(paths) <= 3
+        # The 3 most recent files should be 9, 8, 7
+        for i in (9, 8, 7):
+            assert f"file_{i}.py" in paths
+
+    def test_handles_timeout(self, monkeypatch) -> None:
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
+
+        monkeypatch.setattr(
+            "entirecontext.core.decision_prompt_surfacing.subprocess.run",
+            _raise_timeout,
+        )
+        paths = _get_recent_commit_file_paths("/nonexistent")
+        assert paths == []
+
+
+class TestRankIncludesSignalB:
+    def test_rank_includes_signal_b(self, ec_repo, ec_db) -> None:
+        """Integration: decision linked to a committed file is surfaced via Signal B.
+
+        Signal A (uncommitted changes) is empty — all changes are committed.
+        The prompt text shares no tokens with the decision title/rationale
+        to avoid diff-FTS matching. We discriminate by checking the score
+        carries the file_exact weight (>= 3.0) rather than just presence,
+        since padding fills in decisions at score 0.0.
+        """
+        # Create a decision with a deliberately opaque title/rationale
+        decision = create_decision(ec_db, title="zxqwkj-policy", rationale="vbnmlk-rationale")
+        decision_id = decision["id"]
+
+        # Create and commit a real file
+        target_file = "alpha/bravo.py"
+        _commit_file(ec_repo, target_file, "content = True\n")
+
+        # Link the decision to that file path
+        ec_db.execute(
+            "INSERT INTO decision_files (decision_id, file_path) VALUES (?, ?)",
+            (decision_id, target_file),
+        )
+        ec_db.commit()
+
+        # Verify no uncommitted changes (Signal A returns nothing)
+        result = subprocess.run(
+            ["git", "diff", "HEAD", "--name-only"],
+            cwd=str(ec_repo),
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == "", "Expected no uncommitted changes"
+
+        # Use a prompt that shares no tokens with decision title/rationale
+        config = dict(DEFAULT_CONFIG)
+        surfaced, warnings = rank_decisions_for_prompt(
+            ec_db,
+            repo_path=str(ec_repo),
+            prompt_text="completely unrelated prompt 98765",
+            config=config,
+        )
+
+        matched = [d for d in surfaced if d["id"] == decision_id]
+        assert matched, f"Decision {decision_id[:12]} not found in surfaced results"
+        # file_exact weight is 3.0, staleness_factor for 'fresh' is 1.0
+        # Score should carry at least the file_exact signal
+        assert matched[0]["score"] >= 3.0, f"Expected score >= 3.0 from file_exact match, got {matched[0]['score']}"


### PR DESCRIPTION
## Summary

- **Signal B**: `_get_recent_commit_file_paths()` extracts file paths from recent commits; merged into `rank_decisions_for_prompt()` alongside Signal A so decisions surface even when the working tree is clean
- **Signal C foundation**: `_build_decision_embed_text()`, `semantic_search_decisions()`, decision embedding in `generate_embeddings()` with stale/dedup handling. Auto-embed on `create_decision()`/`confirm_candidate()` gated by `[decisions] auto_embed` (default false). Full 2-pass async deferred to v0.9.0
- **AAR**: SessionEnd emits structured JSON summary (`.entirecontext/aar-{session_id}.json`) — decisions surfaced, PDI delta, assessments created. Config: `[capture] emit_aar` (default true)
- **Docs**: ROADMAP and CHANGELOG updated for v0.8.0

Builds on PR #157 (auto-assess automation, already merged).

## Test plan

- [x] 1679 passed, 93 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` clean
- [x] New tests: `test_signal_b.py` (6), `test_decision_embedding.py` (13), `test_aar.py` (9)
- [x] Embedding stale/dedup regression tests cover GROUP BY guard, DELETE-before-INSERT, inner-tx fetchall

🤖 Generated with [Claude Code](https://claude.com/claude-code)