### PR TITLE
chore: trim docs to non-obvious content, fix Tidy Pilot prompt guardrails

### DIFF
--- a/.github/tidy-pilot/assess_pr.py
+++ b/.github/tidy-pilot/assess_pr.py
@@ -172,7 +172,7 @@ def merge_results(results: list[dict]) -> dict:
         "verdict": dominant.get("verdict", "neutral"),
         "impact_summary": " | ".join(impact_parts[:2]),
         "roadmap_alignment": dominant.get("roadmap_alignment", "N/A"),
-        "tidy_suggestion": suggestions[0] if suggestions else "N/A",
+        "tidy_suggestion": suggestions[0] if suggestions else "No tidy warranted",
     }
 
 

--- a/.github/tidy-pilot/assess_pr.py
+++ b/.github/tidy-pilot/assess_pr.py
@@ -22,12 +22,20 @@ Respond with a JSON object (no markdown fences) with these fields:
 - verdict: "expand" | "narrow" | "neutral"
 - impact_summary: one-sentence summary of the change's impact on future options
 - roadmap_alignment: how this change aligns with the roadmap
-- tidy_suggestion: actionable suggestion grounded in specific project files, structures, or patterns observed in the diff. Do not suggest actions referencing structures that are not present in the project context."""
+- tidy_suggestion: actionable suggestion grounded in specific project files, structures, or patterns observed in the diff, OR "No tidy warranted" when the change is already clean
+
+Suggestion guardrails:
+- "No tidy warranted" is a valid and expected suggestion when no actionable improvement exists
+- Do not suggest refactors for incidental code patterns (e.g., repeated parameter passing) unless the repetition creates a concrete maintenance or correctness risk
+- Do not suggest cleanup or refactoring outside the PR's stated scope
+- Do not submit suggestions based on pattern-matching alone without tracing the actual code flow
+- Do not suggest actions referencing structures that are not present in the project context
+- If the project provides review principles (e.g., in CLAUDE.md), respect their severity and scope rules"""
 
 COMMENT_MARKER = "<!-- tidy-pilot:sticky-comment -->"
 
 # Character budgets — chosen to stay under typical API payload limits.
-MAX_CONTEXT_CHARS = 4_000  # per context section (roadmap, lessons, claude_md)
+MAX_CONTEXT_CHARS = 8_000  # per context section (roadmap, lessons, claude_md)
 MAX_CHUNK_DIFF_CHARS = 8_000  # per diff chunk sent to LLM
 MAX_CHUNKS = 5  # cap on total API calls; excess diff is marked omitted
 FILE_TRUNCATION_MARKER = "\n... (file diff truncated)\n"

--- a/.github/tidy-pilot/assess_pr.py
+++ b/.github/tidy-pilot/assess_pr.py
@@ -163,7 +163,11 @@ def merge_results(results: list[dict]) -> dict:
     priority = {"narrow": 2, "neutral": 1, "expand": 0}
     dominant = max(results, key=lambda r: priority.get(r.get("verdict", "neutral"), 1))
     impact_parts = [r["impact_summary"] for r in results if r.get("impact_summary")]
-    suggestions = [r["tidy_suggestion"] for r in results if r.get("tidy_suggestion")]
+    suggestions = [
+        r["tidy_suggestion"]
+        for r in results
+        if r.get("tidy_suggestion") and r["tidy_suggestion"] != "No tidy warranted"
+    ]
     return {
         "verdict": dominant.get("verdict", "neutral"),
         "impact_summary": " | ".join(impact_parts[:2]),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,162 +1,53 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- Source code lives in `src/entirecontext/`, organized by layer:
-  - `cli/` (Typer commands), `core/` (business logic), `db/` (schema/migrations), `hooks/` (Claude hook handlers), `sync/` (shadow-branch export/import), `mcp/` (MCP server).
-- Tests are in `tests/`, with both unit and end-to-end coverage (for example `tests/test_core.py`, `tests/test_e2e_search.py`).
-- Documentation and research notes are in `docs/` and `docs/research/`.
-- Build artifacts are output to `dist/`.
+CLAUDE.md and AGENTS.md are independently maintained. CLAUDE.md carries compact project reference and review principles; AGENTS.md carries workflow policies.
 
-## Build, Test, and Development Commands
-- `uv sync` : Install runtime dependencies.
-- `uv sync --extra dev` : Install developer tools (`pytest`, `pytest-cov`, `ruff`).
-- `uv run ec --help` : Verify CLI entrypoint and available commands.
-- **MCP ops**: After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
-- `uv run pytest` : Run full test suite.
-- `uv run pytest --cov=entirecontext` : Run tests with coverage.
-- `uv run ruff format .` : Format code (line length 120).
-- `uv run ruff check . --fix` : Lint and auto-fix issues.
-- `uv build` : Build distributable packages.
+After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
 
-## Coding Style & Naming Conventions
-- Python 3.12+ only (`requires-python >=3.12`).
-- Use Ruff for formatting/linting; keep line length at 120.
-- Follow existing naming patterns: snake_case for modules/functions, PascalCase for classes, descriptive command modules like `search_cmds.py`.
-- Keep CLI concerns in `cli/` and domain logic in `core/`; avoid cross-layer shortcuts.
+## Test
 
-## Testing Guidelines
-- Framework: `pytest` with shared fixtures in `tests/conftest.py`.
-- Name tests as `test_*.py` and functions as `test_<behavior>`.
-- Add/adjust tests for every behavior change, including edge and regression paths.
-- Prefer real business logic execution; mock only external integrations when necessary.
+Tests use real git repos via fixtures (`git_repo`, `ec_repo`, `ec_db`, `isolated_global_db`). External deps are isolated with `monkeypatch`. See `tests/conftest.py`.
+
+When modifying a source module, always run the existing tests for that module before committing — not just newly written tests. Test verification scope must match the change scope.
 
 ## Commit & Pull Request Guidelines
-- Commit style in history follows Conventional Commit-like prefixes: `feat(...)`, `fix(...)`, `refactor(...)`, `docs(...)`.
-- Keep each commit focused on one change area and include scope when useful (example: `feat(search): add hybrid reranking`).
+- Conventional Commit prefixes: `feat(...)`, `fix(...)`, `refactor(...)`, `docs(...)`.
+- Keep each commit focused on one change area with scope (example: `feat(search): add hybrid reranking`).
 - PRs should include: purpose, key changes, test evidence (commands + results), and linked issue/task.
 - Include CLI output snippets or screenshots when user-facing command behavior changes.
 
-## Security & Configuration Tips
-- Never commit secrets; use environment variables (for example `OPENAI_API_KEY`, `GITHUB_TOKEN`).
-- Repo/local settings live under `.entirecontext/`; validate setup with `ec doctor` after config changes.
+## Dogfooding Workflow
 
----
+This project's own features should be actively used during development sessions.
 
-## Dogfooding: Using EntireContext During Development
+### When to use what
 
-This project's own features should be actively used during development sessions. Below are patterns for leveraging EntireContext's CLI and MCP tools as part of the development workflow.
-
-### MCP Tools for In-Session Context
-
-The EntireContext MCP server is registered in Claude Code and provides these tools during active sessions:
-
-| MCP Tool | When to Use | Example |
-|---|---|---|
-| `ec_search` | Finding past implementations, debugging history | Search "how was filtering implemented" before adding new filters |
-| `ec_session_context` | Understanding current session state | Check captured turns before session end |
-| `ec_related` | Finding related code/discussions | Find turns that touched `exporter.py` |
-| `ec_checkpoint_list` | Tracking progress snapshots | List checkpoints for current session |
-| `ec_turn_content` | Reviewing full turn details | Get complete content of a specific turn |
-| `ec_attribution` | Understanding code ownership | Check who wrote specific lines |
-| `ec_rewind` | Time-travel to past states | View code at a specific checkpoint |
-| `ec_assess` / `ec_assess_create` | Evaluating changes against roadmap | Assess current diff before committing |
-| `ec_assess_trends` | Cross-session trend analysis | Review verdict distribution over time |
-| `ec_lessons` | Retrieving distilled guidance from past assessed changes | Scan lessons before work in areas with prior narrow verdicts |
-| `ec_feedback` | Providing assessment feedback for lesson accumulation | Record agree/disagree with reason after assessed work completes |
-
-### CLI Commands for Development Workflow
-
-#### Before Starting Work
-```bash
-ec status                        # Check current session/project state
-ec doctor                        # Validate hooks and config
-ec search "topic" --fts          # Find past work on similar topics
-ec session list --limit 5        # Review recent sessions
-```
-
-#### During Development
-```bash
-ec checkpoint create             # Snapshot progress at meaningful points
-ec blame src/path/file.py        # Check attribution for code being modified
-ec ast-search "function_name"    # Find symbol definitions across codebase
-```
-
-#### After Implementation
-```bash
-ec dashboard                     # Review session stats and trends
-ec futures assess                # Assess changes against roadmap
-ec session export                # Export session as markdown doc
-ec sync                          # Push to shadow branch
-```
-
-#### Debugging & Investigation
-```bash
-ec search "error pattern" --fts  # Find past encounters of similar errors
-ec rewind <checkpoint_id>        # View code at a past checkpoint
-ec graph --session <id>          # Visualize multi-agent session graph
-ec session activate <query>      # Find related turns via spreading activation
-```
-
-### Configuration for Active Dogfooding
-
-Enable these config keys in `.entirecontext/config.toml` for full dogfooding:
-
-```toml
-[capture]
-auto_capture = true
-checkpoint_on_commit = true
-checkpoint_on_session_end = true
-intent_summary = true            # LLM-based session intent summarization
-
-[sync]
-auto_sync_on_push = true         # Auto-sync on git push via pre-push hook
-
-[index]
-auto_embed = true                # Auto-generate embeddings on session end
-
-[futures]
-auto_distill = true              # Auto-distill lessons from assessments
-```
-
-### Development Patterns
-
-#### Pattern: Context-Aware Implementation
-Before implementing a feature, search for related past work:
-1. Use `ec_search` or `ec search --fts` to find relevant past turns
-2. Use `ec_related` with file paths being modified
-3. Review `ec_lessons` for applicable learnings, especially when touching areas with prior narrow verdicts, debugging regressions, revisiting subsystems with existing feedback, or making structurally similar changes to previously assessed work
-4. Create checkpoints at meaningful milestones
-
-#### Pattern: Assessment-Driven Development
-After completing a feature:
-1. Run `ec futures assess` to evaluate against roadmap
-2. If assessment feedback exists, review with `ec futures feedback`
-3. Check `ec_assess_trends` for pattern of verdicts over time
-
-#### Pattern: Multi-Session Continuity
-When resuming work across sessions:
-1. `ec session list` to find the previous session
-2. `ec session show <id>` to review what was done
-3. `ec_session_context` to get the last session's summary
-4. `ec search "specific topic"` to find exact implementation details
+| Phase | Action |
+|---|---|
+| Before work | `ec search` / `ec_search` — find past work on the topic |
+| Before work | `ec_lessons` — scan lessons for applicable guidance |
+| During work | `ec checkpoint create` — snapshot progress at meaningful milestones |
+| After work | `ec futures assess` / `ec_assess_create` — evaluate changes against roadmap |
+| After work | `ec_feedback` — record agree/disagree on prior assessments |
+| Debugging | `ec_related` with file paths — find turns that touched the area |
+| Cross-session | `ec_session_context` — get the previous session's summary |
 
 ## Decision and Lesson Reuse Policy
 
-This repository is building decision and lesson memory for coding agents. Agents working in this repository must use stored decisions and lessons as part of the development workflow instead of treating them as optional background context.
+Agents working in this repository must use stored decisions and lessons as part of the development workflow, not optional background context.
 
-### When to check decisions and lessons
-Check for relevant prior decisions and lessons before non-trivial analysis or implementation when the task:
+### When to check
+Before non-trivial analysis or implementation when the task:
 - changes behavior, policy, schema, or interfaces
 - touches retrieval, ranking, sync, session lifecycle, hooks, dashboard, assessments, telemetry, or decision memory
 - implements or reinterprets a roadmap item
 - revisits an area with repeated bugs, repeated refactors, or prior design discussion
-- asks why something was implemented a certain way
-- involves debugging a regression, repeated failure, or issue structurally similar to a previously assessed change
+- involves debugging a regression or issue structurally similar to a previously assessed change
 
 ### Required workflow
 1. Retrieve relevant decisions before implementation.
 2. Read the selected decisions before proposing or applying changes.
-3. Scan lessons for applicable guidance from past assessed changes, especially when the task involves debugging, regressions, repeated subsystem work, or areas with prior narrow verdicts.
+3. Scan lessons for applicable guidance, especially when debugging regressions or working in areas with prior narrow verdicts.
 4. Prefer fresh decisions by default.
 5. Do not silently apply stale, contradicted, or superseded decisions.
 6. If decisions conflict, surface the conflict explicitly.
@@ -164,82 +55,87 @@ Check for relevant prior decisions and lessons before non-trivial analysis or im
 8. If a decision materially informed the work, record that usage.
 9. After the work completes, record whether the result confirmed, contradicted, refined, or replaced the decision.
 10. If the work creates a stable new policy or architectural judgment, create or update a decision record.
-11. If the completed work was previously assessed, provide agree/disagree feedback with a reason so lessons can accumulate.
+11. If assessed work completed, provide agree/disagree feedback with a reason so lessons accumulate.
 
-### Repository-specific retrieval path
-Prefer the strongest decision-aware path available in the current environment:
-- MCP: `ec_decision_related`, `ec_decision_get`, `ec_decision_list`
-- CLI fallback: `ec decision list`, `ec decision show`, plus targeted `ec search` if needed
-
-### Lesson retrieval path
-Scan lessons before non-trivial work, especially when debugging regressions, working in areas with prior narrow verdicts, making structurally similar changes to previously assessed work, or revisiting a subsystem with existing assessment feedback.
-- MCP: `ec_lessons`
-- CLI fallback: `ec futures lessons`
-
-Lesson retrieval is a quick scan, not a targeted lookup. Review recent lessons for relevance and proceed if none apply.
-
-When providing assessment feedback after assessed work completes:
-- MCP: `ec_feedback(assessment_id, feedback, reason)`
-- CLI fallback: `ec futures feedback ASSESSMENT_ID FEEDBACK --reason REASON`
+### Retrieval paths
+- MCP: `ec_decision_related`, `ec_decision_get`, `ec_decision_list`, `ec_lessons`, `ec_feedback`
+- CLI fallback: `ec decision list`, `ec decision show`, `ec futures lessons`, `ec futures feedback`
+- Context application: `ec_context_apply(...)` / `ec context ...`
+- Decision outcome: `ec_decision_outcome(...)` / corresponding CLI command
 
 ### MCP Call Discipline
-When using EntireContext MCP tools, treat the tool schema as strict and do not infer argument shapes from natural-language descriptions alone.
-
-- Verify parameter types before the first call when the shape is not obvious.
+- Treat tool schema as strict; do not infer argument shapes from descriptions alone.
 - For repo filters, prefer `repos` as a list even when targeting a single repo.
-- Prefer `search_type="hybrid"` for natural-language or punctuation-heavy queries before falling back to FTS-specific forms.
-- If a schema validation or parser error occurs, stop and correct the argument shape or query form before retrying.
-- Do not repeat the same malformed MCP call pattern after a validation failure.
-
-When prior guidance materially affects the task, also record usage through the available context-application path:
-- MCP: `ec_context_apply(...)`
-- CLI fallback: use the corresponding `ec context ...` commands if available in the current installed version
-
-When the task outcome validates or invalidates a decision, record a decision outcome through the available interface:
-- MCP: `ec_decision_outcome(...)`
-- CLI fallback: use the corresponding decision outcome command if available in the current installed version
+- Prefer `search_type="hybrid"` for natural-language queries before falling back to FTS.
+- On schema/parser errors, stop and correct argument shape before retrying.
 
 ### Minimum behavior
-For non-trivial tasks, do not move directly from request to implementation without a decision and lesson check unless the user explicitly asks to skip it.
-
-If the agent skips the decision and lesson check, it must state that it skipped it and why.
+For non-trivial tasks, do not skip decision and lesson check unless the user explicitly asks. State when skipped and why.
 
 ### Final reporting
-When decisions or lessons were relevant, the final response must include:
-- which decisions were considered
-- which decision was applied, if any
-- which decisions were rejected or treated as stale, if any
-- whether the completed work confirmed, contradicted, superseded, or extended prior guidance
-- which lessons were reviewed, if any, and whether any influenced the approach
-- which assessments received feedback during this task, if any
+When decisions or lessons were relevant, include:
+- which decisions were considered, applied, rejected, or treated as stale
+- whether completed work confirmed, contradicted, superseded, or extended prior guidance
+- which lessons were reviewed and whether any influenced the approach
+- which assessments received feedback during this task
 
 ### Interpretation rule
-Stored decisions are inputs to judgment, not blind rules. Follow relevant fresh decisions by default, but still verify fit against the current code, current task, and current user intent.
+Stored decisions are inputs to judgment, not blind rules. Verify fit against current code, task, and user intent.
 
-#### Pattern: Hook-Driven Automation
-The hook system captures development activity automatically:
+## Hook-Driven Automation
 - **SessionStart** → creates/resumes session tracking
-- **UserPromptSubmit** → captures each user prompt as a turn; **also injects top-k relevant decisions into `additionalContext`** (Proactive Decision Injection, v0.7.0+)
+- **UserPromptSubmit** → captures turn; **injects top-k relevant decisions** (Proactive Decision Injection, v0.7.0+)
 - **PostToolUse** → tracks tools and files touched
 - **Stop** → captures assistant response summary
 - **SessionEnd** → generates summaries, triggers auto-sync/embed/distill
 - **PostCommit** (git hook) → creates checkpoint on each commit
 - **pre-push** (git hook) → triggers `ec sync --if-enabled`
 
-#### Proactive Memory Reuse (v0.7.0+)
+### Proactive Memory Reuse (v0.7.0+)
 
-Starting with v0.7.0, the `UserPromptSubmit` hook is the **default delivery channel** for relevant decisions. On every user prompt, EntireContext synchronously ranks top-k decisions and injects them as `additionalContext` so Claude Code receives decision guidance before generating each response.
-
-**What this means for agents working in this repo**: relevant decisions now appear automatically as `<system-reminder>` context tagged "UserPromptSubmit hook additional context:". You do not need to call `ec_decision_related` or `ec search` for routine decision lookup — the hook pre-populates relevant decisions. Use explicit MCP/CLI retrieval only when:
-- you need decisions beyond the injected top-k (more breadth)
+The `UserPromptSubmit` hook is the default delivery channel for relevant decisions. Relevant decisions appear automatically as `<system-reminder>` context tagged "UserPromptSubmit hook additional context:". Use explicit MCP/CLI retrieval only when:
+- you need decisions beyond the injected top-k
 - you need to filter by staleness, file, or outcome
 - PDI was skipped (no session, capture disabled, or timeout exceeded)
 - you want to record usage or outcomes
 
-### Adding New CLI Commands
-When adding a new CLI command:
+## Adding New CLI Commands
 1. Create `cli/<name>_cmds.py` with `@app.command()` decorators
 2. Import and register in `cli/__init__.py`
 3. Keep business logic in `core/` — CLI layer handles args/output only
 4. Add corresponding MCP tool in `mcp/server.py` if the feature is useful for in-session queries
 5. Update `CLAUDE.md` architecture section if new module is added
+
+## Code Review Principles
+
+Principles for automated code review (CI and agent review alike). These guide the reviewer, not the code author.
+
+### Grounding
+- Every finding must cite specific code location (file:line)
+- Do not present inferences as facts; label hypotheses clearly
+- Ground claims in repository context or tool outputs, not assumptions
+
+### Confidence Threshold
+- Only submit a finding if you can point to a specific code path that causes the issue
+- Do not submit findings based on pattern-matching alone without tracing the actual call or data flow
+- If confidence is low, omit the finding rather than labeling it a "suggestion"
+
+### Severity
+- Categorize findings: Critical (must fix) / Important (should fix) / Suggestion
+- Critical: correctness bugs, data loss, security vulnerabilities
+- Important: missing error handling, contract mismatches between docs and code, edge cases
+- Suggestion: readability, naming, minor optimization
+
+### Depth
+- After first plausible issue, check second-order failures: empty-state handling, retries, stale state, rollback paths
+- Verify contract consistency: if CLAUDE.md, docstrings, or specs state X, code must match
+
+### False Positive Avoidance
+- Do not flag pre-existing issues unrelated to the change
+- Do not flag issues ruff, pytest, or other configured CI steps already enforce
+- Do not flag intentional behavior changes that align with the PR's stated purpose
+- Do not flag style preferences not codified in this file or ruff config
+
+### Scope
+- Review only the changed code and its immediate blast radius
+- Do not suggest unrelated refactors or cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,38 +2,13 @@
 
 Time-travel searchable agent memory anchored to git state. Python 3.12+, uv, SQLite (WAL mode), Typer CLI (`ec`).
 
-## Build & Run
-
-```bash
-uv sync                          # install deps
-uv sync --extra dev              # + dev tools (pytest, ruff)
-uv sync --extra semantic         # + sentence-transformers
-uv sync --extra mcp              # + MCP server support
-uv run ec --help                 # CLI entry point
-```
-
-> **MCP ops**: After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
-
+After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
 
 ## Test
-
-```bash
-uv run pytest                    # all tests
-uv run pytest tests/test_core.py # single file
-uv run pytest -k "test_search"   # by name pattern
-uv run pytest --cov=entirecontext # coverage
-```
 
 Tests use real git repos via fixtures (`git_repo`, `ec_repo`, `ec_db`, `isolated_global_db`). External deps are isolated with `monkeypatch`. See `tests/conftest.py`.
 
 When modifying a source module, always run the existing tests for that module before committing — not just newly written tests. Test verification scope must match the change scope.
-
-## Lint & Format
-
-```bash
-uv run ruff format .             # format (line-length 120)
-uv run ruff check . --fix        # lint + autofix
-```
 
 ## Architecture
 
@@ -87,12 +62,6 @@ Return codes: 0=success, 2=block.
 TOML deep merge: defaults ← `~/.entirecontext/config.toml` (global) ← `.entirecontext/config.toml` (per-repo)
 
 Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `security`, `filtering.query_redaction`, `index`, `futures`, `decisions`, `decisions.ranking`, `decisions.quality`, `decisions.extraction`, `decisions.injection`
-
-## Code Conventions
-
-- ruff formatter, line-length 120, target Python 3.12
-- Type hints throughout (`from __future__ import annotations`)
-- SQLite pragmas: WAL, foreign_keys=ON, busy_timeout=5000
 
 ## Code Review Principles
 


### PR DESCRIPTION
## Summary

- **Tidy Pilot truncation 근본 해결**: `MAX_CONTEXT_CHARS` 4000→8000. CLAUDE.md (5248 bytes) 의 Code Review Principles (byte 3634~) 가 잘려서 False Positive Avoidance, Scope 규칙이 LLM에 전달되지 않았음 — PR #158 의 false-positive `repo_path` 리팩터링 제안의 근본 원인
- **SYSTEM_PROMPT 가드레일 추가**: `tidy_suggestion`에 "No tidy warranted" 허용, PR scope 밖 리팩터링 제안 금지, pattern-matching만으로 제안 금지
- **CLAUDE.md/AGENTS.md 기술부채 정리**: 표준 빌드/린트 명령어, MCP tool table (`--help` 중복), CLI 예시, config 예시 등 obvious한 내용 삭제. Architecture, Data Model, Code Review Principles, Decision Reuse Policy 등 non-obvious 정책은 보존

## Changes

| File | Before | After | Delta |
|------|--------|-------|-------|
| `CLAUDE.md` | 5248 bytes | 4388 bytes | -16% |
| `AGENTS.md` | 13985 bytes | 7725 bytes | -45% |
| `assess_pr.py` | SYSTEM_PROMPT + cap | guardrails added, cap raised | — |

## Trim criteria

"Obvious" (삭제) vs "Non-obvious" (보존):
- **Obvious**: `uv sync`, `ruff format`, `uv run pytest` — uv/pytest/ruff 프로젝트라면 누구나 아는 것
- **Non-obvious**: Architecture tree (15+ 모듈 관계), Data Model (schema v14, 20+ 테이블), Code Review Principles (자동 리뷰어 정책), Decision Reuse Policy (프로젝트 핵심 워크플로)

## Test plan

- [x] Tidy Pilot 관련 테스트 30개 전체 통과 (`uv run pytest tests/ -k tidy`)
- [x] Code Review Principles: CLAUDE.md byte 2774 시작 → 8000자 cap 이내 전문 전달 확인
- [ ] 다음 PR에서 Tidy Pilot이 "No tidy warranted" 응답을 생성할 수 있는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)