### PR TITLE
feat: v0.8.1 Measurement Accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - Measurement Accuracy
+
+### Fixed
+
+- **Codex session auto-close** — `close_stale_sessions()` sets `ended_at = last_activity_at` for codex sessions idle > 60min. Called automatically during codex notify ingestion. Uses optimistic concurrency to avoid clobbering resumed sessions.
+- **`retrieval_assisted_session_rate` normalization** — both numerator and denominator now filter on `ended_at IS NOT NULL`, consistent with `checkpoint_coverage_rate`. Previously, 383 codex sessions with `ended_at=NULL` inflated the denominator, and retrieval events in active sessions could inflate the numerator.
+
+### Added
+
+- `ec checkpoint assess-accuracy` — verdict accuracy baseline from LLM enrichment feedback (agree/disagree rate per verdict).
+- `close_stale_sessions()` in `core/session.py` — reusable auto-close with optimistic concurrency guard.
+- Config: `[capture] codex_session_idle_minutes` (default 60).
+
 ## [0.8.0] - 2026-06-07
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,15 +208,15 @@ The `capture→distill→retrieve→intervene` loop has stalled at `distill=0` f
 - [x] **Signal B: working-file inference** — `_get_recent_commit_file_paths()` extracts file paths from recent commits via `git log --name-only`; merged into `rank_decisions_for_prompt()` alongside Signal A (uncommitted diff) paths. Decisions linked to recently-committed files now surface even when the working tree is clean.
 - [~] **Signal C: semantic similarity** — v0.8.0 ships the foundation: `_build_decision_embed_text()`, `semantic_search_decisions()`, and decision embedding in `generate_embeddings()` (source_type='decision'). Auto-embed on `create_decision()` gated by `[decisions] auto_embed` (default false, requires `entirecontext[semantic]`). Full 2-pass async architecture (background ranking feeding next prompt's PDI, SessionStart pre-warm) deferred to v0.9.0.
 
-## v0.8.1 — Measurement Accuracy
+## v0.8.1 — Measurement Accuracy (Shipped 2026-06-07)
 
 Theme: fix measurement infrastructure so maturity scores reflect reality. No new features — only corrections that enable trustworthy attribution for subsequent feature releases.
 
-Follows the v0.8.0 retro lesson: "측정 인프라가 측정 대상보다 먼저 정확해야 한다." Codex session lifecycle and maturity calculation must be accurate before adding intervene automation whose effect needs to be measured against a clean baseline.
+Follows the v0.8.0 retro lesson: "측정 인프라가 측정 대상보다 먼저 정확해야 한다."
 
-- [ ] **Codex session auto-close** — `codex_ingest.py` creates sessions (`session_type='codex'`) but has no termination logic; 374 sessions stuck at `ended_at IS NULL`. Add heuristic: last activity + N minutes → auto-set `ended_at`. Related: ec decision `f44d2fdb` (auto-cleanup sessions with no code changes).
-- [ ] **Maturity calculation normalization** — `checkpoint_coverage_rate` (capture dimension) filters on `ended_at IS NOT NULL`, excluding all codex sessions from the denominator. `retrieval_assisted_session_rate` uses `sessions_total` without `ended_at` filter, so codex sessions are already in the denominator but inflate it without contributing ended-session semantics. Both metrics normalize once codex sessions have correct `ended_at`.
-- [ ] **Verdict accuracy baseline** — measure rule-based assessment verdict accuracy before tuning. Establish false-positive rate for `expand`/`narrow`/`neutral` mapping from conventional commit parsing (e.g., dependency bump → `expand` is a known false positive).
+- [x] **Codex session auto-close** — `close_stale_sessions()` sets `ended_at = last_activity_at` for codex sessions idle > N minutes (default 60, config: `[capture] codex_session_idle_minutes`). Called automatically during codex notify ingestion with optimistic concurrency guard.
+- [x] **Maturity calculation normalization** — `retrieval_assisted_session_rate` numerator and denominator both filter on `ended_at IS NOT NULL`, consistent with `checkpoint_coverage_rate`. Previously, 383 codex sessions with `ended_at=NULL` inflated the denominator without contributing ended-session semantics, and retrieval events in active sessions could inflate the numerator.
+- [x] **Verdict accuracy baseline** — `ec checkpoint assess-accuracy` reports agree/disagree rate from LLM enrichment feedback. Current data: 10 enriched (all agree), 8 rule-based pending. v0.9.0 verdict tuning should gate on n≥30.
 
 ## v0.9.0 — Intervene Automation
 

--- a/src/entirecontext/cli/checkpoint_cmds.py
+++ b/src/entirecontext/cli/checkpoint_cmds.py
@@ -324,5 +324,48 @@ def checkpoint_diff(
         console.print("\n[dim]No differences in files_snapshot.[/dim]")
 
 
+@checkpoint_app.command("assess-accuracy")
+def assess_accuracy():
+    """Show verdict accuracy baseline from enrichment feedback."""
+    from ..core.auto_assess import compute_verdict_accuracy
+    from ..core.project import find_git_root, get_project
+    from ..db import get_db
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    project = get_project(repo_path)
+    if not project:
+        console.print("[yellow]Not initialized. Run 'ec init'.[/yellow]")
+        raise typer.Exit(1)
+
+    conn = get_db(repo_path)
+    try:
+        result = compute_verdict_accuracy(conn)
+    finally:
+        conn.close()
+
+    console.print("\n[bold]Verdict Accuracy Baseline[/bold]")
+    console.print(f"  Rule-based assessments (pending enrichment): {result['total_rule_based']}")
+    console.print(f"  Enriched assessments (with feedback): {result['total_enriched']}")
+
+    if result["agreement_rate"] is not None:
+        rate_pct = result["agreement_rate"] * 100
+        console.print(f"  Agreement rate: {rate_pct:.1f}%")
+    else:
+        console.print("  Agreement rate: [dim]no data[/dim]")
+
+    if result["per_verdict"]:
+        table = Table(title="Per-Verdict Breakdown")
+        table.add_column("Verdict")
+        table.add_column("Agree", justify="right")
+        table.add_column("Disagree", justify="right")
+        for verdict, counts in sorted(result["per_verdict"].items()):
+            table.add_row(verdict, str(counts["agree"]), str(counts["disagree"]))
+        console.print(table)
+
+
 def register(app: typer.Typer) -> None:
     app.add_typer(checkpoint_app, name="checkpoint")

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -205,3 +205,44 @@ def apply_git_evidence_feedback(
         return count
     except Exception:
         return 0
+
+
+def compute_verdict_accuracy(conn: sqlite3.Connection) -> dict:
+    rule_count = conn.execute(
+        "SELECT COUNT(*) FROM assessments WHERE model_name = 'rule-based'"
+    ).fetchone()[0]
+
+    enriched_rows = conn.execute(
+        "SELECT verdict, feedback FROM assessments"
+        " WHERE model_name IS NOT NULL AND model_name != 'rule-based'"
+        " AND feedback IS NOT NULL"
+    ).fetchall()
+
+    if not enriched_rows:
+        return {
+            "total_rule_based": rule_count,
+            "total_enriched": 0,
+            "agreement_rate": None,
+            "per_verdict": {},
+        }
+
+    per_verdict: dict[str, dict[str, int]] = {}
+    agree_count = 0
+    for row in enriched_rows:
+        verdict = row["verdict"]
+        feedback = row["feedback"]
+        if verdict not in per_verdict:
+            per_verdict[verdict] = {"agree": 0, "disagree": 0}
+        if feedback == "agree":
+            per_verdict[verdict]["agree"] += 1
+            agree_count += 1
+        elif feedback == "disagree":
+            per_verdict[verdict]["disagree"] += 1
+
+    total = len(enriched_rows)
+    return {
+        "total_rule_based": rule_count,
+        "total_enriched": total,
+        "agreement_rate": agree_count / total if total > 0 else None,
+        "per_verdict": per_verdict,
+    }

--- a/src/entirecontext/core/auto_assess.py
+++ b/src/entirecontext/core/auto_assess.py
@@ -207,15 +207,23 @@ def apply_git_evidence_feedback(
         return 0
 
 
+def _extract_original_verdict(feedback_reason: str | None) -> str | None:
+    if not feedback_reason or not feedback_reason.startswith("auto:revised:"):
+        return None
+    parts = feedback_reason.removeprefix("auto:revised:").split("->", 1)
+    return parts[0] if parts else None
+
+
 def compute_verdict_accuracy(conn: sqlite3.Connection) -> dict:
     rule_count = conn.execute(
         "SELECT COUNT(*) FROM assessments WHERE model_name = 'rule-based'"
     ).fetchone()[0]
 
     enriched_rows = conn.execute(
-        "SELECT verdict, feedback FROM assessments"
+        "SELECT verdict, feedback, feedback_reason FROM assessments"
         " WHERE model_name IS NOT NULL AND model_name != 'rule-based'"
         " AND feedback IS NOT NULL"
+        " AND feedback_reason IS NOT NULL AND feedback_reason LIKE 'auto:%'"
     ).fetchall()
 
     if not enriched_rows:
@@ -229,8 +237,11 @@ def compute_verdict_accuracy(conn: sqlite3.Connection) -> dict:
     per_verdict: dict[str, dict[str, int]] = {}
     agree_count = 0
     for row in enriched_rows:
-        verdict = row["verdict"]
         feedback = row["feedback"]
+        if feedback == "disagree":
+            verdict = _extract_original_verdict(row["feedback_reason"]) or row["verdict"]
+        else:
+            verdict = row["verdict"]
         if verdict not in per_verdict:
             per_verdict[verdict] = {"agree": 0, "disagree": 0}
         if feedback == "agree":

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "auto_cleanup_no_changes": False,
         "intent_summary": False,
         "emit_aar": True,
+        "codex_session_idle_minutes": 60,
         "exclusions": {
             "enabled": False,
             "content_patterns": [],

--- a/src/entirecontext/core/dashboard.py
+++ b/src/entirecontext/core/dashboard.py
@@ -171,8 +171,10 @@ def get_dashboard_stats(
         or 0
     )
     retrieval_sessions_row = conn.execute(
-        "SELECT COUNT(DISTINCT session_id) AS total FROM retrieval_events"
-        + (" WHERE created_at >= ?" if since is not None else ""),
+        "SELECT COUNT(DISTINCT re.session_id) AS total FROM retrieval_events re"
+        " JOIN sessions s ON re.session_id = s.id"
+        " WHERE s.ended_at IS NOT NULL"
+        + (" AND re.created_at >= ?" if since is not None else ""),
         since_params,
     ).fetchone()
     retrieval_sessions_total = retrieval_sessions_row["total"] or 0
@@ -196,7 +198,7 @@ def get_dashboard_stats(
     context_applications_with_selection = applications_row["with_selection"] or 0
     lesson_reuse_count = applications_row["lesson_reuse"] or 0
 
-    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_total if sessions_total > 0 else 0.0
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_ended if sessions_ended > 0 else 0.0
     search_to_selection_rate = (
         retrieval_selections_total / retrieval_events_total if retrieval_events_total > 0 else 0.0
     )

--- a/src/entirecontext/core/session.py
+++ b/src/entirecontext/core/session.py
@@ -82,3 +82,28 @@ def update_session(conn, session_id: str, **kwargs) -> None:
     set_clause = ", ".join(f"{k} = ?" for k in kwargs)
     values = list(kwargs.values()) + [session_id]
     conn.execute(f"UPDATE sessions SET {set_clause} WHERE id = ?", values)
+
+
+def close_stale_sessions(
+    conn,
+    idle_minutes: int = 60,
+    session_type: str = "codex",
+) -> int:
+    rows = conn.execute(
+        "SELECT id, last_activity_at FROM sessions"
+        " WHERE ended_at IS NULL"
+        " AND session_type = ?"
+        " AND last_activity_at IS NOT NULL"
+        " AND datetime(last_activity_at) < datetime('now', ?)",
+        (session_type, f"-{idle_minutes} minutes"),
+    ).fetchall()
+
+    closed = 0
+    for row in rows:
+        cursor = conn.execute(
+            "UPDATE sessions SET ended_at = last_activity_at"
+            " WHERE id = ? AND ended_at IS NULL AND last_activity_at = ?",
+            (row["id"], row["last_activity_at"]),
+        )
+        closed += cursor.rowcount
+    return closed

--- a/src/entirecontext/hooks/codex_ingest.py
+++ b/src/entirecontext/hooks/codex_ingest.py
@@ -328,9 +328,14 @@ def ingest_codex_notify_event(payload: dict[str, Any], *, payload_text: str = ""
             save_turn_content(repo_path, conn, created["id"], session_id, content_blob)
             turn_number += 1
 
+        update_fields = "total_turns = ?, last_activity_at = ?, updated_at = ?"
+        update_params: list = [existing_turns + len(pending), now, now]
+        if pending and existing_session:
+            update_fields += ", ended_at = NULL"
+        update_params.append(session_id)
         conn.execute(
-            "UPDATE sessions SET total_turns = ?, last_activity_at = ?, updated_at = ? WHERE id = ?",
-            (existing_turns + len(pending), now, now, session_id),
+            f"UPDATE sessions SET {update_fields} WHERE id = ?",
+            update_params,
         )
 
         try:

--- a/src/entirecontext/hooks/codex_ingest.py
+++ b/src/entirecontext/hooks/codex_ingest.py
@@ -332,5 +332,15 @@ def ingest_codex_notify_event(payload: dict[str, Any], *, payload_text: str = ""
             "UPDATE sessions SET total_turns = ?, last_activity_at = ?, updated_at = ? WHERE id = ?",
             (existing_turns + len(pending), now, now, session_id),
         )
+
+        try:
+            from ..core.config import load_config
+            config = load_config(repo_path)
+            idle_minutes = config["capture"]["codex_session_idle_minutes"]
+            from ..core.session import close_stale_sessions
+            if close_stale_sessions(conn, idle_minutes=idle_minutes, session_type="codex"):
+                conn.commit()
+        except Exception:
+            pass
     finally:
         conn.close()

--- a/tests/test_codex_session_autoclose.py
+++ b/tests/test_codex_session_autoclose.py
@@ -1,0 +1,183 @@
+"""Tests for codex session auto-close (close_stale_sessions)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from entirecontext.core.project import get_project
+from entirecontext.core.session import close_stale_sessions, create_session
+from entirecontext.db import get_db
+from entirecontext.hooks.codex_ingest import _save_state, ingest_codex_notify_event
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _two_hours_ago() -> str:
+    return _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+
+
+def _just_now() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def test_close_stale_sessions_closes_idle_codex(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+
+    session = create_session(ec_db, project["id"], session_type="codex", session_id="stale-codex-1")
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (stale_time, session["id"]),
+    )
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60, session_type="codex")
+
+    assert closed == 1
+    row = ec_db.execute("SELECT ended_at, last_activity_at FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+    assert row["ended_at"] == row["last_activity_at"]
+    assert row["ended_at"] == stale_time
+
+
+def test_close_stale_sessions_skips_recent_codex(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+
+    session = create_session(ec_db, project["id"], session_type="codex", session_id="recent-codex-1")
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (_just_now(), session["id"]),
+    )
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60, session_type="codex")
+
+    assert closed == 0
+
+
+def test_close_stale_sessions_skips_claude_sessions(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+
+    session = create_session(ec_db, project["id"], session_type="claude", session_id="stale-claude-1")
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (stale_time, session["id"]),
+    )
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60, session_type="codex")
+
+    assert closed == 0
+
+
+def test_close_stale_sessions_skips_already_closed(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+
+    session = create_session(ec_db, project["id"], session_type="codex", session_id="closed-codex-1")
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ?, ended_at = ? WHERE id = ?",
+        (stale_time, stale_time, session["id"]),
+    )
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60, session_type="codex")
+
+    assert closed == 0
+
+
+def test_close_stale_sessions_optimistic_concurrency(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+    fresh_time = _just_now()
+
+    session = create_session(ec_db, project["id"], session_type="codex", session_id="concurrent-codex-1")
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (stale_time, session["id"]),
+    )
+
+    original_execute = ec_db.execute
+
+    def intercepting_execute(sql, params=()):
+        if isinstance(sql, str) and sql.startswith("UPDATE sessions SET ended_at"):
+            original_execute(
+                "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+                (fresh_time, session["id"]),
+            )
+        return original_execute(sql, params)
+
+    ec_db.execute = intercepting_execute  # type: ignore[assignment]
+    try:
+        closed = close_stale_sessions(ec_db, idle_minutes=60, session_type="codex")
+    finally:
+        ec_db.execute = original_execute  # type: ignore[assignment]
+
+    assert closed == 0
+    row = original_execute("SELECT ended_at FROM sessions WHERE id = ?", (session["id"],)).fetchone()
+    assert row["ended_at"] is None
+
+
+def test_codex_ingest_auto_closes_stale_sessions(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+
+    stale_session = create_session(
+        ec_db, project["id"], session_type="codex", session_id="stale-ingest-1"
+    )
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (stale_time, stale_session["id"]),
+    )
+
+    ec_db.close()
+
+    _save_state(str(ec_repo), {})
+
+    codex_home = ec_repo.parent / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "07"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    new_session_id = "new-codex-ingest-1"
+    session_file = session_dir / f"rollout-2026-06-07T00-00-00-{new_session_id}.jsonl"
+    records = [
+        {
+            "timestamp": "2026-06-07T00:00:00Z",
+            "type": "session_meta",
+            "payload": {"id": new_session_id, "timestamp": "2026-06-07T00:00:00Z", "cwd": str(ec_repo)},
+        },
+        {
+            "timestamp": "2026-06-07T00:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "test prompt"}],
+            },
+        },
+        {
+            "timestamp": "2026-06-07T00:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "test response"}],
+            },
+        },
+    ]
+    session_file.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+    ingest_codex_notify_event(
+        {"thread_id": new_session_id, "cwd": str(ec_repo), "codex_home": str(codex_home)},
+        payload_text=json.dumps({"thread_id": new_session_id}),
+    )
+
+    conn = get_db(str(ec_repo))
+    try:
+        stale_row = conn.execute(
+            "SELECT ended_at, last_activity_at FROM sessions WHERE id = ?",
+            (stale_session["id"],),
+        ).fetchone()
+        assert stale_row is not None
+        assert stale_row["ended_at"] is not None
+        assert stale_row["ended_at"] == stale_row["last_activity_at"]
+    finally:
+        conn.close()

--- a/tests/test_codex_session_autoclose.py
+++ b/tests/test_codex_session_autoclose.py
@@ -181,3 +181,47 @@ def test_codex_ingest_auto_closes_stale_sessions(ec_repo, ec_db):
         assert stale_row["ended_at"] == stale_row["last_activity_at"]
     finally:
         conn.close()
+
+
+def test_codex_ingest_reopens_closed_session_on_new_turns(ec_repo, ec_db):
+    """When a closed codex session receives new turns, ended_at is cleared."""
+    project = get_project(str(ec_repo))
+    stale_time = _two_hours_ago()
+
+    session_id = "reopen-codex-1"
+    create_session(ec_db, project["id"], session_type="codex", session_id=session_id)
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ?, ended_at = ? WHERE id = ?",
+        (stale_time, stale_time, session_id),
+    )
+    ec_db.close()
+
+    _save_state(str(ec_repo), {})
+
+    codex_home = ec_repo.parent / "codex-home-reopen"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "07"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_file = session_dir / f"rollout-2026-06-07T00-00-00-{session_id}.jsonl"
+    records = [
+        {"timestamp": "2026-06-07T00:00:00Z", "type": "session_meta",
+         "payload": {"id": session_id, "timestamp": "2026-06-07T00:00:00Z", "cwd": str(ec_repo)}},
+        {"timestamp": "2026-06-07T00:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "new prompt"}]}},
+        {"timestamp": "2026-06-07T00:00:02Z", "type": "response_item",
+         "payload": {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": "new response"}]}},
+    ]
+    session_file.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+    ingest_codex_notify_event(
+        {"thread_id": session_id, "cwd": str(ec_repo), "codex_home": str(codex_home)},
+        payload_text=json.dumps({"thread_id": session_id}),
+    )
+
+    conn = get_db(str(ec_repo))
+    try:
+        row = conn.execute("SELECT ended_at FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        assert row["ended_at"] is None
+    finally:
+        conn.close()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -272,6 +272,62 @@ class TestGetDashboardStats:
         assert stats["maturity_score"] >= 25
         assert stats["maturity_grade"] == "Partial"
 
+    def test_retrieval_rate_excludes_active_sessions(self, ec_repo, ec_db):
+        from uuid import uuid4
+
+        from entirecontext.core.project import get_project
+        from entirecontext.core.session import create_session
+
+        project = get_project(str(ec_repo))
+
+        s1 = create_session(ec_db, project["id"], session_id="ret-s1")
+        s2 = create_session(ec_db, project["id"], session_id="ret-s2")
+        _s3 = create_session(ec_db, project["id"], session_id="ret-s3")  # noqa: F841
+
+        # End s1 and s2, leave s3 active
+        ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s1["id"],))
+        ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s2["id"],))
+        ec_db.commit()
+
+        # Retrieval event only in ended session s1
+        ec_db.execute(
+            "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, created_at)"
+            " VALUES (?, ?, 'hook', 'regex', 'turn', 'test', datetime('now'))",
+            (str(uuid4()), s1["id"]),
+        )
+        ec_db.commit()
+
+        stats = get_dashboard_stats(ec_db)
+        # 1 retrieval session / 2 ended sessions = 0.5 (NOT 1/3)
+        assert stats["telemetry"]["rates"]["retrieval_assisted_session_rate"] == 0.5
+
+    def test_retrieval_rate_ignores_active_session_retrieval(self, ec_repo, ec_db):
+        from uuid import uuid4
+
+        from entirecontext.core.project import get_project
+        from entirecontext.core.session import create_session
+
+        project = get_project(str(ec_repo))
+
+        s1 = create_session(ec_db, project["id"], session_id="ret2-s1")
+        s2 = create_session(ec_db, project["id"], session_id="ret2-s2")
+
+        # End s1 (no retrieval), leave s2 active (with retrieval)
+        ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s1["id"],))
+        ec_db.commit()
+
+        # Retrieval event in active session s2
+        ec_db.execute(
+            "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, created_at)"
+            " VALUES (?, ?, 'hook', 'regex', 'turn', 'test', datetime('now'))",
+            (str(uuid4()), s2["id"]),
+        )
+        ec_db.commit()
+
+        stats = get_dashboard_stats(ec_db)
+        # Active session's retrieval must NOT count in numerator
+        assert stats["telemetry"]["rates"]["retrieval_assisted_session_rate"] == 0.0
+
 
 # ---------------------------------------------------------------------------
 # TestDashboardCLI

--- a/tests/test_verdict_accuracy.py
+++ b/tests/test_verdict_accuracy.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from typer.testing import CliRunner
+
+from entirecontext.cli import app
+from entirecontext.core.auto_assess import compute_verdict_accuracy
+
+runner = CliRunner()
+
+
+def _create_session(conn):
+    """Insert a minimal valid session and return its id."""
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at)"
+        " VALUES ('sess-va', ?, 'claude', '/tmp', ?, ?)",
+        (project_id, now, now),
+    )
+    return "sess-va"
+
+
+def test_compute_verdict_accuracy_empty(ec_repo, ec_db):
+    result = compute_verdict_accuracy(ec_db)
+    assert result["total_rule_based"] == 0
+    assert result["total_enriched"] == 0
+    assert result["agreement_rate"] is None
+    assert result["per_verdict"] == {}
+
+
+def test_compute_verdict_accuracy_with_feedback(ec_repo, ec_db):
+    session_id = _create_session(ec_db)
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash, git_branch, created_at)"
+        " VALUES ('ckp-va-1', ?, 'abc', 'main', datetime('now'))",
+        (session_id,),
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
+        " VALUES ('asmt-va-1', 'ckp-va-1', 'expand', 'claude-cli', 'agree', datetime('now'))"
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
+        " VALUES ('asmt-va-2', 'ckp-va-1', 'neutral', 'claude-cli', 'disagree', datetime('now'))"
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
+        " VALUES ('asmt-va-3', 'ckp-va-1', 'expand', 'rule-based', NULL, datetime('now'))"
+    )
+
+    result = compute_verdict_accuracy(ec_db)
+    assert result["total_rule_based"] == 1
+    assert result["total_enriched"] == 2
+    assert result["agreement_rate"] == 0.5
+    assert result["per_verdict"]["expand"]["agree"] == 1
+    assert result["per_verdict"]["neutral"]["disagree"] == 1
+
+
+def test_compute_verdict_accuracy_disagree_with_reason(ec_repo, ec_db):
+    session_id = _create_session(ec_db)
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash, git_branch, created_at)"
+        " VALUES ('ckp-va-1', ?, 'abc', 'main', datetime('now'))",
+        (session_id,),
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, feedback_reason, created_at)"
+        " VALUES ('asmt-va-1', 'ckp-va-1', 'expand', 'claude-cli', 'disagree',"
+        " 'auto:revised:neutral->expand', datetime('now'))"
+    )
+
+    result = compute_verdict_accuracy(ec_db)
+    assert result["per_verdict"]["expand"]["disagree"] == 1
+    assert result["agreement_rate"] == 0.0
+
+
+def test_assess_accuracy_cli(ec_repo, ec_db, monkeypatch):
+    monkeypatch.chdir(ec_repo)
+    result = runner.invoke(app, ["checkpoint", "assess-accuracy"])
+    assert result.exit_code == 0
+    assert "Verdict Accuracy Baseline" in result.output

--- a/tests/test_verdict_accuracy.py
+++ b/tests/test_verdict_accuracy.py
@@ -10,16 +10,16 @@ from entirecontext.core.auto_assess import compute_verdict_accuracy
 runner = CliRunner()
 
 
-def _create_session(conn):
+def _create_session(conn, session_id="sess-va"):
     """Insert a minimal valid session and return its id."""
     project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
     now = datetime.now(timezone.utc).isoformat()
     conn.execute(
         "INSERT INTO sessions (id, project_id, session_type, workspace_path, started_at, last_activity_at)"
-        " VALUES ('sess-va', ?, 'claude', '/tmp', ?, ?)",
-        (project_id, now, now),
+        " VALUES (?, ?, 'claude', '/tmp', ?, ?)",
+        (session_id, project_id, now, now),
     )
-    return "sess-va"
+    return session_id
 
 
 def test_compute_verdict_accuracy_empty(ec_repo, ec_db):
@@ -38,12 +38,12 @@ def test_compute_verdict_accuracy_with_feedback(ec_repo, ec_db):
         (session_id,),
     )
     ec_db.execute(
-        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
-        " VALUES ('asmt-va-1', 'ckp-va-1', 'expand', 'claude-cli', 'agree', datetime('now'))"
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, feedback_reason, created_at)"
+        " VALUES ('asmt-va-1', 'ckp-va-1', 'expand', 'claude-cli', 'agree', 'auto:llm-confirmed', datetime('now'))"
     )
     ec_db.execute(
-        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
-        " VALUES ('asmt-va-2', 'ckp-va-1', 'neutral', 'claude-cli', 'disagree', datetime('now'))"
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, feedback_reason, created_at)"
+        " VALUES ('asmt-va-2', 'ckp-va-1', 'expand', 'claude-cli', 'disagree', 'auto:revised:neutral->expand', datetime('now'))"
     )
     ec_db.execute(
         "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, created_at)"
@@ -55,6 +55,7 @@ def test_compute_verdict_accuracy_with_feedback(ec_repo, ec_db):
     assert result["total_enriched"] == 2
     assert result["agreement_rate"] == 0.5
     assert result["per_verdict"]["expand"]["agree"] == 1
+    # disagree attributed to original rule verdict 'neutral', not current 'expand'
     assert result["per_verdict"]["neutral"]["disagree"] == 1
 
 
@@ -72,8 +73,28 @@ def test_compute_verdict_accuracy_disagree_with_reason(ec_repo, ec_db):
     )
 
     result = compute_verdict_accuracy(ec_db)
-    assert result["per_verdict"]["expand"]["disagree"] == 1
+    # attributed to original 'neutral', not current 'expand'
+    assert "neutral" in result["per_verdict"]
+    assert result["per_verdict"]["neutral"]["disagree"] == 1
     assert result["agreement_rate"] == 0.0
+
+
+def test_compute_verdict_accuracy_excludes_manual_feedback(ec_repo, ec_db):
+    session_id = _create_session(ec_db)
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash, git_branch, created_at)"
+        " VALUES ('ckp-va-m', ?, 'abc', 'main', datetime('now'))",
+        (session_id,),
+    )
+    # Manual feedback (no auto: prefix in feedback_reason) should be excluded
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, feedback_reason, created_at)"
+        " VALUES ('asmt-manual', 'ckp-va-m', 'expand', 'mcp-agent', 'agree', 'user manual review', datetime('now'))"
+    )
+
+    result = compute_verdict_accuracy(ec_db)
+    assert result["total_enriched"] == 0
+    assert result["agreement_rate"] is None
 
 
 def test_assess_accuracy_cli(ec_repo, ec_db, monkeypatch):


### PR DESCRIPTION
## Summary

- **Codex session auto-close**: `close_stale_sessions()` sets `ended_at = last_activity_at` for codex sessions idle > 60min. Called automatically during codex notify ingestion with optimistic concurrency guard. Fixes 383 sessions stuck at `ended_at IS NULL`.
- **Dashboard retrieval rate normalization**: `retrieval_assisted_session_rate` numerator and denominator both filter on `ended_at IS NOT NULL`, consistent with `checkpoint_coverage_rate`. Previously the ratio sides used different populations.
- **Verdict accuracy baseline**: `ec checkpoint assess-accuracy` reports agree/disagree rate from LLM enrichment feedback. Infrastructure for v0.9.0 verdict tuning.

Follows v0.8.0 retro lesson: "측정 인프라가 측정 대상보다 먼저 정확해야 한다."

## Test plan

- [x] 1693 tests pass, 93 skipped
- [x] `ruff check .` clean
- [x] 6 new tests for codex auto-close (idle close, skip recent/claude/closed, optimistic concurrency, ingest integration)
- [x] 2 new tests for dashboard normalization (active session excluded from numerator AND denominator)
- [x] 4 new tests for verdict accuracy (empty, with feedback, disagree+reason, CLI)
- [x] Existing `test_codex_ingest.py` (2), `test_dashboard.py` (29), `test_auto_assess.py` (18) all pass — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)