### PR TITLE
docs: backfill release plan docs, regenerate lessons, ignore .omc state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ coverage.json
 .claude
 .cursor/
 .codex/
-.omc/
+.omc/*
+!.omc/RELEASE_RULE.md
 .serena/
 agents.lock
 .agents/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage.json
 .claude
 .cursor/
 .codex/
+.omc/
 .serena/
 agents.lock
 .agents/.gitignore

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,8 +1,26 @@
 # Lessons Learned
 
-_Generated from 10 assessed changes._
+_Generated from 18 assessed changes._
 
 ## 🟢 Expand (increases future options)
+
+### ✅ chore(deps): bump sentence-transformers from 5.5.0 to 5.5.1
+
+**Feedback:** agree — auto:committed
+
+_Assessment: d28a0263 | 2026-06-06T14:40:01.177319+00:00_ 
+
+### ✅ chore(deps): bump sentence-transformers from 5.5.0 to 5.5.1
+
+**Feedback:** agree — auto:committed
+
+_Assessment: d58c0efa | 2026-06-06T14:40:01.169773+00:00_ 
+
+### ✅ feat(distill): v0.8.0 auto-assess automation (#157)
+
+**Feedback:** agree — auto:committed
+
+_Assessment: dbe3569f | 2026-06-06T14:40:01.145677+00:00_ 
 
 ### ✅ MCP 입력 정규화와 FTS 오류 처리를 안정화해 에이전트가 검색·결정 도구를 더 예측 가능하게 사용할 수 있게 하므로 future option을 넓힌다.
 
@@ -91,6 +109,36 @@ _Assessment: 84288d4f | 2026-02-20T10:48:16.009213+00:00_
 _Assessment: dd6184a2 | 2026-02-20T08:51:22.221135+00:00_ 
 
 ## 🟡 Neutral
+
+### ✅ Auto-assessed checkpoint
+
+**Feedback:** agree — auto:committed
+
+_Assessment: b5fed17f | 2026-06-07T04:04:23.897323+00:00_ 
+
+### ✅ Merge branch 'docs/roadmap-direction-2026-06-02'
+
+**Feedback:** agree — auto:committed
+
+_Assessment: 5d19a93c | 2026-06-06T14:40:01.191856+00:00_ 
+
+### ✅ fix(hooks): prevent codex-notify stdin blocking that accumulates zombie processes
+
+**Feedback:** agree — auto:committed
+
+_Assessment: d9e00b3f | 2026-06-06T14:40:01.184484+00:00_ 
+
+### ✅ Auto-assessed checkpoint
+
+**Feedback:** agree — auto:committed
+
+_Assessment: be7950ff | 2026-06-06T14:40:01.161669+00:00_ 
+
+### ✅ Auto-assessed checkpoint
+
+**Feedback:** agree — auto:committed
+
+_Assessment: 4ac6facf | 2026-06-06T14:40:01.154162+00:00_ 
 
 ### ✅ 릴리스 커밋의 closing reference를 기준으로 GitHub 이슈를 자동 종료해 운영 마찰은 줄이지만, 결정 메모리 루프 자체의 선택지를 크게 넓히거나 좁히지는 않는다.
 

--- a/docs/superpowers/plans/2026-06-07-measurement-accuracy.md
+++ b/docs/superpowers/plans/2026-06-07-measurement-accuracy.md
@@ -1,0 +1,857 @@
+# v0.8.1 Measurement Accuracy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix measurement infrastructure so maturity scores reflect reality — no new features, only corrections that enable trustworthy attribution for v0.9.0.
+
+**Architecture:** Three sequential items: (1) auto-close stale codex sessions so they have valid `ended_at`, (2) normalize dashboard denominators so all session-based maturity metrics use ended sessions only, (3) build verdict accuracy reporting from existing enrichment feedback data. Item 1 is a data prerequisite for item 2's verification; item 3 is independent.
+
+**Tech Stack:** Python 3.12+, SQLite, Typer CLI, pytest
+
+**Key decision:** `retrieval_assisted_session_rate` currently uses `sessions_total` (all sessions including active) as denominator. After this change, it uses `sessions_ended` (only completed sessions), consistent with `checkpoint_coverage_rate`. Rationale: active sessions haven't completed their lifecycle and should not count toward maturity — a session that just started cannot be "retrieval-assisted" or not yet.
+
+---
+
+## Prior Retro Carryover Review (v0.8.0)
+
+| v0.8.0 Retro Item | This Release? | Rationale |
+|---|---|---|
+| codex session lifecycle 누락 | Yes (Task 1) | Primary measurement distortion source |
+| maturity 분모 왜곡 | Yes (Task 2) | Direct consequence of lifecycle gap |
+| rule-based verdict 품질 의문 | Yes (Task 3) | Accuracy baseline before v0.9.0 tuning |
+| intervene=5 gap | No → v0.9.0 | Feature work (auto-apply inference), blocked until measurement is trustworthy |
+| PR blast radius 미확인 | N/A | Process improvement (plan checklist), already in memory |
+
+## File Structure
+
+| File | Role | Action |
+|---|---|---|
+| `src/entirecontext/core/session.py` | Session CRUD | Add `close_stale_sessions()` |
+| `src/entirecontext/hooks/codex_ingest.py` | Codex notify handler | Call `close_stale_sessions()` after ingestion |
+| `src/entirecontext/core/config.py` | Config defaults | Add `codex_session_idle_minutes` |
+| `src/entirecontext/core/dashboard.py` | Maturity metrics | Change `retrieval_assisted_session_rate` numerator AND denominator to ended-session basis |
+| `src/entirecontext/core/auto_assess.py` | Assessment logic | Add `compute_verdict_accuracy()` |
+| `src/entirecontext/cli/checkpoint_cmds.py` | CLI commands | Add `ec assess accuracy` |
+| `tests/test_codex_session_autoclose.py` | Tests for Task 1 | Create |
+| `tests/test_dashboard.py` | Dashboard tests | Modify (denominator change) |
+| `tests/test_verdict_accuracy.py` | Tests for Task 3 | Create |
+
+## Callers & Invariants
+
+### Changed Functions — Callers
+
+| Function | Callers |
+|---|---|
+| `session.py` (new `close_stale_sessions`) | `codex_ingest.py:ingest_codex_notify_event()`, `session_cmds.py:session_backfill_ended_at()` |
+| `dashboard.py:get_dashboard_stats()` | `cli/dashboard_cmds.py`, `mcp/tools/misc.py`, `tests/test_dashboard.py` |
+| `auto_assess.py` (new `compute_verdict_accuracy`) | `cli/checkpoint_cmds.py` (new command) |
+| `config.py:DEFAULT_CONFIG` | All `load_config()` callers (no breaking change — additive key) |
+
+### Invariants
+
+1. `close_stale_sessions` must use optimistic concurrency: re-check `ended_at IS NULL AND last_activity_at = ?` before UPDATE (same pattern as `session_cmds.py:520-524`)
+2. `retrieval_assisted_session_rate` numerator and denominator must share the same population (`ended_at IS NOT NULL`) — a ratio where sides use different filters can exceed 1.0
+3. Maturity grade thresholds unchanged (capture/distill/retrieve/intervene point allocation stays the same)
+4. Active claude sessions (`ended_at IS NULL, session_type='claude'`) must NOT be auto-closed
+5. `checkpoint_coverage_rate` formula unchanged — it already correctly filters on `ended_at IS NOT NULL`
+6. Existing `ec session backfill-ended-at` command behavior unchanged — it remains a manual safety net for all session types
+7. `feedback` column accepts only `"agree"` or `"disagree"` (validated by `VALID_FEEDBACKS`); `"auto:revised:..."` goes to `feedback_reason`
+
+---
+
+### Task 1: Codex Session Auto-Close
+
+**Files:**
+- Modify: `src/entirecontext/core/session.py`
+- Modify: `src/entirecontext/core/config.py:11-17`
+- Modify: `src/entirecontext/hooks/codex_ingest.py:258-336`
+- Create: `tests/test_codex_session_autoclose.py`
+
+- [ ] **Step 1: Write the failing test — `close_stale_sessions` basic behavior**
+
+```python
+# tests/test_codex_session_autoclose.py
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from entirecontext.core.session import close_stale_sessions, create_session
+from entirecontext.core.project import get_project
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def test_close_stale_sessions_closes_idle_codex(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    s = create_session(ec_db, project["id"], session_type="codex", session_id="codex-stale-1")
+    two_hours_ago = _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (two_hours_ago, s["id"]),
+    )
+    ec_db.commit()
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60)
+
+    assert closed == 1
+    row = ec_db.execute("SELECT ended_at FROM sessions WHERE id = ?", (s["id"],)).fetchone()
+    assert row["ended_at"] == two_hours_ago
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_closes_idle_codex -v`
+Expected: FAIL — `ImportError: cannot import name 'close_stale_sessions'`
+
+- [ ] **Step 3: Implement `close_stale_sessions` in `core/session.py`**
+
+Add to the end of `src/entirecontext/core/session.py`:
+
+```python
+def close_stale_sessions(
+    conn,
+    idle_minutes: int = 60,
+    session_type: str = "codex",
+) -> int:
+    """Auto-close stale sessions: set ended_at = last_activity_at for idle sessions.
+
+    Uses optimistic concurrency to avoid clobbering sessions resumed between
+    SELECT and UPDATE.
+    """
+    rows = conn.execute(
+        "SELECT id, last_activity_at FROM sessions"
+        " WHERE ended_at IS NULL"
+        " AND session_type = ?"
+        " AND last_activity_at IS NOT NULL"
+        " AND datetime(last_activity_at) < datetime('now', ?)",
+        (session_type, f"-{idle_minutes} minutes"),
+    ).fetchall()
+
+    closed = 0
+    for row in rows:
+        cursor = conn.execute(
+            "UPDATE sessions SET ended_at = last_activity_at"
+            " WHERE id = ? AND ended_at IS NULL AND last_activity_at = ?",
+            (row["id"], row["last_activity_at"]),
+        )
+        closed += cursor.rowcount
+    if closed:
+        conn.commit()
+    return closed
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_closes_idle_codex -v`
+Expected: PASS
+
+- [ ] **Step 5: Write test — does NOT close active codex sessions**
+
+```python
+def test_close_stale_sessions_skips_recent_codex(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    s = create_session(ec_db, project["id"], session_type="codex", session_id="codex-active-1")
+    # last_activity_at is set to now by create_session — should NOT be closed
+    ec_db.commit()
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60)
+
+    assert closed == 0
+    row = ec_db.execute("SELECT ended_at FROM sessions WHERE id = ?", (s["id"],)).fetchone()
+    assert row["ended_at"] is None
+```
+
+- [ ] **Step 6: Run test — should pass without code changes**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_skips_recent_codex -v`
+Expected: PASS
+
+- [ ] **Step 7: Write test — does NOT close claude sessions**
+
+```python
+def test_close_stale_sessions_skips_claude_sessions(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    s = create_session(ec_db, project["id"], session_type="claude", session_id="claude-stale-1")
+    two_hours_ago = _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (two_hours_ago, s["id"]),
+    )
+    ec_db.commit()
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60)
+
+    assert closed == 0
+    row = ec_db.execute("SELECT ended_at FROM sessions WHERE id = ?", (s["id"],)).fetchone()
+    assert row["ended_at"] is None
+```
+
+- [ ] **Step 8: Run test — should pass without code changes**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_skips_claude_sessions -v`
+Expected: PASS
+
+- [ ] **Step 9: Write test — does NOT close already-closed sessions**
+
+```python
+def test_close_stale_sessions_skips_already_closed(ec_repo, ec_db):
+    project = get_project(str(ec_repo))
+    s = create_session(ec_db, project["id"], session_type="codex", session_id="codex-closed-1")
+    two_hours_ago = _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ?, ended_at = ? WHERE id = ?",
+        (two_hours_ago, two_hours_ago, s["id"]),
+    )
+    ec_db.commit()
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60)
+
+    assert closed == 0
+```
+
+- [ ] **Step 10: Run test — should pass**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_skips_already_closed -v`
+Expected: PASS
+
+- [ ] **Step 11: Write test — optimistic concurrency guard**
+
+This test exercises the UPDATE's `WHERE last_activity_at = ?` guard by monkeypatching the function to inject a concurrent modification between SELECT and UPDATE.
+
+```python
+def test_close_stale_sessions_optimistic_concurrency(ec_repo, ec_db, monkeypatch):
+    """If last_activity_at changes between SELECT and UPDATE, row is skipped."""
+    from unittest.mock import patch
+
+    project = get_project(str(ec_repo))
+    s = create_session(ec_db, project["id"], session_type="codex", session_id="codex-race-1")
+    two_hours_ago = _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (two_hours_ago, s["id"]),
+    )
+    ec_db.commit()
+
+    original_execute = ec_db.execute
+    injected = False
+
+    def intercepting_execute(sql, params=None):
+        nonlocal injected
+        # After the SELECT but before the first UPDATE, change last_activity_at
+        if not injected and "UPDATE sessions SET ended_at" in sql:
+            injected = True
+            fresh = _iso(datetime.now(timezone.utc))
+            original_execute(
+                "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+                (fresh, s["id"]),
+            )
+        return original_execute(sql, params) if params else original_execute(sql)
+
+    ec_db.execute = intercepting_execute
+
+    closed = close_stale_sessions(ec_db, idle_minutes=60)
+
+    # The UPDATE's WHERE clause requires last_activity_at = <old_value>,
+    # but the concurrent update changed it, so rowcount = 0
+    assert closed == 0
+    # Session should still be open
+    row = original_execute("SELECT ended_at FROM sessions WHERE id = ?", (s["id"],)).fetchone()
+    assert row["ended_at"] is None
+```
+
+- [ ] **Step 12: Run test — should pass**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py::test_close_stale_sessions_optimistic_concurrency -v`
+Expected: PASS
+
+- [ ] **Step 13: Add config default**
+
+In `src/entirecontext/core/config.py`, add to `DEFAULT_CONFIG["capture"]`:
+
+```python
+"codex_session_idle_minutes": 60,
+```
+
+- [ ] **Step 14: Write test — auto-close triggered from codex ingest**
+
+```python
+def test_codex_ingest_auto_closes_stale_sessions(ec_repo, ec_db):
+    """ingest_codex_notify_event closes stale codex sessions as a side effect."""
+    import json
+    from pathlib import Path
+
+    from entirecontext.core.project import get_project
+    from entirecontext.hooks.codex_ingest import _save_state, ingest_codex_notify_event
+
+    project = get_project(str(ec_repo))
+    # Create a stale codex session
+    s = create_session(ec_db, project["id"], session_type="codex", session_id="codex-old-1")
+    two_hours_ago = _iso(datetime.now(timezone.utc) - timedelta(hours=2))
+    ec_db.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+        (two_hours_ago, s["id"]),
+    )
+    ec_db.commit()
+    ec_db.close()
+
+    # Enable codex notify
+    _save_state(str(ec_repo), {})
+
+    # Write codex session file
+    codex_home = ec_repo.parent / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "07"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / "rollout-2026-06-07T00-00-00-new-session.jsonl"
+    records = [
+        {"timestamp": "2026-06-07T00:00:00Z", "type": "session_meta",
+         "payload": {"id": "codex-new-1", "timestamp": "2026-06-07T00:00:00Z", "cwd": str(ec_repo)}},
+        {"timestamp": "2026-06-07T00:00:01Z", "type": "response_item",
+         "payload": {"type": "message", "role": "user",
+                     "content": [{"type": "input_text", "text": "hello"}]}},
+        {"timestamp": "2026-06-07T00:00:02Z", "type": "response_item",
+         "payload": {"type": "message", "role": "assistant",
+                     "content": [{"type": "output_text", "text": "hi"}]}},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+    ingest_codex_notify_event(
+        {"thread_id": "codex-new-1", "cwd": str(ec_repo), "codex_home": str(codex_home)},
+        payload_text="{}",
+    )
+
+    from entirecontext.db import get_db
+    conn = get_db(str(ec_repo))
+    row = conn.execute("SELECT ended_at FROM sessions WHERE id = ?", (s["id"],)).fetchone()
+    conn.close()
+    assert row["ended_at"] is not None
+```
+
+- [ ] **Step 15: Integrate auto-close into `codex_ingest.py`**
+
+In `src/entirecontext/hooks/codex_ingest.py`, add after the `conn.execute("UPDATE sessions SET total_turns...")` block (line 334), before `finally`:
+
+```python
+        try:
+            from ..core.config import load_config
+            config = load_config(repo_path)
+            idle_minutes = config.get("capture", {}).get("codex_session_idle_minutes", 60)
+            from ..core.session import close_stale_sessions
+            close_stale_sessions(conn, idle_minutes=idle_minutes, session_type="codex")
+        except Exception:
+            pass
+```
+
+- [ ] **Step 16: Run all Task 1 tests**
+
+Run: `uv run pytest tests/test_codex_session_autoclose.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 17: Run existing codex ingest tests for regression**
+
+Run: `uv run pytest tests/test_codex_ingest.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 18: Commit**
+
+```bash
+git add src/entirecontext/core/session.py src/entirecontext/core/config.py \
+  src/entirecontext/hooks/codex_ingest.py tests/test_codex_session_autoclose.py
+git commit -m "feat(session): auto-close stale codex sessions on ingest
+
+Codex sessions created by codex_ingest.py had no termination logic, leaving
+374+ sessions with ended_at IS NULL. Add close_stale_sessions() that sets
+ended_at = last_activity_at for codex sessions idle > N minutes (default 60).
+
+Called automatically during codex notify ingestion. Uses optimistic
+concurrency (re-check ended_at IS NULL AND last_activity_at = ?) to
+avoid clobbering resumed sessions."
+```
+
+---
+
+### Task 2: Dashboard Retrieval Rate Normalization
+
+**Files:**
+- Modify: `src/entirecontext/core/dashboard.py:173-178,199`
+- Modify: `tests/test_dashboard.py`
+
+**Design decision:** Change `retrieval_assisted_session_rate` to use ended sessions for BOTH numerator and denominator. Currently the numerator counts `COUNT(DISTINCT session_id) FROM retrieval_events` (no `ended_at` filter) and the denominator is `sessions_total` (also no filter). Both sides are inconsistent with `checkpoint_coverage_rate` which uses `ended_at IS NOT NULL`.
+
+Rationale:
+- `checkpoint_coverage_rate` already filters on `ended_at IS NOT NULL` (lines 213, 240)
+- Active sessions haven't completed their lifecycle — including them in either side is misleading
+- After Task 1, codex sessions gain `ended_at` and enter both sides correctly
+- Both sides must share the same population — a retrieval event in an active session must NOT count in the numerator when the denominator excludes active sessions, or the rate can exceed 1.0
+
+**Expected metric change:**
+- Before: `59 / 535 = 0.110` (both sides unfiltered)
+- After (all sessions ended): ended sessions with retrieval / ended sessions ≈ similar rate
+- The fix is about **coherence**, not inflating the score
+
+- [ ] **Step 1: Write the failing test — rate excludes active sessions from BOTH sides**
+
+```python
+# In tests/test_dashboard.py, add these tests
+
+def test_retrieval_rate_excludes_active_sessions(ec_repo, ec_db):
+    """retrieval_assisted_session_rate uses ended sessions for both numerator and denominator."""
+    from entirecontext.core.project import get_project
+    from entirecontext.core.session import create_session
+
+    project = get_project(str(ec_repo))
+
+    # 2 ended sessions, 1 active
+    s1 = create_session(ec_db, project["id"], session_id="rate-s1")
+    s2 = create_session(ec_db, project["id"], session_id="rate-s2")
+    s3 = create_session(ec_db, project["id"], session_id="rate-s3")
+    ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s1["id"],))
+    ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s2["id"],))
+    ec_db.commit()
+
+    # 1 retrieval event in ended session s1
+    from uuid import uuid4
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, query, source, created_at)"
+        " VALUES (?, ?, 'test', 'hook', datetime('now'))",
+        (str(uuid4()), s1["id"]),
+    )
+    ec_db.commit()
+
+    stats = get_dashboard_stats(ec_db)
+
+    # rate = 1 ended session with retrieval / 2 ended sessions = 0.5
+    # NOT 1/3 (which would include the active session in denominator)
+    assert stats["retrieval"]["assisted_session_rate"] == 0.5
+
+
+def test_retrieval_rate_ignores_active_session_retrieval(ec_repo, ec_db):
+    """Retrieval event in an active session must NOT inflate the numerator."""
+    from entirecontext.core.project import get_project
+    from entirecontext.core.session import create_session
+
+    project = get_project(str(ec_repo))
+
+    # 1 ended session (no retrieval), 1 active session (with retrieval)
+    s1 = create_session(ec_db, project["id"], session_id="rate-ended-1")
+    s2 = create_session(ec_db, project["id"], session_id="rate-active-1")
+    ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s1["id"],))
+    ec_db.commit()
+
+    # Retrieval event only in the ACTIVE session
+    from uuid import uuid4
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, query, source, created_at)"
+        " VALUES (?, ?, 'test', 'hook', datetime('now'))",
+        (str(uuid4()), s2["id"]),
+    )
+    ec_db.commit()
+
+    stats = get_dashboard_stats(ec_db)
+
+    # rate = 0 ended sessions with retrieval / 1 ended session = 0.0
+    # The active session's retrieval event must NOT count
+    assert stats["retrieval"]["assisted_session_rate"] == 0.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_dashboard.py::test_retrieval_rate_excludes_active_sessions tests/test_dashboard.py::test_retrieval_rate_ignores_active_session_retrieval -v`
+Expected: FAIL — both tests fail because current formula uses unfiltered populations
+
+- [ ] **Step 3: Fix BOTH numerator and denominator in `dashboard.py`**
+
+In `src/entirecontext/core/dashboard.py`, change the numerator query (lines 173-178):
+
+Old:
+```python
+    retrieval_sessions_row = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) AS total FROM retrieval_events"
+        + (" WHERE created_at >= ?" if since is not None else ""),
+        since_params,
+    ).fetchone()
+```
+
+New:
+```python
+    retrieval_sessions_row = conn.execute(
+        "SELECT COUNT(DISTINCT re.session_id) AS total FROM retrieval_events re"
+        " JOIN sessions s ON re.session_id = s.id"
+        " WHERE s.ended_at IS NOT NULL"
+        + (" AND re.created_at >= ?" if since is not None else ""),
+        since_params,
+    ).fetchone()
+```
+
+And change the denominator (line 199):
+
+Old:
+```python
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_total if sessions_total > 0 else 0.0
+```
+
+New:
+```python
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_ended if sessions_ended > 0 else 0.0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_dashboard.py::test_retrieval_rate_excludes_active_sessions tests/test_dashboard.py::test_retrieval_rate_ignores_active_session_retrieval -v`
+Expected: PASS
+
+- [ ] **Step 5: Run ALL dashboard tests for regression**
+
+Run: `uv run pytest tests/test_dashboard.py -v`
+Expected: ALL PASS (existing tests may need adjustment — see step 6)
+
+- [ ] **Step 6: Fix any failing existing tests**
+
+If existing tests fail due to the denominator change, update their expected values. The `_seed_db` helper creates 1 ended session (`dash-s2`) and 1 active session (`dash-s1`). Check each failing test and update expected values to match the new formula (ended sessions only, both sides).
+
+- [ ] **Step 7: Run full dashboard test suite**
+
+Run: `uv run pytest tests/test_dashboard.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/entirecontext/core/dashboard.py tests/test_dashboard.py
+git commit -m "fix(dashboard): normalize retrieval rate to ended-session basis
+
+Both numerator (retrieval_sessions_total) and denominator were using
+unfiltered session counts, while checkpoint_coverage_rate filters on
+ended_at IS NOT NULL. This caused: (a) 383 codex sessions with
+ended_at=NULL inflating the denominator, (b) retrieval events in
+active sessions counting in the numerator but not the denominator,
+allowing rates >1.0 in edge cases. Both sides now join sessions and
+filter on ended_at IS NOT NULL."
+```
+
+---
+
+### Task 3: Verdict Accuracy Baseline
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_assess.py`
+- Modify: `src/entirecontext/cli/checkpoint_cmds.py`
+- Create: `tests/test_verdict_accuracy.py`
+
+**Data source:** `enrich_assessment()` (auto_assess.py:168-171) records `agree`/`disagree` feedback when LLM confirms or revises the rule verdict. Disagreement rate on rule-based assessments IS the false-positive baseline. No new labeling process needed.
+
+**Known correction:** The v0.8.0 retro claimed "chore(deps): bump → expand" was a false positive. Verified against code: `compute_rule_verdict` only matches `^feat` (expand) and `^revert` (narrow). `chore(deps)` returns `neutral`. The retro's example was inaccurate — the actual false-positive cases need to be identified from enrichment feedback data.
+
+- [ ] **Step 1: Write the failing test — `compute_verdict_accuracy` returns structured report**
+
+```python
+# tests/test_verdict_accuracy.py
+from __future__ import annotations
+
+from entirecontext.core.auto_assess import compute_verdict_accuracy
+from entirecontext.core.futures import create_assessment
+
+
+def test_compute_verdict_accuracy_empty(ec_repo, ec_db):
+    result = compute_verdict_accuracy(ec_db)
+
+    assert result["total_rule_based"] == 0
+    assert result["total_enriched"] == 0
+    assert result["agreement_rate"] is None
+    assert result["per_verdict"] == {}
+
+
+def test_compute_verdict_accuracy_with_feedback(ec_repo, ec_db):
+    # 2 rule-based assessments enriched: 1 agree, 1 disagree
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash, git_branch, created_at)"
+        " VALUES ('ckp-va-1', 'sess-va', 'abc', 'main', datetime('now'))"
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, impact_summary, created_at)"
+        " VALUES ('asmt-va-1', 'ckp-va-1', 'expand', 'claude-cli', 'agree', 'feat: add X', datetime('now'))"
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, impact_summary, created_at)"
+        " VALUES ('asmt-va-2', 'ckp-va-1', 'neutral', 'claude-cli', 'disagree', 'chore: bump', datetime('now'))"
+    )
+    # 1 pure rule-based (no enrichment yet)
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, impact_summary, created_at)"
+        " VALUES ('asmt-va-3', 'ckp-va-1', 'expand', 'rule-based', 'feat: login', datetime('now'))"
+    )
+    ec_db.commit()
+
+    result = compute_verdict_accuracy(ec_db)
+
+    assert result["total_rule_based"] == 1
+    assert result["total_enriched"] == 2
+    assert result["agreement_rate"] == 0.5
+    assert result["per_verdict"]["expand"]["agree"] == 1
+    assert result["per_verdict"]["neutral"]["disagree"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_verdict_accuracy.py -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_verdict_accuracy'`
+
+- [ ] **Step 3: Implement `compute_verdict_accuracy` in `auto_assess.py`**
+
+Add to `src/entirecontext/core/auto_assess.py`:
+
+```python
+def compute_verdict_accuracy(conn: sqlite3.Connection) -> dict:
+    """Compute verdict accuracy from enrichment feedback data.
+
+    Returns structured report with agreement rate and per-verdict breakdown.
+    """
+    rule_count = conn.execute(
+        "SELECT COUNT(*) FROM assessments WHERE model_name = 'rule-based'"
+    ).fetchone()[0]
+
+    enriched_rows = conn.execute(
+        "SELECT verdict, feedback FROM assessments"
+        " WHERE model_name IS NOT NULL AND model_name != 'rule-based'"
+        " AND feedback IS NOT NULL"
+    ).fetchall()
+
+    if not enriched_rows:
+        return {
+            "total_rule_based": rule_count,
+            "total_enriched": 0,
+            "agreement_rate": None,
+            "per_verdict": {},
+        }
+
+    per_verdict: dict[str, dict[str, int]] = {}
+    agree_count = 0
+    for row in enriched_rows:
+        verdict = row["verdict"]
+        feedback = row["feedback"]
+        if verdict not in per_verdict:
+            per_verdict[verdict] = {"agree": 0, "disagree": 0}
+        if feedback == "agree":
+            per_verdict[verdict]["agree"] += 1
+            agree_count += 1
+        elif feedback == "disagree":
+            per_verdict[verdict]["disagree"] += 1
+
+    total = len(enriched_rows)
+    return {
+        "total_rule_based": rule_count,
+        "total_enriched": total,
+        "agreement_rate": agree_count / total if total > 0 else None,
+        "per_verdict": per_verdict,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_verdict_accuracy.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Write test — disagree feedback with reason is counted correctly**
+
+Note: `add_feedback()` validates that `feedback` is either `"agree"` or `"disagree"` only (see `VALID_FEEDBACKS` in futures.py:13). The detail string like `"auto:revised:neutral->expand"` goes to `feedback_reason`, not `feedback`. So the `compute_verdict_accuracy` function only needs to check `feedback = "agree"` or `feedback = "disagree"`.
+
+```python
+def test_compute_verdict_accuracy_disagree_with_reason(ec_repo, ec_db):
+    ec_db.execute(
+        "INSERT INTO checkpoints (id, session_id, git_commit_hash, git_branch, created_at)"
+        " VALUES ('ckp-va-rev', 'sess-va-rev', 'def', 'main', datetime('now'))"
+    )
+    ec_db.execute(
+        "INSERT INTO assessments (id, checkpoint_id, verdict, model_name, feedback, feedback_reason, impact_summary, created_at)"
+        " VALUES ('asmt-rev-1', 'ckp-va-rev', 'expand', 'claude-cli', 'disagree', 'auto:revised:neutral->expand', 'revised', datetime('now'))"
+    )
+    ec_db.commit()
+
+    result = compute_verdict_accuracy(ec_db)
+
+    assert result["per_verdict"]["expand"]["disagree"] == 1
+    assert result["agreement_rate"] == 0.0
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_verdict_accuracy.py::test_compute_verdict_accuracy_disagree_with_reason -v`
+Expected: PASS
+
+- [ ] **Step 7: Add CLI command `ec assess accuracy`**
+
+In `src/entirecontext/cli/checkpoint_cmds.py`, add near the end (before `register()`):
+
+```python
+@checkpoint_app.command("assess-accuracy")
+def assess_accuracy():
+    """Show verdict accuracy baseline from enrichment feedback."""
+    from ..core.auto_assess import compute_verdict_accuracy
+    from ..core.project import find_git_root, get_project
+    from ..db import get_db
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    project = get_project(repo_path)
+    if not project:
+        console.print("[yellow]Not initialized. Run 'ec init'.[/yellow]")
+        raise typer.Exit(1)
+
+    conn = get_db(repo_path)
+    try:
+        result = compute_verdict_accuracy(conn)
+    finally:
+        conn.close()
+
+    console.print(f"\n[bold]Verdict Accuracy Baseline[/bold]")
+    console.print(f"  Rule-based assessments (pending enrichment): {result['total_rule_based']}")
+    console.print(f"  Enriched assessments (with feedback): {result['total_enriched']}")
+
+    if result["agreement_rate"] is not None:
+        rate_pct = result["agreement_rate"] * 100
+        console.print(f"  Agreement rate: {rate_pct:.1f}%")
+    else:
+        console.print("  Agreement rate: [dim]no data[/dim]")
+
+    if result["per_verdict"]:
+        table = Table(title="Per-Verdict Breakdown")
+        table.add_column("Verdict")
+        table.add_column("Agree", justify="right")
+        table.add_column("Disagree", justify="right")
+        for verdict, counts in sorted(result["per_verdict"].items()):
+            table.add_row(verdict, str(counts["agree"]), str(counts["disagree"]))
+        console.print(table)
+```
+
+Also add the missing import at the top of the file if not present:
+```python
+from rich.table import Table
+```
+
+- [ ] **Step 8: Write CLI test**
+
+```python
+# Add to tests/test_verdict_accuracy.py
+
+from typer.testing import CliRunner
+
+from entirecontext.cli import app
+
+runner = CliRunner()
+
+
+def test_assess_accuracy_cli(ec_repo, ec_db, monkeypatch):
+    monkeypatch.chdir(ec_repo)
+    result = runner.invoke(app, ["checkpoint", "assess-accuracy"])
+    assert result.exit_code == 0
+    assert "Verdict Accuracy Baseline" in result.output
+```
+
+- [ ] **Step 9: Run CLI test**
+
+Run: `uv run pytest tests/test_verdict_accuracy.py::test_assess_accuracy_cli -v`
+Expected: PASS
+
+- [ ] **Step 10: Run all Task 3 tests**
+
+Run: `uv run pytest tests/test_verdict_accuracy.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 11: Run existing auto_assess tests for regression**
+
+Run: `uv run pytest tests/test_auto_assess.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/entirecontext/core/auto_assess.py src/entirecontext/cli/checkpoint_cmds.py \
+  tests/test_verdict_accuracy.py
+git commit -m "feat(assess): add verdict accuracy baseline reporting
+
+compute_verdict_accuracy() aggregates agree/disagree feedback from LLM
+enrichment to measure rule-based verdict accuracy. CLI: ec checkpoint
+assess-accuracy. Uses existing enrichment feedback data — no new
+labeling process.
+
+Current data: 10 enriched (all agree), 8 rule-based pending. Baseline
+will grow as auto-enrichment processes more assessments."
+```
+
+---
+
+### Task 4: Integration Verification + Docs
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `ROADMAP.md`
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: ALL PASS, zero failures
+
+- [ ] **Step 2: Lint check**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: Clean
+
+- [ ] **Step 3: Verify dashboard after auto-close (manual)**
+
+Run: `uv run ec session backfill-ended-at --max-age-hours 1 --apply` first to close existing stale sessions, then:
+
+Run: `uv run ec dashboard`
+Expected: maturity score reflects corrected denominators
+
+- [ ] **Step 4: Verify verdict accuracy (manual)**
+
+Run: `uv run ec checkpoint assess-accuracy`
+Expected: shows current accuracy data
+
+- [ ] **Step 5: Update CHANGELOG.md**
+
+Add under `## [Unreleased]` (or create `## [0.8.1]` section):
+
+```markdown
+## [0.8.1] - Measurement Accuracy
+
+### Fixed
+- Codex sessions auto-closed on notify ingestion (stale > 60min idle)
+- `retrieval_assisted_session_rate` denominator changed from all sessions to ended sessions only, consistent with `checkpoint_coverage_rate`
+
+### Added
+- `ec checkpoint assess-accuracy` — verdict accuracy baseline from enrichment feedback
+- `close_stale_sessions()` in `core/session.py` — reusable auto-close with optimistic concurrency
+- Config: `[capture] codex_session_idle_minutes` (default 60)
+```
+
+- [ ] **Step 6: Update ROADMAP.md**
+
+Mark v0.8.1 items as completed:
+
+```markdown
+## v0.8.1 — Measurement Accuracy (Shipped YYYY-MM-DD)
+
+- [x] **Codex session auto-close** — ...
+- [x] **Maturity calculation normalization** — ...
+- [x] **Verdict accuracy baseline** — ...
+```
+
+- [ ] **Step 7: Commit docs**
+
+```bash
+git add CHANGELOG.md ROADMAP.md
+git commit -m "docs: v0.8.1 changelog and roadmap updates"
+```
+
+---
+
+## Unresolved Questions
+
+1. **42 codex sessions have retrieval events — how?** `codex_ingest.py` doesn't create retrieval events. These may originate from PDI hooks that fire in the same repo and coincidentally use codex session IDs, or from manual `ec search` commands during codex sessions. Understanding the source would clarify whether codex sessions should contribute to `retrieval_sessions_total` or be filtered out entirely. **Impact on this plan:** low — the denominator fix (ended sessions) is correct regardless.
+
+2. **Enrichment sample size (n=10) too small for statistical confidence.** The accuracy baseline infrastructure is correct, but the number will only become meaningful after more assessments are enriched. **Mitigation:** v0.9.0's verdict tuning should gate on n≥30 before making mapping changes.

--- a/docs/superpowers/plans/2026-06-08-intervene-automation.md
+++ b/docs/superpowers/plans/2026-06-08-intervene-automation.md
@@ -1,0 +1,1070 @@
+# v0.9.0 Intervene Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automate the weakest maturity dimension (intervene=5) so the `capture→distill→retrieve→intervene` loop can close without manual `ec_context_apply`. Maturity ≥75 is a measurement outcome, not a code target — leave unchecked (per v0.8.0 lesson).
+
+**Architecture:** SessionEnd hook detects file-overlap between surfaced decisions and session-modified files, auto-records `context_application` + `accepted` outcome. Both writes are atomic (single transaction). A backfill command bootstraps historical data. Measurement fixes (search_to_selection_rate DISTINCT) and Signal C activation ship alongside.
+
+**Tech Stack:** Python 3.12+, SQLite (WAL, autocommit), Typer CLI, pytest
+
+**Maturity gap analysis:**
+
+| Dimension | Current | Max | Gap |
+|-----------|---------|-----|-----|
+| capture | 22 | 30 | 8 |
+| distill | 25 | 25 | 0 |
+| retrieve | 17 | 25 | 8 |
+| intervene | 5 | 20 | 15 |
+| **Total** | **69** | **100** | — |
+
+Auto-apply targets `applied_context_rate >= 0.1` (currently 0.011, threshold +8 pts). Ceiling query: 154 candidate (session, decision) pairs vs 48 needed — feasible from historical data, but actual overlap filtering will reduce it.
+
+`lesson_reuse_rate` has no automated path in v0.9.0 (auto-apply creates `source_type='decision'`, not assessment/lesson). BUT not blocking: intervene=13 (5+8) → total 77 ≥ 75 Closed Loop without lesson reuse.
+
+Verdict mapping tuning deferred: `compute_verdict_accuracy()` counts 0 new-format enrichments (10 old gpt-4o-mini exist but use free-text reason, excluded by `LIKE 'auto:%'` filter). Running `ec futures enrich-backlog` on 8 pending rule-based assessments would produce new-format data, but still under n≥30 gate.
+
+**NOTE on outcome type:** File-overlap is weaker evidence than explicit `ec_context_apply`. The project boundary ("outcome attribution, not behavior judgment") accepts this tradeoff — the agent modified files that a surfaced decision references. False positives are possible (agent may have contradicted the decision). This is a conscious design choice: activating the intervene dimension with imperfect signal is preferable to leaving it at zero with no signal.
+
+**NOTE on Signal C model load:** Flipping `auto_embed=True` means `create_decision()` calls `generate_embeddings(decisions_only=True)` on every decision creation, which loads a SentenceTransformer model. `create_decision` is NOT on any hook hot path — it's called from CLI/MCP explicit commands and candidate confirmation. Acceptable for v0.9.0; 2-pass async batching deferred.
+
+**Callers of modified functions:**
+
+| Function | Callers |
+|----------|---------|
+| `dashboard.compute_dashboard()` | `cli/dashboard_cmds.py`, `mcp/tools/dashboard.py`, `cli/repo_cmds.py` |
+| `session_lifecycle.on_session_end()` | `hooks/handler.py` (SessionEnd dispatch) |
+| `session.close_stale_sessions()` | `hooks/codex_ingest.py` (after ingest) |
+| `telemetry.record_context_application()` | `mcp/tools/session.py`, `cli/context_cmds.py` |
+| `decisions.record_decision_outcome()` | `mcp/tools/decision.py`, `cli/decision_cmds.py`, `hooks/session_lifecycle.py` |
+| `config.DEFAULT_CONFIG` | `config.load_config()` → all hook/core callers |
+
+**Invariants:**
+
+1. `_rate` metrics in dashboard MUST be in [0, 1] range
+2. Auto-apply MUST run BEFORE ignored inference — applied decisions must not be double-marked as ignored
+3. `record_decision_outcome` requires a valid `decision_id` that exists in the decisions table
+4. `record_context_application` requires valid `selection_id` when provided, and `application_type` in `VALID_APPLICATION_TYPES`
+5. Codex sessions never call `on_session_end()` — only Claude Code sessions do. Codex stale cleanup uses idle-timeout heuristic triggered separately.
+6. `generate_embeddings()` raises `ImportError` when `sentence-transformers` is not installed — `create_decision()` wraps this in bare except
+
+**Prior retro carry-forward coverage:**
+
+| v0.8.1 retro item | Task |
+|--------------------|------|
+| search_to_selection_rate DISTINCT fix | A |
+| Dashboard _rate metrics audit | A (guard test) |
+| SessionEnd codex stale cleanup trigger expansion | B |
+| Duplicate notify regression test | D |
+| Decision record enforcement mechanism | Deferred (needs hook-based gate design) |
+| SessionEnd auto apply inference | B + C |
+| Reopen → sessions_ended non-monotonic | Deferred (measurement study, not code) |
+
+---
+
+### Task A: search_to_selection_rate DISTINCT Fix
+
+**Files:**
+- Modify: `src/entirecontext/core/dashboard.py:166-204`
+- Modify: `tests/test_dashboard.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create a test that seeds multiple selections per event and asserts the rate is a fraction in [0,1].
+
+```python
+# tests/test_dashboard.py — add to existing file
+
+def test_search_to_selection_rate_distinct_events(ec_db, ec_repo):
+    """search_to_selection_rate must be DISTINCT events with >=1 selection / total events."""
+    conn = ec_db
+    from entirecontext.core.session import create_session
+    from entirecontext.core.turn import create_turn
+    from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
+
+    project = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()
+    session = create_session(conn, project_id=project["id"])
+    turn = create_turn(conn, session_id=session["id"], turn_number=1, user_message="test")
+
+    # Event 1: 3 selections (same event)
+    ev1 = record_retrieval_event(conn, source="hook", search_type="session_start", target="decisions",
+                                  query="test", result_count=3, latency_ms=10,
+                                  session_id=session["id"], turn_id=turn["id"])
+    for i in range(3):
+        record_retrieval_selection(conn, ev1["id"], "decision", f"d{i}",
+                                    session_id=session["id"], turn_id=turn["id"])
+
+    # Event 2: 0 selections
+    record_retrieval_event(conn, source="hook", search_type="user_prompt", target="decisions",
+                           query="test2", result_count=0, latency_ms=5,
+                           session_id=session["id"], turn_id=turn["id"])
+
+    # Mark session ended
+    conn.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (session["id"],))
+
+    from entirecontext.core.dashboard import compute_dashboard
+    result = compute_dashboard(conn)
+    rate = result["telemetry"]["rates"]["search_to_selection_rate"]
+
+    # 1 event with selections / 2 total events = 0.5
+    assert rate == 0.5, f"Expected 0.5, got {rate}"
+    assert 0.0 <= rate <= 1.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dashboard.py::test_search_to_selection_rate_distinct_events -v`
+Expected: FAIL — current formula returns 3/2 = 1.5
+
+- [ ] **Step 3: Fix dashboard.py — replace total selections / total events with DISTINCT events**
+
+```python
+# src/entirecontext/core/dashboard.py — replace lines 182-204
+
+    retrieval_selections_total = (
+        conn.execute(
+            f"SELECT COUNT(*) AS total FROM retrieval_selections{since_clause_ca}",
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+
+    events_with_selection = (
+        conn.execute(
+            "SELECT COUNT(DISTINCT re.id) AS total"
+            " FROM retrieval_events re"
+            " JOIN retrieval_selections rs ON rs.retrieval_event_id = re.id"
+            + (f" WHERE re.created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+
+    # ... keep existing applications_row query ...
+
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_ended if sessions_ended > 0 else 0.0
+    search_to_selection_rate = (
+        events_with_selection / retrieval_events_total if retrieval_events_total > 0 else 0.0
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_dashboard.py::test_search_to_selection_rate_distinct_events -v`
+Expected: PASS
+
+- [ ] **Step 5: Add _rate range guard test**
+
+```python
+def test_all_rate_metrics_in_unit_range(ec_db, ec_repo):
+    """All _rate metrics must be in [0, 1] range."""
+    conn = ec_db
+    from entirecontext.core.session import create_session
+    from entirecontext.core.turn import create_turn
+    from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
+
+    project = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()
+    session = create_session(conn, project_id=project["id"])
+    turn = create_turn(conn, session_id=session["id"], turn_number=1, user_message="test")
+    ev = record_retrieval_event(conn, source="hook", search_type="session_start", target="decisions",
+                                 query="q", result_count=10, latency_ms=10,
+                                 session_id=session["id"], turn_id=turn["id"])
+    for i in range(10):
+        record_retrieval_selection(conn, ev["id"], "decision", f"d{i}",
+                                    session_id=session["id"], turn_id=turn["id"])
+    conn.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (session["id"],))
+
+    from entirecontext.core.dashboard import compute_dashboard
+    result = compute_dashboard(conn)
+    rate_keys = [
+        "retrieval_assisted_session_rate",
+        "search_to_selection_rate",
+        "applied_context_rate",
+        "lesson_reuse_rate",
+        "checkpoint_anchored_assessment_rate",
+    ]
+    for key in rate_keys:
+        val = result["telemetry"]["rates"][key]
+        assert 0.0 <= val <= 1.0, f"{key} = {val} is outside [0, 1]"
+```
+
+- [ ] **Step 6: Run full test suite for dashboard**
+
+Run: `uv run pytest tests/test_dashboard.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entirecontext/core/dashboard.py tests/test_dashboard.py
+git commit -m "fix(dashboard): use DISTINCT event count for search_to_selection_rate
+
+The metric was computed as total_selections / total_events (541/191 = 2.83),
+which exceeds 1.0. Correct formula: DISTINCT events with ≥1 selection /
+total events = [0, 1] fraction. Maturity scoring threshold (≥0.25) happens
+to be unchanged but the semantic bug is fixed.
+
+Adds guard test asserting all _rate metrics stay in [0, 1] range."
+```
+
+---
+
+### Task B: SessionEnd Auto-Apply Inference
+
+**Files:**
+- Create: `src/entirecontext/core/auto_apply.py`
+- Modify: `src/entirecontext/hooks/session_lifecycle.py:281-290`
+- Modify: `src/entirecontext/core/config.py:73-95`
+- Create: `tests/test_auto_apply.py`
+
+**Design notes:**
+- Runs on SessionEnd, BEFORE `_maybe_infer_ignored_decisions` (ordering invariant #2)
+- For each decision surfaced via PDI in this session, check if session-modified files overlap with `decision_files`
+- If overlap found: record `context_application` (type `decision_change`) + `accepted` outcome
+- The `accepted` outcome prevents ignored inference from double-marking
+- Also adds `close_stale_sessions` call on SessionEnd (codex stale cleanup trigger expansion)
+
+- [ ] **Step 1: Write the core inference function test**
+
+```python
+# tests/test_auto_apply.py
+
+import pytest
+
+from entirecontext.core.session import create_session
+from entirecontext.core.turn import create_turn
+from entirecontext.core.decisions import create_decision, link_decision_to_file, record_decision_outcome
+from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
+
+
+@pytest.fixture
+def auto_apply_setup(ec_db, ec_repo):
+    """Seed: 1 session, 1 turn with files_touched, 1 decision linked to overlapping file, 1 surfaced selection."""
+    conn = ec_db
+    project = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()
+    project_id = project["id"]
+
+    session = create_session(conn, project_id=project_id, session_type="claude")
+    conn.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (session["id"],))
+
+    turn = create_turn(conn, session_id=session["id"], turn_number=1, user_message="implement feature",
+                       files_touched='["src/core/foo.py", "src/core/bar.py"]')
+
+    decision = create_decision(conn, title="Use foo pattern", rationale="Because reasons")
+    link_decision_to_file(conn, decision["id"], "src/core/foo.py")
+
+    ev = record_retrieval_event(conn, source="hook", search_type="user_prompt", target="decisions",
+                                 query="test", result_count=1, latency_ms=10,
+                                 session_id=session["id"], turn_id=turn["id"])
+    sel = record_retrieval_selection(conn, ev["id"], "decision", decision["id"],
+                                      session_id=session["id"], turn_id=turn["id"])
+
+    return {
+        "conn": conn,
+        "session_id": session["id"],
+        "turn_id": turn["id"],
+        "decision_id": decision["id"],
+        "event_id": ev["id"],
+        "selection_id": sel["id"],
+    }
+
+
+def test_infer_applied_creates_application_and_outcome(auto_apply_setup):
+    s = auto_apply_setup
+    from entirecontext.core.auto_apply import infer_applied_decisions
+
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+
+    assert result["applied_count"] == 1
+    assert result["applied_decisions"][0]["decision_id"] == s["decision_id"]
+
+    app = s["conn"].execute(
+        "SELECT * FROM context_applications WHERE session_id = ?", (s["session_id"],)
+    ).fetchone()
+    assert app is not None
+    assert app["application_type"] == "decision_change"
+    assert app["source_type"] == "decision"
+    assert app["source_id"] == s["decision_id"]
+    assert app["retrieval_selection_id"] == s["selection_id"]
+
+    outcome = s["conn"].execute(
+        "SELECT * FROM decision_outcomes WHERE decision_id = ? AND session_id = ?",
+        (s["decision_id"], s["session_id"]),
+    ).fetchone()
+    assert outcome is not None
+    assert outcome["outcome_type"] == "accepted"
+    assert "auto: session_end file_overlap" in outcome["note"]
+
+
+def test_infer_applied_atomicity_both_or_neither(auto_apply_setup, monkeypatch):
+    """If outcome write fails, application must also be rolled back."""
+    s = auto_apply_setup
+    from entirecontext.core import auto_apply as mod
+
+    original_record = mod.record_decision_outcome
+    def failing_record(*args, **kwargs):
+        raise RuntimeError("simulated outcome failure")
+    monkeypatch.setattr(mod, "record_decision_outcome", failing_record)
+
+    from entirecontext.core.auto_apply import infer_applied_decisions
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+    assert result["applied_count"] == 0
+
+    apps = s["conn"].execute(
+        "SELECT COUNT(*) FROM context_applications WHERE session_id = ?", (s["session_id"],)
+    ).fetchone()[0]
+    assert apps == 0, "Application must not persist when outcome write fails"
+
+
+def test_infer_applied_skips_existing_outcome(auto_apply_setup):
+    s = auto_apply_setup
+    record_decision_outcome(s["conn"], s["decision_id"], outcome_type="ignored",
+                            session_id=s["session_id"], note="manual")
+
+    from entirecontext.core.auto_apply import infer_applied_decisions
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+    assert result["applied_count"] == 0
+
+
+def test_infer_applied_skips_no_file_overlap(auto_apply_setup):
+    s = auto_apply_setup
+    s["conn"].execute("DELETE FROM decision_files WHERE decision_id = ?", (s["decision_id"],))
+    link_decision_to_file(s["conn"], s["decision_id"], "unrelated/path.py")
+
+    from entirecontext.core.auto_apply import infer_applied_decisions
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+    assert result["applied_count"] == 0
+
+
+def test_infer_applied_deduplicates_across_turns(auto_apply_setup):
+    s = auto_apply_setup
+    turn2 = create_turn(s["conn"], session_id=s["session_id"], turn_number=2, user_message="continue",
+                        files_touched='["src/core/foo.py"]')
+    ev2 = record_retrieval_event(s["conn"], source="hook", search_type="user_prompt", target="decisions",
+                                  query="test2", result_count=1, latency_ms=5,
+                                  session_id=s["session_id"], turn_id=turn2["id"])
+    record_retrieval_selection(s["conn"], ev2["id"], "decision", s["decision_id"],
+                                session_id=s["session_id"], turn_id=turn2["id"])
+
+    from entirecontext.core.auto_apply import infer_applied_decisions
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+    assert result["applied_count"] == 1
+
+    apps = s["conn"].execute(
+        "SELECT COUNT(*) FROM context_applications WHERE session_id = ? AND source_id = ?",
+        (s["session_id"], s["decision_id"]),
+    ).fetchone()[0]
+    assert apps == 1
+
+
+def test_infer_applied_dry_run_writes_nothing(auto_apply_setup):
+    """dry_run=True must detect overlaps but not persist any records."""
+    s = auto_apply_setup
+    from entirecontext.core.auto_apply import infer_applied_decisions
+
+    result = infer_applied_decisions(s["conn"], s["session_id"], dry_run=True)
+    assert result["applied_count"] == 1
+
+    apps = s["conn"].execute(
+        "SELECT COUNT(*) FROM context_applications WHERE session_id = ?", (s["session_id"],)
+    ).fetchone()[0]
+    assert apps == 0
+
+    outcomes = s["conn"].execute(
+        "SELECT COUNT(*) FROM decision_outcomes WHERE session_id = ?", (s["session_id"],)
+    ).fetchone()[0]
+    assert outcomes == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_auto_apply.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'entirecontext.core.auto_apply'`
+
+- [ ] **Step 3: Implement `core/auto_apply.py`**
+
+```python
+# src/entirecontext/core/auto_apply.py
+"""SessionEnd auto-apply inference: detect file overlap between surfaced decisions and session-modified files."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import PurePosixPath
+
+
+def _collect_session_modified_files(conn: sqlite3.Connection, session_id: str) -> set[str]:
+    rows = conn.execute(
+        "SELECT files_touched FROM turns WHERE session_id = ? AND files_touched IS NOT NULL",
+        (session_id,),
+    ).fetchall()
+    paths: set[str] = set()
+    for row in rows:
+        raw = row["files_touched"]
+        if not raw or raw.strip() in ("", "[]"):
+            continue
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                for p in parsed:
+                    if isinstance(p, str) and p.strip():
+                        paths.add(str(PurePosixPath(p.strip())))
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return paths
+
+
+def _detect_overlapping_decisions(
+    conn: sqlite3.Connection,
+    session_id: str,
+) -> list[dict]:
+    """Pure detection: find surfaced decisions with file overlap. No writes."""
+    modified_files = _collect_session_modified_files(conn, session_id)
+    if not modified_files:
+        return []
+
+    rows = conn.execute(
+        """
+        SELECT rs.id AS selection_id, rs.result_id AS decision_id, rs.turn_id
+        FROM retrieval_selections rs
+        JOIN retrieval_events re ON re.id = rs.retrieval_event_id
+        WHERE rs.session_id = ?
+          AND rs.result_type = 'decision'
+          AND NOT EXISTS (
+              SELECT 1 FROM decision_outcomes do
+              WHERE do.decision_id = rs.result_id
+                AND do.session_id = ?
+          )
+        ORDER BY rs.result_id, rs.created_at ASC
+        """,
+        (session_id, session_id),
+    ).fetchall()
+
+    seen: set[str] = set()
+    matches: list[dict] = []
+
+    for row in rows:
+        decision_id = row["decision_id"]
+        if decision_id in seen:
+            continue
+        seen.add(decision_id)
+
+        decision_files_rows = conn.execute(
+            "SELECT file_path FROM decision_files WHERE decision_id = ?",
+            (decision_id,),
+        ).fetchall()
+        decision_paths = {r["file_path"] for r in decision_files_rows}
+
+        overlap = modified_files & decision_paths
+        if not overlap:
+            continue
+
+        matches.append({
+            "decision_id": decision_id,
+            "selection_id": row["selection_id"],
+            "turn_id": row["turn_id"],
+            "overlap_files": sorted(overlap),
+        })
+
+    return matches
+
+
+def infer_applied_decisions(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    dry_run: bool = False,
+) -> dict:
+    matches = _detect_overlapping_decisions(conn, session_id)
+    if not matches or dry_run:
+        return {"applied_count": len(matches), "applied_decisions": matches}
+
+    from .context import transaction
+    from .telemetry import record_context_application
+    from .decisions import record_decision_outcome
+
+    applied: list[dict] = []
+
+    for match in matches:
+        note = f"auto: session_end file_overlap ({', '.join(match['overlap_files'][:3])})"
+        with transaction(conn):
+            record_context_application(
+                conn,
+                application_type="decision_change",
+                selection_id=match["selection_id"],
+                session_id=session_id,
+                turn_id=match["turn_id"],
+                note=note,
+            )
+            record_decision_outcome(
+                conn,
+                match["decision_id"],
+                outcome_type="accepted",
+                retrieval_selection_id=match["selection_id"],
+                session_id=session_id,
+                turn_id=match["turn_id"],
+                note=note,
+            )
+        applied.append(match)
+
+    return {"applied_count": len(applied), "applied_decisions": applied}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_auto_apply.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Add config key**
+
+```python
+# src/entirecontext/core/config.py — add to decisions section (after "infer_ignored_on_session_end")
+        "infer_applied_on_session_end": True,
+```
+
+- [ ] **Step 6: Wire into SessionEnd hook**
+
+```python
+# src/entirecontext/hooks/session_lifecycle.py — add _maybe_infer_applied_decisions BEFORE _maybe_infer_ignored_decisions
+
+def _maybe_infer_applied_decisions(repo_path: str, session_id: str) -> None:
+    """Infer 'accepted' outcome for decisions with file overlap. Config-gated."""
+    try:
+        from ..core.config import load_config
+
+        config = load_config(repo_path)
+        if not config.get("decisions", {}).get("infer_applied_on_session_end", True):
+            return
+
+        from ..core.auto_apply import infer_applied_decisions
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            infer_applied_decisions(conn, session_id)
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "infer_applied_decisions", exc)
+```
+
+In `on_session_end()`, insert the call BEFORE `_maybe_infer_ignored_decisions`:
+
+```python
+    _maybe_infer_applied_decisions(repo_path, session_id)
+    _maybe_infer_ignored_decisions(repo_path, session_id)
+```
+
+- [ ] **Step 7: Add codex stale cleanup trigger in SessionEnd**
+
+```python
+# src/entirecontext/hooks/session_lifecycle.py — add to on_session_end(), after the _maybe_* calls
+
+def _maybe_close_stale_codex_sessions(repo_path: str) -> None:
+    """Trigger codex session auto-close from SessionEnd as additional trigger surface."""
+    try:
+        from ..core.config import load_config
+        from ..core.session import close_stale_sessions
+        from ..db import get_db
+
+        config = load_config(repo_path)
+        idle_minutes = config["capture"]["codex_session_idle_minutes"]
+
+        conn = get_db(repo_path)
+        try:
+            close_stale_sessions(conn, idle_minutes=idle_minutes, session_type="codex")
+        finally:
+            conn.close()
+    except Exception as exc:
+        _record_hook_warning(repo_path, "close_stale_codex_sessions", exc)
+```
+
+Add to the `on_session_end` call chain:
+
+```python
+    _maybe_close_stale_codex_sessions(repo_path)
+    _maybe_emit_aar(repo_path, session_id)
+```
+
+- [ ] **Step 8: Write integration test for hook ordering**
+
+```python
+# tests/test_auto_apply.py — add (already included in auto_apply_setup fixture block above)
+
+def test_auto_apply_prevents_ignored_double_marking(auto_apply_setup):
+    """Applied decisions must not also be marked as ignored."""
+    s = auto_apply_setup
+    from entirecontext.core.auto_apply import infer_applied_decisions
+
+    result = infer_applied_decisions(s["conn"], s["session_id"])
+    assert result["applied_count"] == 1
+
+    # Simulate ignored inference query (same as _maybe_infer_ignored_decisions)
+    remaining = s["conn"].execute(
+        """
+        SELECT rs.result_id AS decision_id
+        FROM retrieval_selections rs
+        JOIN retrieval_events re ON re.id = rs.retrieval_event_id
+        WHERE rs.session_id = ?
+          AND rs.result_type = 'decision'
+          AND NOT EXISTS (
+              SELECT 1 FROM decision_outcomes do
+              WHERE do.decision_id = rs.result_id
+                AND do.session_id = ?
+          )
+        """,
+        (s["session_id"], s["session_id"]),
+    ).fetchall()
+
+    decision_ids = {r["decision_id"] for r in remaining}
+    assert s["decision_id"] not in decision_ids
+```
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `uv run pytest tests/test_auto_apply.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/entirecontext/core/auto_apply.py src/entirecontext/core/config.py \
+  src/entirecontext/hooks/session_lifecycle.py tests/test_auto_apply.py
+git commit -m "feat(intervene): SessionEnd auto-apply inference for file-overlap decisions
+
+On SessionEnd, check intersection of surfaced decision files and
+session-modified files. When overlap is detected, auto-record
+context_application (decision_change) + accepted outcome. Runs BEFORE
+ignored inference so applied decisions are not double-marked.
+
+Config: decisions.infer_applied_on_session_end (default true).
+
+Also adds close_stale_codex_sessions trigger on SessionEnd (retro
+carry-forward: codex stale cleanup trigger expansion)."
+```
+
+---
+
+### Task C: Auto-Apply Backfill Command
+
+**Files:**
+- Modify: `src/entirecontext/cli/session_cmds.py`
+- Create: `tests/test_auto_apply_backfill.py`
+
+**Design:** Iterate over ended sessions with retrieval events, run `infer_applied_decisions()` per session, report results. Pattern follows `ec session backfill-ended-at`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_auto_apply_backfill.py
+
+from typer.testing import CliRunner
+from entirecontext.cli.main import app
+
+runner = CliRunner()
+
+
+def test_backfill_applied_dry_run(ec_db, ec_repo, monkeypatch):
+    conn = ec_db
+    conn.execute("INSERT INTO projects (id, name, repo_path) VALUES ('p1', 'test', ?)", (ec_repo,))
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, started_at, ended_at, last_activity_at)"
+        " VALUES ('s1', 'p1', 'claude', datetime('now', '-2 hours'), datetime('now', '-1 hour'), datetime('now', '-1 hour'))"
+    )
+    conn.execute(
+        "INSERT INTO turns (id, session_id, turn_number, user_message, files_touched)"
+        " VALUES ('t1', 's1', 1, 'fix bug', '[\"src/core/foo.py\"]')"
+    )
+    conn.execute(
+        "INSERT INTO decisions (id, title, rationale, created_at)"
+        " VALUES ('d1', 'Foo pattern', 'Reasons', datetime('now', '-7 days'))"
+    )
+    conn.execute("INSERT INTO decision_files (decision_id, file_path) VALUES ('d1', 'src/core/foo.py')")
+    conn.execute(
+        "INSERT INTO retrieval_events (id, session_id, turn_id, search_type, search_query, created_at)"
+        " VALUES ('re1', 's1', 't1', 'user_prompt', 'q', datetime('now', '-90 minutes'))"
+    )
+    conn.execute(
+        "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, turn_id, result_type, result_id, created_at)"
+        " VALUES ('rs1', 're1', 's1', 't1', 'decision', 'd1', datetime('now', '-90 minutes'))"
+    )
+    conn.close()
+
+    result = runner.invoke(app, ["session", "backfill-applied", "--dry-run"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "1 session" in result.output.lower() or "1" in result.output
+    assert "dry run" in result.output.lower() or "dry" in result.output.lower()
+
+
+def test_backfill_applied_apply(ec_db, ec_repo, monkeypatch):
+    conn = ec_db
+    conn.execute("INSERT INTO projects (id, name, repo_path) VALUES ('p1', 'test', ?)", (ec_repo,))
+    conn.execute(
+        "INSERT INTO sessions (id, project_id, session_type, started_at, ended_at, last_activity_at)"
+        " VALUES ('s1', 'p1', 'claude', datetime('now', '-2 hours'), datetime('now', '-1 hour'), datetime('now', '-1 hour'))"
+    )
+    conn.execute(
+        "INSERT INTO turns (id, session_id, turn_number, user_message, files_touched)"
+        " VALUES ('t1', 's1', 1, 'fix bug', '[\"src/core/foo.py\"]')"
+    )
+    conn.execute(
+        "INSERT INTO decisions (id, title, rationale, created_at)"
+        " VALUES ('d1', 'Foo pattern', 'Reasons', datetime('now', '-7 days'))"
+    )
+    conn.execute("INSERT INTO decision_files (decision_id, file_path) VALUES ('d1', 'src/core/foo.py')")
+    conn.execute(
+        "INSERT INTO retrieval_events (id, session_id, turn_id, search_type, search_query, created_at)"
+        " VALUES ('re1', 's1', 't1', 'user_prompt', 'q', datetime('now', '-90 minutes'))"
+    )
+    conn.execute(
+        "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, turn_id, result_type, result_id, created_at)"
+        " VALUES ('rs1', 're1', 's1', 't1', 'decision', 'd1', datetime('now', '-90 minutes'))"
+    )
+
+    from entirecontext.db import get_db
+    monkeypatch.setattr("entirecontext.cli.session_cmds._get_repo_path", lambda: ec_repo)
+
+    result = runner.invoke(app, ["session", "backfill-applied", "--apply"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    reconn = get_db(ec_repo)
+    try:
+        app_count = reconn.execute(
+            "SELECT COUNT(*) FROM context_applications WHERE session_id = 's1'"
+        ).fetchone()[0]
+        assert app_count == 1
+    finally:
+        reconn.close()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_auto_apply_backfill.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the CLI command**
+
+```python
+# src/entirecontext/cli/session_cmds.py — add to existing session command group
+
+@session_app.command("backfill-applied")
+def session_backfill_applied(
+    dry_run: bool = typer.Option(True, "--dry-run/--apply", help="Preview without changes (default) or apply."),
+):
+    """Retroactively infer applied decisions for ended sessions with retrieval events.
+
+    Detects file overlap between surfaced decisions and session-modified files.
+    Safe default is --dry-run; pass --apply to commit changes.
+    """
+    from ..core.project import find_git_root, get_project
+    from ..db import get_db
+    from ..core.auto_apply import infer_applied_decisions
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    project = get_project(repo_path)
+    if not project:
+        console.print("[yellow]Not initialized. Run 'ec init'.[/yellow]")
+        raise typer.Exit(1)
+
+    conn = get_db(repo_path)
+    try:
+        session_ids = [
+            r[0]
+            for r in conn.execute(
+                """
+                SELECT DISTINCT s.id
+                FROM sessions s
+                JOIN retrieval_events re ON re.session_id = s.id
+                JOIN retrieval_selections rs ON rs.retrieval_event_id = re.id
+                                             AND rs.result_type = 'decision'
+                WHERE s.ended_at IS NOT NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM context_applications ca
+                      WHERE ca.session_id = s.id
+                        AND ca.note LIKE 'auto: session_end file_overlap%'
+                  )
+                """
+            ).fetchall()
+        ]
+
+        if not session_ids:
+            console.print("[dim]No eligible sessions found.[/dim]")
+            return
+
+        total_applied = 0
+        sessions_with_applies = 0
+
+        for sid in session_ids:
+            result = infer_applied_decisions(conn, sid, dry_run=dry_run)
+            if result["applied_count"] > 0:
+                sessions_with_applies += 1
+                total_applied += result["applied_count"]
+
+        mode = "Dry run" if dry_run else "Applied"
+        console.print(
+            f"[bold]{mode}: {total_applied} applications across "
+            f"{sessions_with_applies}/{len(session_ids)} sessions[/bold]"
+        )
+        if dry_run:
+            console.print("[dim]Use --apply to commit changes.[/dim]")
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_auto_apply_backfill.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/cli/session_cmds.py tests/test_auto_apply_backfill.py
+git commit -m "feat(cli): ec session backfill-applied for historical auto-apply
+
+Retroactively runs auto-apply inference on ended sessions with retrieval
+events. Bootstraps context_applications from historical PDI data.
+Options: --dry-run (preview) or --apply (write)."
+```
+
+---
+
+### Task D: Duplicate Notify Regression Test
+
+**Files:**
+- Modify: `tests/test_codex_ingest.py`
+
+- [ ] **Step 1: Write the regression test**
+
+```python
+# tests/test_codex_ingest.py — add to existing file
+
+def test_duplicate_notify_does_not_refresh_last_activity_at(ec_db, ec_repo, tmp_path):
+    """Commit 150faab: duplicate notify events must not update last_activity_at."""
+    import json
+    import time
+
+    notify_data = {
+        "meta": {"session_id": "dup-test", "cwd": ec_repo},
+        "turns": [
+            {"user_message": "hello", "assistant_summary": "world", "timestamp": "2026-01-01T00:00:00Z"}
+        ],
+    }
+    notify_file = tmp_path / "notify.json"
+    notify_file.write_text(json.dumps(notify_data))
+
+    from entirecontext.hooks.codex_ingest import ingest_codex_notify_event
+
+    # First ingest
+    ingest_codex_notify_event(str(notify_file), ec_repo)
+
+    from entirecontext.db import get_db
+    conn = get_db(ec_repo)
+    try:
+        row1 = conn.execute(
+            "SELECT last_activity_at, total_turns FROM sessions WHERE id = 'dup-test'"
+        ).fetchone()
+        assert row1 is not None
+        assert row1["total_turns"] == 1
+        first_activity = row1["last_activity_at"]
+    finally:
+        conn.close()
+
+    time.sleep(0.05)
+
+    # Second ingest with same data — duplicate
+    ingest_codex_notify_event(str(notify_file), ec_repo)
+
+    conn = get_db(ec_repo)
+    try:
+        row2 = conn.execute(
+            "SELECT last_activity_at, total_turns FROM sessions WHERE id = 'dup-test'"
+        ).fetchone()
+        assert row2["total_turns"] == 1, "Turn count should not change on duplicate"
+        assert row2["last_activity_at"] == first_activity, "last_activity_at must not change on duplicate"
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_codex_ingest.py::test_duplicate_notify_does_not_refresh_last_activity_at -v`
+Expected: PASS (the fix from 150faab should already handle this)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_codex_ingest.py
+git commit -m "test(codex): regression test for duplicate notify skip (150faab)
+
+Verifies that calling ingest_codex_notify_event twice with the same event
+does not update last_activity_at or increment total_turns. Guards the
+auto-close accuracy invariant."
+```
+
+---
+
+### Task E: Signal C Config Activation
+
+**Files:**
+- Modify: `src/entirecontext/core/config.py:126`
+- Modify: `tests/test_decision_embedding.py`
+
+- [ ] **Step 1: Write failing test for default-on behavior**
+
+```python
+# tests/test_decision_embedding.py — add to existing file
+
+def test_auto_embed_default_is_true():
+    """Signal C activation: auto_embed should default to True in v0.9.0."""
+    from entirecontext.core.config import DEFAULT_CONFIG
+    assert DEFAULT_CONFIG["decisions"]["auto_embed"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_decision_embedding.py::test_auto_embed_default_is_true -v`
+Expected: FAIL — current default is False
+
+- [ ] **Step 3: Flip the config default**
+
+```python
+# src/entirecontext/core/config.py line 126 — change:
+        "auto_embed": False,
+# to:
+        "auto_embed": True,
+```
+
+- [ ] **Step 4: Write test for graceful fallback without sentence-transformers**
+
+```python
+# tests/test_decision_embedding.py — add
+
+def test_create_decision_auto_embed_graceful_without_transformers(ec_db, ec_repo, monkeypatch):
+    """auto_embed=True must not crash create_decision when sentence-transformers is missing."""
+    import builtins
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise ImportError("mocked: no sentence_transformers")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    from entirecontext.core.decisions import create_decision
+
+    result = create_decision(
+        ec_db,
+        title="Test decision",
+        rationale="Test rationale",
+        repo_path=ec_repo,
+    )
+    assert result["title"] == "Test decision"
+
+    embed_count = ec_db.execute(
+        "SELECT COUNT(*) FROM embeddings WHERE source_type = 'decision'"
+    ).fetchone()[0]
+    assert embed_count == 0
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_decision_embedding.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/config.py tests/test_decision_embedding.py
+git commit -m "feat(signal-c): flip auto_embed default to True
+
+Decisions are now auto-embedded on creation when sentence-transformers
+is available. Gracefully falls back (no-op) when the semantic extra is
+not installed. Foundation for future 2-pass async ranking."
+```
+
+---
+
+### Task F: ROADMAP + CHANGELOG
+
+**Files:**
+- Modify: `ROADMAP.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update ROADMAP.md v0.9.0 section**
+
+Replace the current v0.9.0 section with checked items:
+
+```markdown
+## v0.9.0 — Intervene Automation (Shipped YYYY-MM-DD)
+
+Theme: automate the weakest maturity dimension (intervene=5), activate deferred signal depth, and fix measurement gaps — all measured against v0.8.1's corrected baseline.
+
+- [x] **SessionEnd auto-apply inference** — on SessionEnd, check intersection of surfaced decision-linked files and session-modified files; auto-record `context_application` + `accepted` outcome for matches. Inverse of `_maybe_infer_ignored_decisions`. Config: `decisions.infer_applied_on_session_end` (default true).
+- [x] **Auto-apply backfill** — `ec session backfill-applied` retroactively infers applied decisions for historical sessions. Options: `--dry-run` / `--apply`.
+- [x] **search_to_selection_rate DISTINCT fix** — formula changed from `total_selections / total_events` to `DISTINCT events with ≥1 selection / total_events`. Now a proper [0,1] fraction.
+- [x] **Signal C default ON** — `[decisions] auto_embed` flipped to `true` by default. Graceful no-op without `entirecontext[semantic]`.
+- [x] **Codex stale cleanup trigger expansion** — `close_stale_sessions()` now also triggered on SessionEnd, not just codex notify ingestion.
+- [x] **Duplicate notify regression test** — guards 150faab auto-close accuracy invariant.
+- [ ] **Rule-based verdict mapping tuning** — deferred to n≥30 enriched assessments (current: n=10).
+```
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add `## [0.9.0] - Intervene Automation` section above `## [0.8.1]`:
+
+```markdown
+## [0.9.0] - Intervene Automation
+
+### Added
+
+- **SessionEnd auto-apply inference** — on SessionEnd, detects file overlap between surfaced decisions (`decision_files`) and session-modified files (`turns.files_touched`), auto-records `context_application` (type `decision_change`) and `accepted` outcome. Runs before ignored inference to prevent double-marking. Config: `decisions.infer_applied_on_session_end` (default true).
+- **`ec session backfill-applied`** — retroactive auto-apply inference for historical ended sessions with retrieval events. Options: `--dry-run` (preview), `--apply` (write).
+- **Codex stale cleanup on SessionEnd** — `close_stale_sessions()` now also fires during SessionEnd hook, expanding trigger surface beyond codex notify ingestion.
+- **Dashboard _rate metric guard test** — asserts all `_rate` metrics in `compute_dashboard()` output stay in [0, 1] range.
+- **Duplicate notify regression test** — guards commit 150faab invariant (duplicate codex notify does not refresh `last_activity_at`).
+
+### Fixed
+
+- **`search_to_selection_rate` semantic bug** — formula changed from `total_selections / total_events` (could exceed 1.0 due to 1:N selection relationship) to `DISTINCT events with ≥1 selection / total_events`, a proper [0, 1] fraction. Maturity scoring threshold (≥0.25) and current score unchanged.
+
+### Changed
+
+- **`[decisions] auto_embed`** — default flipped from `false` to `true`. Decisions are now auto-embedded on creation when `entirecontext[semantic]` is installed. Graceful no-op without the optional dependency.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ROADMAP.md CHANGELOG.md
+git commit -m "docs: v0.9.0 Intervene Automation roadmap and changelog"
+```
+
+---
+
+## Parallelization
+
+```
+Task A (measurement fix) ───┐
+Task B (auto-apply) ────────┼──> Task F (docs)
+Task C (backfill CLI) ──────┤    (sequential after A-E)
+Task D (regression test) ───┤
+Task E (Signal C config) ───┘
+```
+
+Task C depends on Task B (uses `infer_applied_decisions`). All others are independent. Config edits in Task B and E both touch `config.py` — execute B before E to avoid merge conflicts.
+
+## Verification
+
+1. `uv run pytest` — all tests pass
+2. `uv run ruff check . && uv run ruff format --check .` — lint clean
+3. `uv run ec dashboard` — verify maturity ≥69 maintained (pre-backfill)
+4. `uv run ec session backfill-applied --dry-run` — verify candidate count (ceiling: 154 pairs, expect ≥48 after overlap filter)
+5. `uv run ec session backfill-applied --apply` — bootstrap historical data
+6. `uv run ec dashboard` — measure post-backfill maturity (mechanism is the deliverable; score is a measurement outcome)

--- a/docs/superpowers/plans/2026-06-09-dev-process-conventions.md
+++ b/docs/superpowers/plans/2026-06-09-dev-process-conventions.md
@@ -1,0 +1,426 @@
+# Development Process Conventions
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish four development process guardrails: Conventional Commits CI gate, measure-first principle, ADR tracking, and mypy strict type checking (with grandfather for legacy).
+
+**Architecture:** CI workflow additions + AGENTS.md policy updates + new `docs/adr/` directory + mypy strict config in pyproject.toml with per-module overrides for legacy code.
+
+**Tech Stack:** GitHub Actions (`amannn/action-semantic-pull-request@v5`), mypy 2.1+, pyproject.toml
+
+**Callers:** CI pipeline (ci.yml), all agent workflows (AGENTS.md), contributor onboarding.
+
+**Invariants:**
+- Existing CI jobs (lint, test) must not break.
+- `uv run mypy src/entirecontext/` must pass with zero errors after changes — strict default + grandfather overrides guarantee this.
+- AGENTS.md remains the canonical policy source.
+
+**Prior retro carry-forward:** measure-first lesson from v0.8.1 retro.
+
+**Follow-up (out of scope):** Add `type-check` and `commit-lint` to branch protection required checks — repo settings change, not automatable via code.
+
+---
+
+### Task 1: Conventional Commits CI Gate
+
+**Files:**
+- Create: `.github/workflows/commit-lint.yml`
+
+- [ ] **Step 1: Create commit-lint workflow**
+
+Use `amannn/action-semantic-pull-request@v5` (1350★, validates PR titles). Since the repo uses squash-merge, PR title = final commit message.
+
+```yaml
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            ref
+            perf
+            docs
+            test
+            build
+            ci
+            chore
+            style
+            meta
+            license
+            revert
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true
+```
+
+Notes:
+- `ref` is the project convention for refactoring (not `refactor`).
+- `validateSingleCommit: true` catches single-commit PRs where GitHub suggests the commit message instead of PR title.
+- `permissions: pull-requests: read` — minimum required.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/commit-lint.yml
+git commit -m "ci: add Conventional Commits PR title validation
+
+Uses amannn/action-semantic-pull-request@v5 to enforce
+project commit types including 'ref' for refactoring."
+```
+
+---
+
+### Task 2: Measure-First Principle + ADR Workflow in AGENTS.md
+
+**Files:**
+- Modify: `AGENTS.md` — add two new sections
+
+- [ ] **Step 1: Add Measure-First Principle section**
+
+Insert after the "Dogfooding Workflow" table (after line 33, before "Decision and Lesson Reuse Policy"):
+
+```markdown
+## Measure-First Principle
+
+Before implementing any feature or behavior change:
+
+1. Define measurable success criteria (metric name, target value, measurement method).
+2. Verify the measurement infrastructure exists and works (dashboard query, test assertion, CLI command).
+3. If measurement infra is missing, build it first as a separate commit/PR.
+4. After implementation, verify the metric moved as expected.
+
+Skip only for pure documentation, config, or CI-only changes. State when skipped and why.
+
+Rationale: v0.8.1 showed that building features without pre-existing measurement leads to formula bugs that ship undetected across multiple releases.
+```
+
+- [ ] **Step 2: Add ADR Workflow section**
+
+Insert immediately after "Measure-First Principle":
+
+```markdown
+## Architecture Decision Records (ADR)
+
+Decisions with cross-cutting or long-lived impact go into `docs/adr/` using the template in `docs/adr/README.md`.
+
+### When to write an ADR
+- New module boundaries, data model changes, or public interface contracts
+- Technology or dependency choices
+- Convention or policy establishment (like this one)
+- Any decision where "why not the obvious alternative?" deserves a written answer
+
+### ADR ↔ EC Decision bridge
+- ADRs reference EC decision IDs in their footer when an EC record exists.
+- EC decisions that graduate to project-wide policy should get a companion ADR.
+- Lightweight decisions stay as EC records only; ADRs are for durable, cross-cutting policy.
+```
+
+- [ ] **Step 3: Add Spec → ADR → Plan → Code traceability note**
+
+In the existing "Commit & Pull Request Guidelines" section (line 13), append:
+
+```markdown
+- Decision traceability chain: Spec (`docs/superpowers/plans/`) → ADR (`docs/adr/`) → Plan → Code. PRs that change behavior should reference the governing ADR or EC decision.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(agents): add measure-first principle, ADR workflow, and traceability chain"
+```
+
+---
+
+### Task 3: ADR Directory Bootstrap
+
+**Files:**
+- Create: `docs/adr/README.md`
+- Create: `docs/adr/0001-adr-process.md`
+
+- [ ] **Step 1: Create ADR README with template**
+
+`docs/adr/README.md`:
+
+```markdown
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADR) for the EntireContext project.
+
+## Convention
+
+- Number sequentially: `NNNN-short-title.md`
+- Status lifecycle: `proposed` → `accepted` → (`deprecated` | `superseded by NNNN`)
+- Use the template below for new ADRs.
+
+## Template
+
+```
+# NNNN. Short Title
+
+**Status:** proposed | accepted | deprecated | superseded by [NNNN](NNNN-title.md)
+**Date:** YYYY-MM-DD
+**EC Decision:** `<id>` (if applicable)
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+```
+```
+
+- [ ] **Step 2: Create bootstrap ADR (0001)**
+
+`docs/adr/0001-adr-process.md`:
+
+```markdown
+# 0001. Use ADRs for Cross-Cutting Decisions
+
+**Status:** accepted
+**Date:** 2026-06-09
+
+## Context
+
+The project uses EntireContext's decision memory for tracking implementation decisions.
+However, durable cross-cutting policies (coding conventions, CI gates, architectural boundaries)
+need a format that is version-controlled, discoverable without tooling, and readable in plain text.
+
+## Decision
+
+Adopt Architecture Decision Records in `docs/adr/` for cross-cutting decisions.
+Lightweight implementation decisions remain as EC decision records.
+ADRs reference EC decision IDs when both exist.
+
+## Consequences
+
+- Contributors can discover project policies by browsing `docs/adr/`.
+- The ADR ↔ EC decision bridge avoids duplicate record-keeping.
+- New ADRs require a PR, adding review friction (intentional for durable decisions).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/
+git commit -m "docs(adr): bootstrap ADR directory with template and process record"
+```
+
+---
+
+### Task 4: mypy Strict with Grandfather Overrides
+
+**Files:**
+- Modify: `pyproject.toml` — add `[tool.mypy]` strict config + overrides
+- Modify: `.github/workflows/ci.yml` — add type-check job
+- Create: `docs/adr/0002-mypy-strict-gradual.md`
+
+**Key design: strict default + grandfather.** mypy runs in strict mode globally. The 79 legacy modules that currently fail get `ignore_errors = true` overrides. New files are strict from day one. The override list shrinks over time as modules are annotated.
+
+- [ ] **Step 1: Add mypy strict configuration to pyproject.toml**
+
+Add after `[tool.ruff]` section:
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+strict = true
+
+# Legacy modules grandfathered from strict mode (2026-06-09).
+# Shrink this list over time. See docs/adr/0002-mypy-strict-gradual.md.
+[[tool.mypy.overrides]]
+module = [
+    "entirecontext.cli.ast_cmds",
+    "entirecontext.cli.blame_cmds",
+    "entirecontext.cli.checkpoint_cmds",
+    "entirecontext.cli.dashboard_cmds",
+    "entirecontext.cli.decisions_cmds",
+    "entirecontext.cli.event_cmds",
+    "entirecontext.cli.futures_cmds",
+    "entirecontext.cli.graph_cmds",
+    "entirecontext.cli.hook_cmds",
+    "entirecontext.cli.import_cmds",
+    "entirecontext.cli.index_cmds",
+    "entirecontext.cli.mcp_cmds",
+    "entirecontext.cli.project_cmds",
+    "entirecontext.cli.purge_cmds",
+    "entirecontext.cli.repo_cmds",
+    "entirecontext.cli.rewind_cmds",
+    "entirecontext.cli.search_cmds",
+    "entirecontext.cli.session_cmds",
+    "entirecontext.cli.sync_cmds",
+    "entirecontext.core.activation",
+    "entirecontext.core.agent_graph",
+    "entirecontext.core.ast_index",
+    "entirecontext.core.async_worker",
+    "entirecontext.core.attribution",
+    "entirecontext.core.auto_apply",
+    "entirecontext.core.auto_assess",
+    "entirecontext.core.checkpoint",
+    "entirecontext.core.config",
+    "entirecontext.core.consolidation",
+    "entirecontext.core.content_filter",
+    "entirecontext.core.context",
+    "entirecontext.core.cross_repo",
+    "entirecontext.core.dashboard",
+    "entirecontext.core.decision_candidates",
+    "entirecontext.core.decision_extraction",
+    "entirecontext.core.decision_prompt_surfacing",
+    "entirecontext.core.decisions",
+    "entirecontext.core.embedding",
+    "entirecontext.core.event",
+    "entirecontext.core.futures",
+    "entirecontext.core.knowledge_graph",
+    "entirecontext.core.llm",
+    "entirecontext.core.project",
+    "entirecontext.core.purge",
+    "entirecontext.core.resolve",
+    "entirecontext.core.search",
+    "entirecontext.core.security",
+    "entirecontext.core.session",
+    "entirecontext.core.telemetry",
+    "entirecontext.core.tidy_pr",
+    "entirecontext.core.turn",
+    "entirecontext.db.migrations",
+    "entirecontext.db.migrations.v005",
+    "entirecontext.db.migrations.v011",
+    "entirecontext.db.migrations.v012",
+    "entirecontext.db.schema",
+    "entirecontext.hooks.codex_ingest",
+    "entirecontext.hooks.decision_hooks",
+    "entirecontext.hooks.handler",
+    "entirecontext.hooks.session_lifecycle",
+    "entirecontext.hooks.turn_capture",
+    "entirecontext.mcp.runtime",
+    "entirecontext.mcp.server",
+    "entirecontext.mcp.tools.checkpoint",
+    "entirecontext.mcp.tools.decision_candidates",
+    "entirecontext.mcp.tools.decisions",
+    "entirecontext.mcp.tools.futures",
+    "entirecontext.mcp.tools.misc",
+    "entirecontext.mcp.tools.search",
+    "entirecontext.mcp.tools.session",
+    "entirecontext.sync.auto_sync",
+    "entirecontext.sync.coordinator",
+    "entirecontext.sync.engine",
+    "entirecontext.sync.export_flow",
+    "entirecontext.sync.exporter",
+    "entirecontext.sync.git_transport",
+    "entirecontext.sync.merge",
+    "entirecontext.sync.security",
+    "entirecontext.sync.shadow_branch",
+]
+ignore_errors = true
+```
+
+- [ ] **Step 2: Verify mypy passes**
+
+```bash
+uv run mypy src/entirecontext/
+```
+
+Expected: `Success: no issues found in 111 source files` (or similar zero-error output). If any errors remain, the override list is incomplete — add the missing module.
+
+- [ ] **Step 3: Add type-check CI job**
+
+Add to `.github/workflows/ci.yml` after the `lint` job:
+
+```yaml
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Type check
+        run: uv run mypy src/entirecontext/
+```
+
+- [ ] **Step 4: Create ADR-0002 documenting the gradual mypy strategy**
+
+`docs/adr/0002-mypy-strict-gradual.md`:
+
+```markdown
+# 0002. Gradual mypy Strict Adoption
+
+**Status:** accepted
+**Date:** 2026-06-09
+
+## Context
+
+The codebase has 111 Python source files. 79 of them (71%) fail mypy `--strict` due to
+missing type annotations and `Any` usage accumulated over organic development. Adding
+type annotations to all 79 modules in one pass would be a large, risky change.
+
+## Decision
+
+Enable mypy strict mode globally. Grandfather the 79 failing modules via
+`[[tool.mypy.overrides]]` with `ignore_errors = true`. New files are strict from day one.
+
+The override list in `pyproject.toml` is the single source of truth for legacy debt.
+To annotate a module: remove it from the list, run mypy, fix errors, commit.
+
+## Consequences
+
+- New code is strictly typed from the start — no regression.
+- Legacy modules can be annotated incrementally without blocking other work.
+- The override list is visible, countable, and shrinks monotonically.
+- `ignore_errors = true` silences ALL mypy diagnostics in grandfathered modules, including potential real bugs. Accepted trade-off: fixing those modules is the remedy.
+```
+
+- [ ] **Step 5: Run full verification**
+
+```bash
+uv run mypy src/entirecontext/ && echo "mypy: PASS"
+uv run ruff check . && echo "ruff: PASS"
+uv run pytest && echo "pytest: PASS"
+```
+
+All three must pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml .github/workflows/ci.yml docs/adr/0002-mypy-strict-gradual.md
+git commit -m "ci: add mypy strict type checking with grandfather overrides
+
+Enable mypy strict globally. 79 legacy modules get ignore_errors=true
+overrides (see ADR-0002). New files are strict from day one."
+```
+
+---
+
+## Verification
+
+1. `uv run mypy src/entirecontext/` — zero errors
+2. `uv run ruff check .` — lint clean
+3. `uv run pytest` — all tests pass
+4. All four commits present with conventional format
+5. New files: `.github/workflows/commit-lint.yml`, `docs/adr/README.md`, `docs/adr/0001-adr-process.md`, `docs/adr/0002-mypy-strict-gradual.md`
+6. Modified files: `AGENTS.md`, `pyproject.toml`, `.github/workflows/ci.yml`

--- a/docs/superpowers/plans/2026-06-09-measurement-calibration.md
+++ b/docs/superpowers/plans/2026-06-09-measurement-calibration.md
@@ -1,0 +1,395 @@
+# v0.9.1 Measurement Calibration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `applied_context_rate` formula to session-based metric so maturity scoring reflects reality, and register retro carry-forward items in ROADMAP.
+
+**Architecture:** Change the `applied_context_rate` numerator/denominator from per-selection counts to per-session counts. Update dashboard query, telemetry output shape, maturity scoring, all tests, and ROADMAP/CHANGELOG docs.
+
+**Tech Stack:** Python 3.12+, SQLite, pytest
+
+---
+
+## Callers / Blast Radius
+
+| Caller | Impact |
+|--------|--------|
+| `core/aar.py` `pdi_delta` | **None** — AAR computes per-session `applied_count / surfaced_count` independently |
+| `cli/dashboard_cmds.py:171` | **None** — reads `rates['applied_context_rate']` value only; label "applied-context rate" still accurate |
+| `mcp/server.py` `ec_dashboard` | **None** — passes through `get_dashboard_stats()` dict; additive keys are safe |
+
+## Invariants
+
+1. `applied_context_rate` must stay in [0, 1] — enforced by existing `test_all_rate_metrics_in_valid_range`
+2. Both numerator and denominator must filter `ended_at IS NOT NULL` — matches v0.8.1 normalization pattern (dashboard.py:173-177)
+3. Prior retro carry-forwards: `reopen → sessions_ended` non-monotonic (v0.8.1), retro→ROADMAP transfer (v0.9.0)
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/entirecontext/core/dashboard.py:170-215` | Modify | Replace per-selection rate query with session-based query |
+| `src/entirecontext/core/dashboard.py:340-375` | Modify | Update telemetry output dict to expose session-based counts |
+| `tests/test_dashboard.py` | Modify | Update `_seed_telemetry`, rate assertions, `_mock_stats`, guard test |
+| `ROADMAP.md` | Modify | Add v0.9.1 section, register carry-forward items |
+| `CHANGELOG.md` | Modify | Add v0.9.1 entry (version bump deferred until auto_extract dogfooding confirmed) |
+
+---
+
+### Task 1: `applied_context_rate` Session-Based Formula
+
+**Files:**
+- Modify: `src/entirecontext/core/dashboard.py:182-214`
+- Modify: `src/entirecontext/core/dashboard.py:354-374`
+- Test: `tests/test_dashboard.py`
+
+**Context:**
+
+Current formula (line 213-214):
+```python
+applied_context_rate = (
+    context_applications_with_selection / retrieval_selections_total if retrieval_selections_total > 0 else 0.0
+)
+```
+This divides total context_applications (that have a selection FK) by total retrieval_selections. With ~15 selections per session and ~1 application per session, the rate converges to ~6.7% max — structurally cannot reach the 0.1 threshold.
+
+New formula:
+```python
+applied_context_rate = (
+    sessions_with_application / sessions_with_selection if sessions_with_selection > 0 else 0.0
+)
+```
+Where:
+- `sessions_with_selection` = COUNT(DISTINCT rs.session_id) FROM retrieval_selections rs JOIN sessions s ON rs.session_id = s.id WHERE s.ended_at IS NOT NULL
+- `sessions_with_application` = COUNT(DISTINCT ca.session_id) FROM context_applications ca JOIN sessions s ON ca.session_id = s.id WHERE ca.retrieval_selection_id IS NOT NULL AND s.ended_at IS NOT NULL
+
+**Critical**: both queries JOIN sessions and filter `ended_at IS NOT NULL` — matching the v0.8.1 normalization pattern. Without this, active/codex sessions inflate the denominator without contributing to the numerator (applications only recorded at SessionEnd).
+
+- [ ] **Step 1: Write failing test for session-based rate**
+
+In `tests/test_dashboard.py`, add a new test after `test_all_rate_metrics_in_valid_range`:
+
+```python
+def test_applied_context_rate_session_based(self, ec_repo, ec_db):
+    """applied_context_rate uses session-based denominator, not selection count."""
+    from entirecontext.core.project import get_project
+    from entirecontext.core.session import create_session
+
+    project = get_project(str(ec_repo))
+
+    # Session 1: 10 selections, 1 application -> should count as 1 session with application
+    s1 = create_session(ec_db, project["id"], session_id="acr-s1")
+    ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s1["id"],))
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, created_at)"
+        " VALUES ('acr-re1', ?, 'hook', 'regex', 'turn', 'q', datetime('now'))",
+        (s1["id"],),
+    )
+    for i in range(10):
+        ec_db.execute(
+            "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id, rank, created_at)"
+            f" VALUES ('acr-rs1-{i}', 'acr-re1', ?, 'turn', 'turn-{i}', {i + 1}, datetime('now'))",
+            (s1["id"],),
+        )
+    ec_db.execute(
+        "INSERT INTO context_applications (id, session_id, retrieval_selection_id, source_type, source_id, application_type, created_at)"
+        " VALUES ('acr-ca1', ?, 'acr-rs1-0', 'decision', 'd1', 'decision_change', datetime('now'))",
+        (s1["id"],),
+    )
+
+    # Session 2: 5 selections, 0 applications -> 1 session without application
+    s2 = create_session(ec_db, project["id"], session_id="acr-s2")
+    ec_db.execute("UPDATE sessions SET ended_at = datetime('now') WHERE id = ?", (s2["id"],))
+    ec_db.execute(
+        "INSERT INTO retrieval_events (id, session_id, source, search_type, target, query, created_at)"
+        " VALUES ('acr-re2', ?, 'hook', 'regex', 'turn', 'q', datetime('now'))",
+        (s2["id"],),
+    )
+    for i in range(5):
+        ec_db.execute(
+            "INSERT INTO retrieval_selections (id, retrieval_event_id, session_id, result_type, result_id, rank, created_at)"
+            f" VALUES ('acr-rs2-{i}', 'acr-re2', ?, 'turn', 'turn-{i}', {i + 1}, datetime('now'))",
+            (s2["id"],),
+        )
+    ec_db.commit()
+
+    stats = get_dashboard_stats(ec_db)
+    # Session-based: 1 session with app / 2 sessions with selections = 0.5
+    # Old per-selection: 1 app / 15 selections = 0.067
+    assert stats["telemetry"]["rates"]["applied_context_rate"] == 0.5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_dashboard.py::TestGetDashboardStats::test_applied_context_rate_session_based -v`
+Expected: FAIL — current formula returns ~0.067 instead of 0.5
+
+- [ ] **Step 3: Replace queries in dashboard.py**
+
+In `src/entirecontext/core/dashboard.py`, replace lines 182-214:
+
+**Old** (lines 182-214):
+```python
+    retrieval_selections_total = (
+        conn.execute(
+            f"SELECT COUNT(*) AS total FROM retrieval_selections{since_clause_ca}",
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+    events_with_selection = (
+        conn.execute(
+            "SELECT COUNT(DISTINCT re.id) AS total"
+            " FROM retrieval_events re"
+            " JOIN retrieval_selections rs ON rs.retrieval_event_id = re.id"
+            + (" WHERE re.created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+
+    applications_row = conn.execute(
+        "SELECT COUNT(*) AS total,"
+        " SUM(CASE WHEN retrieval_selection_id IS NOT NULL THEN 1 ELSE 0 END) AS with_selection,"
+        " SUM(CASE WHEN source_type IN ('assessment', 'lesson') THEN 1 ELSE 0 END) AS lesson_reuse"
+        f" FROM context_applications{since_clause_ca}",
+        since_params,
+    ).fetchone()
+    context_applications_total = applications_row["total"] or 0
+    context_applications_with_selection = applications_row["with_selection"] or 0
+    lesson_reuse_count = applications_row["lesson_reuse"] or 0
+
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_ended if sessions_ended > 0 else 0.0
+    search_to_selection_rate = events_with_selection / retrieval_events_total if retrieval_events_total > 0 else 0.0
+    applied_context_rate = (
+        context_applications_with_selection / retrieval_selections_total if retrieval_selections_total > 0 else 0.0
+    )
+    lesson_reuse_rate = lesson_reuse_count / context_applications_total if context_applications_total > 0 else 0.0
+```
+
+**New:**
+```python
+    retrieval_selections_total = (
+        conn.execute(
+            f"SELECT COUNT(*) AS total FROM retrieval_selections{since_clause_ca}",
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+    sessions_with_selection = (
+        conn.execute(
+            "SELECT COUNT(DISTINCT rs.session_id) AS total"
+            " FROM retrieval_selections rs"
+            " JOIN sessions s ON rs.session_id = s.id"
+            " WHERE s.ended_at IS NOT NULL"
+            + (" AND rs.created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+    events_with_selection = (
+        conn.execute(
+            "SELECT COUNT(DISTINCT re.id) AS total"
+            " FROM retrieval_events re"
+            " JOIN retrieval_selections rs ON rs.retrieval_event_id = re.id"
+            + (" WHERE re.created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+
+    applications_row = conn.execute(
+        "SELECT COUNT(*) AS total,"
+        " SUM(CASE WHEN retrieval_selection_id IS NOT NULL THEN 1 ELSE 0 END) AS with_selection,"
+        " SUM(CASE WHEN source_type IN ('assessment', 'lesson') THEN 1 ELSE 0 END) AS lesson_reuse"
+        f" FROM context_applications{since_clause_ca}",
+        since_params,
+    ).fetchone()
+    context_applications_total = applications_row["total"] or 0
+    context_applications_with_selection = applications_row["with_selection"] or 0
+    lesson_reuse_count = applications_row["lesson_reuse"] or 0
+    sessions_with_application = (
+        conn.execute(
+            "SELECT COUNT(DISTINCT ca.session_id) AS total"
+            " FROM context_applications ca"
+            " JOIN sessions s ON ca.session_id = s.id"
+            " WHERE ca.retrieval_selection_id IS NOT NULL"
+            " AND s.ended_at IS NOT NULL"
+            + (" AND ca.created_at >= ?" if since is not None else ""),
+            since_params,
+        ).fetchone()["total"]
+        or 0
+    )
+
+    retrieval_assisted_session_rate = retrieval_sessions_total / sessions_ended if sessions_ended > 0 else 0.0
+    search_to_selection_rate = events_with_selection / retrieval_events_total if retrieval_events_total > 0 else 0.0
+    applied_context_rate = (
+        sessions_with_application / sessions_with_selection if sessions_with_selection > 0 else 0.0
+    )
+    lesson_reuse_rate = lesson_reuse_count / context_applications_total if context_applications_total > 0 else 0.0
+```
+
+- [ ] **Step 4: Update telemetry output dict**
+
+In `src/entirecontext/core/dashboard.py`, update the telemetry section (lines ~354-374) to expose session-based counts:
+
+**Old:**
+```python
+        "retrieval_selections": {
+            "total": retrieval_selections_total,
+        },
+        "context_applications": {
+            "total": context_applications_total,
+            "with_selection": context_applications_with_selection,
+        },
+```
+
+**New:**
+```python
+        "retrieval_selections": {
+            "total": retrieval_selections_total,
+            "sessions_with_selection": sessions_with_selection,
+        },
+        "context_applications": {
+            "total": context_applications_total,
+            "with_selection": context_applications_with_selection,
+            "sessions_with_application": sessions_with_application,
+        },
+```
+
+- [ ] **Step 5: Update existing tests**
+
+In `tests/test_dashboard.py`:
+
+1. Update `test_telemetry_rates` (line 253-261) — `_seed_telemetry` seeds 1 session with 1 selection and 1 application, so session-based rate is still 1.0. **No change needed to assertion.**
+
+2. Update `_mock_stats()` (around line 491-498) — add the new keys to the mock:
+
+```python
+"retrieval_selections": {"total": 1, "sessions_with_selection": 1},
+"context_applications": {"total": 1, "with_selection": 1, "sessions_with_application": 1},
+```
+
+3. Update `test_empty_stats_renders_without_error` (around line 554-555) — add new keys:
+
+```python
+"retrieval_selections": {"total": 0, "sessions_with_selection": 0},
+"context_applications": {"total": 0, "with_selection": 0, "sessions_with_application": 0},
+```
+
+- [ ] **Step 6: Run all dashboard tests**
+
+Run: `uv run pytest tests/test_dashboard.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Run rate guard test specifically**
+
+Run: `uv run pytest tests/test_dashboard.py::TestGetDashboardStats::test_all_rate_metrics_in_valid_range -v`
+Expected: PASS — session-based rate still in [0, 1]
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/entirecontext/core/dashboard.py tests/test_dashboard.py
+git commit -m "fix(dashboard): change applied_context_rate to session-based formula
+
+Old formula: context_applications_with_selection / retrieval_selections_total
+converges to ~6.7% max (structurally cannot reach 0.1 threshold).
+
+New formula: sessions_with_application / sessions_with_selection
+counts at session granularity, making the rate semantically meaningful."
+```
+
+---
+
+### Task 2: ROADMAP v0.9.1 Section + Carry-Forward Registration
+
+**Files:**
+- Modify: `ROADMAP.md:221-231`
+
+**Context:** v0.9.0 retro identified two carry-forward items that were never registered in ROADMAP:
+1. `reopen → sessions_ended` non-monotonic impact (deferred since v0.8.1)
+2. Retro → ROADMAP transfer rule (process gap discovered in v0.9.0 retro)
+
+- [ ] **Step 1: Add v0.9.1 section after v0.9.0 in ROADMAP.md**
+
+After line 231 (end of v0.9.0 section), insert:
+
+```markdown
+
+## v0.9.1 — Measurement Calibration
+
+Theme: fix measurement formulas so maturity scores reflect actual loop completion, and establish the retro carry-forward process.
+
+- [ ] **`applied_context_rate` session-based formula** — numerator/denominator changed from per-selection counts to per-session counts. Old formula structurally capped at ~6.7%; new formula `sessions_with_application / sessions_with_selection` reaches threshold naturally. ec decision `b09d1aed`.
+- [ ] **`auto_extract` default true** — pending local dogfooding confirmation (config flip in v0.3.0 code, never enabled). ec decision `309d472a`.
+- [ ] **Retro carry-forward → ROADMAP registration rule** — v0.9.0 retro finding: deferred items were not transferred to ROADMAP, causing 4-release drift. Rule: retro completion must register carry-forwards in ROADMAP or mark explicit won't-fix.
+- [ ] **`reopen → sessions_ended` non-monotonic evaluation** — deferred from v0.8.1, v0.9.0. Evaluate whether session reopen can make `sessions_ended` count decrease and whether this matters for rate stability. Resolve as fix or won't-fix.
+```
+
+- [ ] **Step 2: Run no tests (docs-only change)**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ROADMAP.md
+git commit -m "docs(roadmap): add v0.9.1 Measurement Calibration section
+
+Registers carry-forward items from v0.9.0 retro:
+- applied_context_rate formula fix
+- auto_extract default flip (pending dogfooding)
+- retro→ROADMAP transfer rule
+- reopen non-monotonic evaluation (deferred since v0.8.1)"
+```
+
+---
+
+### Task 3: CHANGELOG v0.9.1 Entry
+
+**Files:**
+- Modify: `CHANGELOG.md:1-8`
+
+Note: version bump in pyproject.toml and tag/push are deferred to the release step — `auto_extract` dogfooding must confirm before shipping.
+
+- [ ] **Step 1: Add v0.9.1 entry above v0.9.0**
+
+Insert after line 7 (before `## [0.9.0]`):
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- **`applied_context_rate` session-based formula** — numerator/denominator changed from per-selection counts (`context_applications_with_selection / retrieval_selections_total`, structurally capped at ~6.7%) to per-session counts (`sessions_with_application / sessions_with_selection`). Both queries filter `ended_at IS NOT NULL` (v0.8.1 normalization pattern). Maturity intervene dimension now reachable.
+
+### Changed
+
+- Telemetry output adds `sessions_with_selection` and `sessions_with_application` counters for transparency.
+
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): add applied_context_rate formula fix entry"
+```
+
+---
+
+## Parallelization
+
+```
+Task 1 (formula fix) ──> Task 2 (ROADMAP) ──> Task 3 (CHANGELOG)
+```
+
+Sequential: Task 2 depends on Task 1 being committed (ROADMAP references the fix). Task 3 depends on both.
+
+## Verification
+
+1. `uv run pytest tests/test_dashboard.py -v` — all tests pass
+2. `uv run ruff check . && uv run ruff format --check .` — lint clean
+3. New `test_applied_context_rate_session_based` proves session-based math
+4. Rate guard test confirms [0, 1] range preserved
+5. `uv run ec dashboard` on dogfooding DB — verify intervene score reaches 13 (5 base + 8 from rate≥0.1)
+6. No schema changes — still v14

--- a/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
@@ -1682,12 +1682,12 @@ def _has_new_decision_with_file_overlap(
 ) -> bool:
     """Check if a new decision was created in this session with overlapping decision_files."""
     session_row = conn.execute(
-        "SELECT created_at, ended_at FROM sessions WHERE id = ?", (session_id,)
+        "SELECT started_at, ended_at FROM sessions WHERE id = ?", (session_id,)
     ).fetchone()
     if not session_row:
         return False
 
-    session_start = session_row["created_at"]
+    session_start = session_row["started_at"]
     # Upper bound is mandatory: backfill runs over historical sessions, and
     # without it a decision created days after an old session ended would
     # retroactively reclassify that session's outcome as refined/replaced.
@@ -1697,8 +1697,10 @@ def _has_new_decision_with_file_overlap(
 
         session_end = datetime.now(timezone.utc).isoformat()
 
+    from .decisions import _normalize_path
+
     original_files = {
-        r["file_path"]
+        _normalize_path(r["file_path"])
         for r in conn.execute(
             "SELECT file_path FROM decision_files WHERE decision_id = ?", (decision_id,)
         ).fetchall()
@@ -1720,7 +1722,7 @@ def _has_new_decision_with_file_overlap(
 
     for row in new_decisions:
         new_files = {
-            r["file_path"]
+            _normalize_path(r["file_path"])
             for r in conn.execute(
                 "SELECT file_path FROM decision_files WHERE decision_id = ?", (row["id"],)
             ).fetchall()
@@ -1736,8 +1738,10 @@ def _classify_diff_pattern(
 ) -> str:
     """Classify diff as 'refined' (net additions) or 'replaced' (net deletions).
 
-    Uses git diff --numstat between session start commit and HEAD,
-    filtered to overlapping files.
+    Uses git diff --numstat between session start commit and session end
+    commit (or HEAD for live sessions), filtered to overlapping files.
+    For historical backfill the end-of-session boundary prevents later
+    unrelated commits from flipping an old accepted outcome.
     """
     session_row = conn.execute(
         "SELECT metadata FROM sessions WHERE id = ?", (session_id,)
@@ -1748,14 +1752,17 @@ def _classify_diff_pattern(
     try:
         metadata = json.loads(session_row["metadata"])
         start_sha = metadata.get("start_git_commit")
+        end_sha = metadata.get("end_git_commit")
     except (json.JSONDecodeError, TypeError):
         return "accepted"
 
     if not start_sha:
         return "accepted"
 
+    diff_target = end_sha or "HEAD"
+
     try:
-        cmd = ["git", "diff", "--numstat", f"{start_sha}..HEAD", "--"] + overlap_files
+        cmd = ["git", "diff", "--numstat", f"{start_sha}..{diff_target}", "--"] + overlap_files
         result = subprocess.run(
             cmd, cwd=repo_path, capture_output=True, text=True, timeout=5
         )
@@ -1923,7 +1930,7 @@ Task 8 runs after all others.
 
 ## Backfill (No Separate Task Needed)
 
-The existing `ec session backfill-applied` command (`session_cmds.py:583`) calls `infer_applied_decisions(conn, sid, dry_run=dry_run, repo_path=repo_path)` — the same function modified in Tasks 6 and 7. Since `repo_path` is already passed, both lesson detection and Layer 2 classification apply automatically to historical sessions. Verified via source read.
+The existing `ec session backfill-applied` command (`session_cmds.py:583`) calls `infer_applied_decisions(conn, sid, dry_run=dry_run, repo_path=repo_path)` — the same function modified in Tasks 6 and 7. However, its session prefilter currently joins `retrieval_selections` with `rs.result_type = 'decision'`, so sessions that only surfaced lessons/assessments are excluded. **Implementer action:** widen the prefilter at `session_cmds.py:569` to `rs.result_type IN ('decision', 'assessment', 'lesson')` so lesson-only sessions are also backfilled.
 
 ## Out-of-Band Items (Manual, Not Auto-Executed)
 

--- a/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
@@ -71,7 +71,7 @@ Expected: PASS (all 3 threshold tests)
 
 - [ ] **Step 3: Update RELEASE_RULE.md (1b + 1c)**
 
-Add after the "## Test Gate" section in `.omc/RELEASE_RULE.md`:
+If `.omc/RELEASE_RULE.md` does not exist in git (check `git ls-files .omc/RELEASE_RULE.md`), create it first with a `## Test Gate` section. Then add after it:
 
 ```markdown
 ## Pre-Release Review Gate
@@ -844,8 +844,12 @@ Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace 
                 # the result — if the 100ms join timed out or entries were
                 # trimmed, nothing is written, so phantom selections cannot
                 # feed SessionEnd auto-apply and inflate lesson_reuse_rate.
+                # Pass the current prompt turn so auto-apply can require
+                # file edits AFTER the lesson was surfaced, not before.
+                current_turn_id = _get_current_turn_id(conn_pdi, session_id)
                 _record_lesson_selections(
-                    repo_path, session_id, emitted_lessons, lesson_files
+                    repo_path, session_id, emitted_lessons, lesson_files,
+                    turn_id=current_turn_id,
                 )
 
             print(
@@ -913,7 +917,8 @@ def _rank_and_format_lessons_for_pdi(
 
 
 def _record_lesson_selections(
-    repo_path: str, session_id: str | None, lessons: list[dict], file_paths: list[str]
+    repo_path: str, session_id: str | None, lessons: list[dict], file_paths: list[str],
+    turn_id: str | None = None,
 ) -> None:
     """Record retrieval event + selections for lessons actually injected. Never raises."""
     if not lessons:
@@ -945,6 +950,7 @@ def _record_lesson_selections(
                         result_id=lesson["id"],
                         rank=idx,
                         session_id=session_id,
+                        turn_id=turn_id,
                     )
         finally:
             conn.close()
@@ -1245,9 +1251,12 @@ def _detect_overlapping_lessons(
                rs.result_type, rs.turn_id, t.turn_number, rs.created_at
         FROM retrieval_selections rs
         JOIN retrieval_events re ON re.id = rs.retrieval_event_id
+        JOIN assessments a ON a.id = rs.result_id
         LEFT JOIN turns t ON t.id = rs.turn_id
         WHERE rs.session_id = ?
           AND rs.result_type IN ('assessment', 'lesson')
+          AND a.feedback IS NOT NULL
+          AND re.search_type = 'lesson_surfacing'
           AND NOT EXISTS (
               SELECT 1
               FROM context_applications ca
@@ -1679,8 +1688,13 @@ import subprocess
 
 def _has_new_decision_with_file_overlap(
     conn: sqlite3.Connection, session_id: str, decision_id: str
-) -> bool:
-    """Check if a new decision was created in this session with overlapping decision_files."""
+) -> list[str]:
+    """Check if a new decision was created in this session with overlapping decision_files.
+
+    Uses decision_checkpoints to verify the candidate decision is linked
+    to a checkpoint from this session — decisions.created_at alone cannot
+    distinguish concurrent sessions touching the same files.
+    """
     session_row = conn.execute(
         "SELECT started_at, ended_at FROM sessions WHERE id = ?", (session_id,)
     ).fetchone()
@@ -1716,8 +1730,14 @@ def _has_new_decision_with_file_overlap(
         WHERE d.created_at >= ?
           AND d.created_at <= ?
           AND d.id != ?
+          AND EXISTS (
+              SELECT 1 FROM decision_checkpoints dc
+              JOIN checkpoints c ON c.id = dc.checkpoint_id
+              WHERE dc.decision_id = d.id
+                AND c.session_id = ?
+          )
         """,
-        (session_start, session_end, decision_id),
+        (session_start, session_end, decision_id, session_id),
     ).fetchall()
 
     for row in new_decisions:
@@ -1727,10 +1747,11 @@ def _has_new_decision_with_file_overlap(
                 "SELECT file_path FROM decision_files WHERE decision_id = ?", (row["id"],)
             ).fetchall()
         }
-        if original_files & new_files:
-            return True
+        intersection = original_files & new_files
+        if intersection:
+            return sorted(intersection)
 
-    return False
+    return []
 
 
 def _classify_diff_pattern(
@@ -1811,11 +1832,12 @@ Then modify the decision loop in `infer_applied_decisions()`:
 
             config = load_config(repo_path)
             if config.get("decisions", {}).get("infer_outcome_type", True):
-                if _has_new_decision_with_file_overlap(conn, session_id, match["decision_id"]):
+                intersecting = _has_new_decision_with_file_overlap(conn, session_id, match["decision_id"])
+                if intersecting:
                     outcome_type = _classify_diff_pattern(
-                        repo_path, session_id, match["overlap_files"], conn
+                        repo_path, session_id, intersecting, conn
                     )
-                    note = f"auto: session_end {outcome_type} ({', '.join(match['overlap_files'][:3])})"
+                    note = f"auto: session_end {outcome_type} ({', '.join(intersecting[:3])})"
 
         with transaction(conn):
             record_context_application(

--- a/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
@@ -806,52 +806,56 @@ Expected: FAIL
 Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace lines 173-187 (the stdout JSON output block) with:
 
 ```python
+        # Build decision markdown (may be empty when no decisions match)
+        md = ""
         if trimmed:
             from ..core.decision_prompt_surfacing import _format_decision_entry
 
             entries = [_format_decision_entry(d, i + 1) for i, d in enumerate(trimmed)]
             md = "## Related Decisions\n\n" + "\n\n".join(entries)
 
-            # Best-effort lesson surfacing in separate timeout thread —
-            # lesson latency must never block decision output.
-            lesson_payload = None
-            try:
-                remaining_tokens = max_tokens - _estimate_tokens(md)
-                _lesson_result: list[tuple[str, list[dict], list[str]] | None] = []
+        # Best-effort lesson surfacing — runs independently of whether
+        # decisions were found, so decision-sparse file areas can still
+        # receive relevant lessons.
+        lesson_payload = None
+        try:
+            remaining_tokens = max_tokens - _estimate_tokens(md) if md else max_tokens
+            _lesson_result: list[tuple[str, list[dict], list[str]] | None] = []
 
-                def _lesson_wrapper() -> None:
-                    try:
-                        _lesson_result.append(
-                            _rank_and_format_lessons_for_pdi(
-                                repo_path, session_id, config, remaining_tokens
-                            )
+            def _lesson_wrapper() -> None:
+                try:
+                    _lesson_result.append(
+                        _rank_and_format_lessons_for_pdi(
+                            repo_path, session_id, config, remaining_tokens
                         )
-                    except Exception:
-                        _lesson_result.append(None)
+                    )
+                except Exception:
+                    _lesson_result.append(None)
 
-                lt = threading.Thread(target=_lesson_wrapper, daemon=True)
-                lt.start()
-                lt.join(timeout=0.1)  # 100ms — lessons are best-effort
-                if not lt.is_alive() and _lesson_result and _lesson_result[0]:
-                    lesson_payload = _lesson_result[0]
-            except Exception:
-                pass
+            lt = threading.Thread(target=_lesson_wrapper, daemon=True)
+            lt.start()
+            lt.join(timeout=0.1)  # 100ms — lessons are best-effort
+            if not lt.is_alive() and _lesson_result and _lesson_result[0]:
+                lesson_payload = _lesson_result[0]
+        except Exception:
+            pass
 
-            if lesson_payload:
-                lesson_md, emitted_lessons, lesson_files = lesson_payload
-                md = md + "\n\n" + lesson_md
-                # Selections are recorded only here, after the caller accepts
-                # the result — if the 100ms join timed out or entries were
-                # trimmed, nothing is written, so phantom selections cannot
-                # feed SessionEnd auto-apply and inflate lesson_reuse_rate.
-                # Pass the current prompt turn so auto-apply can require
-                # file edits AFTER the lesson was surfaced, not before.
-                current_turn_id = _get_current_turn_id(conn_pdi, session_id)
-                _record_lesson_selections(
-                    repo_path, session_id, emitted_lessons, lesson_files,
-                    turn_id=current_turn_id,
-                )
+        if lesson_payload:
+            lesson_md, emitted_lessons, lesson_files = lesson_payload
+            md = (md + "\n\n" + lesson_md) if md else lesson_md
+            from ..db import get_db as _get_db
 
+            _conn_pdi = _get_db(repo_path)
+            try:
+                current_turn_id = _get_current_turn_id(_conn_pdi, session_id)
+            finally:
+                _conn_pdi.close()
+            _record_lesson_selections(
+                repo_path, session_id, emitted_lessons, lesson_files,
+                turn_id=current_turn_id,
+            )
+
+        if md:
             print(
                 json.dumps(
                     {
@@ -956,6 +960,17 @@ def _record_lesson_selections(
             conn.close()
     except Exception:
         pass
+
+
+def _get_current_turn_id(conn, session_id: str | None) -> str | None:
+    """Return the most recent turn id for this session, or None."""
+    if not session_id:
+        return None
+    row = conn.execute(
+        "SELECT id FROM turns WHERE session_id = ? ORDER BY turn_number DESC LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    return row["id"] if row else None
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1498,9 +1513,18 @@ def outcome_setup(ec_db, ec_repo):
         turn_id=turn["id"],
     )
 
-    # New decision in same session (overlapping file)
+    # New decision in same session (overlapping file).
+    # Must also link to a checkpoint in this session so
+    # _has_new_decision_with_file_overlap() can verify same-session provenance.
     new_decision = create_decision(conn, title="Refined auth with refresh tokens", rationale="Better UX")
     link_decision_to_file(conn, new_decision["id"], "src/auth.py")
+    from entirecontext.core.checkpoint import create_checkpoint
+    ckpt = create_checkpoint(conn, session_id, git_commit_hash=start_sha, git_branch="main")
+    conn.execute(
+        "INSERT INTO decision_checkpoints (decision_id, checkpoint_id) VALUES (?, ?)",
+        (new_decision["id"], ckpt["id"]),
+    )
+    conn.commit()
 
     return {
         "conn": conn,

--- a/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
@@ -1,0 +1,1889 @@
+# v0.10.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close retro carry-forward debt, activate lesson-reuse path (lesson_reuse_rate > 0) for maturity 75, and add git-evidence outcome inference (refined/replaced) for the v1.0 autonomous-loop gate.
+
+**Architecture:** Dual-channel lesson surfacing (SessionStart broad + PDI narrow) creates `retrieval_selection` entries with `result_type='assessment'`. Auto-apply at SessionEnd detects file overlap between surfaced lessons and session-modified files using the assessment's checkpoint `files_snapshot`. Outcome inference adds Layer 2 classification (refined/replaced) on top of the existing file-overlap gate when a new decision is created in the same session.
+
+**Tech Stack:** Python 3.12+, SQLite (WAL), Typer CLI, pytest, uv
+
+**Spec:** `docs/superpowers/specs/2026-06-10-v0.10.0-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/entirecontext/core/lesson_surfacing.py` | Lesson retrieval, ranking, formatting |
+| Create | `tests/test_lesson_surfacing.py` | Lesson surfacing unit tests |
+| Create | `tests/test_outcome_inference.py` | Layer 2 outcome inference tests |
+| Modify | `src/entirecontext/core/config.py:11-136` | New config keys |
+| Modify | `src/entirecontext/hooks/handler.py:74-191` | Dispatch lesson surfacing on SessionStart; extend PDI with lessons |
+| Modify | `src/entirecontext/core/auto_apply.py:74-186` | Extend overlap detection for lessons; add Layer 2 outcome classification |
+| Modify | `tests/test_hooks_performance.py:110-120` | 250ms → 300ms threshold |
+| Modify | `.omc/RELEASE_RULE.md` | Carry-forward updates (1b, 1c) |
+| Modify | `CHANGELOG.md` | v0.10.0 entries |
+| Modify | `ROADMAP.md` | v0.10.0 status |
+
+---
+
+## Task 1: Carry-Forward (Config & Docs Only)
+
+**Files:**
+- Modify: `tests/test_hooks_performance.py:110-120`
+- Modify: `.omc/RELEASE_RULE.md`
+
+> **1a (ghost release) and 1e (auto_extract verification) are out-of-band**: 1a is a destructive external action (`gh release delete`), 1e requires a real SessionEnd. Both require explicit user confirmation, not auto-execution.
+
+- [ ] **Step 1: Fix flaky performance test threshold (1d)**
+
+In `tests/test_hooks_performance.py`, change all three 250ms thresholds to 300ms:
+
+```python
+# tests/test_hooks_performance.py — lines 110-120
+
+    def test_p95_under_300ms_at_100(self, results):
+        p95 = results[100]["p95"]
+        assert p95 < 300, f"p95@100={p95:.1f}ms ≥ 300ms"
+
+    def test_p95_under_300ms_at_500(self, results):
+        p95 = results[500]["p95"]
+        assert p95 < 300, f"p95@500={p95:.1f}ms ≥ 300ms"
+
+    def test_p95_under_300ms_at_1000(self, results):
+        p95 = results[1000]["p95"]
+        assert p95 < 300, f"p95@1000={p95:.1f}ms ≥ 300ms — default inject_on_user_prompt should be false"
+```
+
+Also update the gate column header in `test_record_results` (line 135):
+```python
+            "| Corpus size | p50 (ms) | p95 (ms) | Gate (< 300ms) |",
+```
+
+And the gate check (find `< 250` in the `test_record_results` method and replace with `< 300`).
+
+- [ ] **Step 2: Run perf test to verify**
+
+Run: `uv run pytest tests/test_hooks_performance.py -v -k "not test_record_results"`
+Expected: PASS (all 3 threshold tests)
+
+- [ ] **Step 3: Update RELEASE_RULE.md (1b + 1c)**
+
+Add after the "## Test Gate" section in `.omc/RELEASE_RULE.md`:
+
+```markdown
+## Pre-Release Review Gate
+- Run Codex review (`codex --approval-policy on-failure`) on the release branch BEFORE tagging
+- Fix all Codex findings before proceeding to tag push
+- Ordering: Codex review → fix → tag push → CI publish
+- [ ] Codex review completed (shift-left checklist item — 3 consecutive releases missed this)
+```
+
+- [ ] **Step 4: Commit carry-forward changes**
+
+```bash
+git add tests/test_hooks_performance.py .omc/RELEASE_RULE.md
+git commit -m "chore: v0.10.0 carry-forward — perf threshold 300ms, release review gate"
+```
+
+---
+
+## Task 2: Config Keys
+
+**Files:**
+- Modify: `src/entirecontext/core/config.py:12-136`
+
+- [ ] **Step 1: Add `surface_lessons_on_start` to capture config**
+
+In `src/entirecontext/core/config.py`, add to the `"capture"` dict (after `"codex_session_idle_minutes": 60,` at line 19):
+
+```python
+        "surface_lessons_on_start": True,
+```
+
+- [ ] **Step 2: Add `infer_outcome_type` to decisions config**
+
+In `src/entirecontext/core/config.py`, add to the `"decisions"` dict (after `"infer_applied_on_session_end": True,` at line 95):
+
+```python
+        "infer_outcome_type": True,
+```
+
+- [ ] **Step 3: Run existing config tests**
+
+Run: `uv run pytest tests/ -k "config" -v`
+Expected: PASS (no existing tests break)
+
+- [ ] **Step 4: Commit config changes**
+
+```bash
+git add src/entirecontext/core/config.py
+git commit -m "feat(config): add surface_lessons_on_start and infer_outcome_type keys"
+```
+
+---
+
+## Task 3: Lesson Surfacing Core
+
+**Files:**
+- Create: `src/entirecontext/core/lesson_surfacing.py`
+- Create: `tests/test_lesson_surfacing.py`
+
+This task builds the retrieval/ranking/formatting logic. No hook wiring yet.
+
+- [ ] **Step 1: Write tests for lesson retrieval**
+
+```python
+# tests/test_lesson_surfacing.py
+"""Tests for core/lesson_surfacing.py — lesson retrieval, ranking, formatting."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from entirecontext.core.checkpoint import create_checkpoint
+from entirecontext.core.futures import add_feedback, create_assessment
+from entirecontext.core.session import create_session
+from entirecontext.core.turn import create_turn
+
+
+@pytest.fixture
+def lesson_setup(ec_db, ec_repo):
+    """Seed: 1 session, 1 checkpoint with files_snapshot, 1 assessment with feedback."""
+    conn = ec_db
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    session = create_session(conn, project_id, session_type="claude")
+    session_id = session["id"]
+
+    turn = create_turn(
+        conn,
+        session_id,
+        turn_number=1,
+        user_message="implement auth",
+        files_touched=json.dumps(["src/auth.py", "src/middleware.py"]),
+        tools_used=json.dumps(["Edit"]),
+    )
+
+    checkpoint = create_checkpoint(
+        conn,
+        session_id,
+        git_commit_hash="abc123",
+        files_snapshot={"src/auth.py": "hash1", "src/middleware.py": "hash2", "README.md": "hash3"},
+    )
+
+    assessment = create_assessment(
+        conn,
+        checkpoint_id=checkpoint["id"],
+        verdict="expand",
+        impact_summary="Added token refresh reduces session drops",
+        roadmap_alignment="Aligned with auth hardening",
+        tidy_suggestion="Consider extracting token logic to separate module",
+    )
+    add_feedback(conn, assessment["id"], "agree", "Confirmed token refresh works in prod")
+
+    return {
+        "conn": conn,
+        "repo_path": str(ec_repo),
+        "project_id": project_id,
+        "session_id": session_id,
+        "checkpoint_id": checkpoint["id"],
+        "assessment_id": assessment["id"],
+    }
+
+
+def test_get_surfaceable_lessons_returns_lessons_with_feedback(lesson_setup):
+    """Only assessments with non-null feedback are returned."""
+    from entirecontext.core.lesson_surfacing import get_surfaceable_lessons
+
+    ctx = lesson_setup
+    lessons = get_surfaceable_lessons(ctx["conn"], limit=10)
+    assert len(lessons) == 1
+    assert lessons[0]["id"] == ctx["assessment_id"]
+    assert lessons[0]["feedback"] is not None
+
+
+def test_get_surfaceable_lessons_excludes_no_feedback(lesson_setup):
+    """Assessment without feedback is not a lesson."""
+    from entirecontext.core.lesson_surfacing import get_surfaceable_lessons
+
+    ctx = lesson_setup
+    create_assessment(
+        ctx["conn"],
+        checkpoint_id=ctx["checkpoint_id"],
+        verdict="neutral",
+        impact_summary="No feedback assessment",
+    )
+    lessons = get_surfaceable_lessons(ctx["conn"], limit=10)
+    assert len(lessons) == 1  # only the one with feedback
+
+
+def test_get_surfaceable_lessons_respects_limit(lesson_setup):
+    from entirecontext.core.lesson_surfacing import get_surfaceable_lessons
+
+    ctx = lesson_setup
+    for i in range(5):
+        a = create_assessment(
+            ctx["conn"],
+            checkpoint_id=ctx["checkpoint_id"],
+            verdict="expand",
+            impact_summary=f"Lesson {i}",
+        )
+        add_feedback(ctx["conn"], a["id"], "agree")
+
+    lessons = get_surfaceable_lessons(ctx["conn"], limit=3)
+    assert len(lessons) == 3
+
+
+def test_get_checkpoint_file_paths_returns_snapshot_keys(lesson_setup):
+    """Extract file paths from checkpoint's files_snapshot dict."""
+    from entirecontext.core.lesson_surfacing import get_checkpoint_file_paths
+
+    ctx = lesson_setup
+    paths = get_checkpoint_file_paths(ctx["conn"], ctx["checkpoint_id"])
+    assert set(paths) == {"src/auth.py", "src/middleware.py", "README.md"}
+
+
+def test_get_checkpoint_file_paths_null_snapshot(ec_db, ec_repo):
+    """Checkpoint with null files_snapshot returns empty list."""
+    from entirecontext.core.lesson_surfacing import get_checkpoint_file_paths
+
+    conn = ec_db
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+    session = create_session(conn, project_id)
+    cp = create_checkpoint(conn, session["id"], git_commit_hash="def456", files_snapshot=None)
+    paths = get_checkpoint_file_paths(conn, cp["id"])
+    assert paths == []
+
+
+def test_rank_lessons_by_file_overlap(lesson_setup):
+    """Lessons with file overlap rank higher than those without."""
+    from entirecontext.core.lesson_surfacing import rank_lessons_for_prompt
+
+    ctx = lesson_setup
+    # Create a second lesson with no file overlap
+    session2 = create_session(ctx["conn"], ctx["project_id"])
+    cp2 = create_checkpoint(
+        ctx["conn"],
+        session2["id"],
+        git_commit_hash="xyz789",
+        files_snapshot={"unrelated/file.py": "hash4"},
+    )
+    a2 = create_assessment(
+        ctx["conn"],
+        checkpoint_id=cp2["id"],
+        verdict="narrow",
+        impact_summary="Unrelated lesson",
+    )
+    add_feedback(ctx["conn"], a2["id"], "disagree", "Not relevant")
+
+    ranked = rank_lessons_for_prompt(
+        ctx["conn"],
+        file_paths=["src/auth.py"],
+        limit=5,
+    )
+    assert len(ranked) == 2
+    assert ranked[0]["id"] == ctx["assessment_id"]  # file overlap → ranked first
+
+
+def test_format_lesson_entry_output(lesson_setup):
+    from entirecontext.core.lesson_surfacing import format_lesson_entry, get_surfaceable_lessons
+
+    ctx = lesson_setup
+    lessons = get_surfaceable_lessons(ctx["conn"], limit=1)
+    output = format_lesson_entry(lessons[0], rank=1)
+    assert "### 1." in output
+    assert "token refresh" in output.lower()
+    assert lessons[0]["id"][:12] in output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v`
+Expected: FAIL (ModuleNotFoundError: No module named 'entirecontext.core.lesson_surfacing')
+
+- [ ] **Step 3: Implement lesson_surfacing.py**
+
+```python
+# src/entirecontext/core/lesson_surfacing.py
+"""Lesson retrieval, ranking, and formatting for surfacing pipelines."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def get_surfaceable_lessons(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Retrieve assessments with feedback (lessons), ordered by recency."""
+    rows = conn.execute(
+        """
+        SELECT a.*, c.files_snapshot, c.git_commit_hash
+        FROM assessments a
+        LEFT JOIN checkpoints c ON c.id = a.checkpoint_id
+        WHERE a.feedback IS NOT NULL
+        ORDER BY a.created_at DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def get_checkpoint_file_paths(
+    conn: sqlite3.Connection,
+    checkpoint_id: str,
+) -> list[str]:
+    """Extract file paths from a checkpoint's files_snapshot."""
+    row = conn.execute(
+        "SELECT files_snapshot FROM checkpoints WHERE id = ?",
+        (checkpoint_id,),
+    ).fetchone()
+    if not row or not row["files_snapshot"]:
+        return []
+    try:
+        snapshot = json.loads(row["files_snapshot"]) if isinstance(row["files_snapshot"], str) else row["files_snapshot"]
+        if isinstance(snapshot, dict):
+            return list(snapshot.keys())
+        if isinstance(snapshot, list):
+            return [str(p) for p in snapshot if p]
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return []
+
+
+def rank_lessons_for_prompt(
+    conn: sqlite3.Connection,
+    *,
+    file_paths: list[str] | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Rank lessons by file overlap with working-area files, then recency.
+
+    Returns lessons sorted by: (has_file_overlap DESC, created_at DESC).
+    """
+    lessons = get_surfaceable_lessons(conn, limit=limit * 3)
+    if not lessons:
+        return []
+
+    file_set = set(file_paths) if file_paths else set()
+    scored: list[tuple[float, dict[str, Any]]] = []
+
+    for lesson in lessons:
+        overlap_score = 0.0
+        snapshot_raw = lesson.pop("files_snapshot", None)
+        lesson.pop("git_commit_hash", None)
+
+        if file_set and snapshot_raw:
+            try:
+                snapshot = json.loads(snapshot_raw) if isinstance(snapshot_raw, str) else snapshot_raw
+                if isinstance(snapshot, dict):
+                    lesson_files = set(snapshot.keys())
+                elif isinstance(snapshot, list):
+                    lesson_files = set(str(p) for p in snapshot if p)
+                else:
+                    lesson_files = set()
+                overlap_count = len(file_set & lesson_files)
+                if overlap_count > 0:
+                    overlap_score = 10.0 + overlap_count
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        scored.append((overlap_score, lesson))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [item[1] for item in scored[:limit]]
+
+
+def format_lesson_entry(lesson: dict[str, Any], rank: int) -> str:
+    """Format a single lesson for Markdown output."""
+    title = lesson.get("impact_summary") or "(no summary)"
+    parts = [f"### {rank}. {title}"]
+    if lesson.get("id"):
+        parts.append(f"  ID: `{lesson['id'][:12]}`")
+    verdict = lesson.get("verdict", "")
+    if verdict:
+        icon = {"expand": "\U0001f7e2", "narrow": "\U0001f534", "neutral": "\U0001f7e1"}.get(verdict, "")
+        parts.append(f"  Verdict: {icon} {verdict}")
+    if lesson.get("feedback"):
+        parts.append(f"  Feedback: {lesson['feedback']}")
+    if lesson.get("feedback_reason"):
+        reason = lesson["feedback_reason"]
+        if len(reason) > 200:
+            reason = reason[:200] + "…"
+        parts.append(f"  Reason: {reason}")
+    if lesson.get("tidy_suggestion"):
+        suggestion = lesson["tidy_suggestion"]
+        if len(suggestion) > 200:
+            suggestion = suggestion[:200] + "…"
+        parts.append(f"\n  Suggestion: {suggestion}")
+    return "\n".join(parts)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 5: Run existing tests to check for regressions**
+
+Run: `uv run pytest tests/ -x -q --timeout=60`
+Expected: All pass, no regressions
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/lesson_surfacing.py tests/test_lesson_surfacing.py
+git commit -m "feat: lesson surfacing core — retrieval, file-overlap ranking, formatting"
+```
+
+---
+
+## Task 4: SessionStart Lesson Surfacing (2a)
+
+**Files:**
+- Modify: `src/entirecontext/hooks/handler.py:74-87`
+- Modify: `tests/test_lesson_surfacing.py`
+
+SessionStart lesson surfacing follows the same pattern as `on_session_start_decisions()` in `decision_hooks.py:175`: try/except wrapper, config gate, telemetry recording, stdout output.
+
+- [ ] **Step 1: Write integration test for SessionStart lesson surfacing**
+
+Append to `tests/test_lesson_surfacing.py`:
+
+```python
+def test_session_start_surfaces_lessons_to_stdout(lesson_setup, capsys, monkeypatch):
+    """SessionStart dispatches lesson surfacing and prints to stdout."""
+    import entirecontext.core.config as config_mod
+
+    ctx = lesson_setup
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda *a, **kw: {
+            "capture": {"auto_capture": True, "surface_lessons_on_start": True},
+            "decisions": {},
+        },
+    )
+
+    from entirecontext.hooks.handler import _handle_session_start
+
+    data = {
+        "cwd": ctx["repo_path"],
+        "session_id": ctx["session_id"],
+    }
+    _handle_session_start(data)
+
+    captured = capsys.readouterr()
+    assert "Lessons" in captured.out or "lesson" in captured.out.lower()
+
+
+def test_session_start_lesson_surfacing_config_off(lesson_setup, capsys, monkeypatch):
+    """surface_lessons_on_start=False skips lesson surfacing."""
+    import entirecontext.core.config as config_mod
+
+    ctx = lesson_setup
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda *a, **kw: {
+            "capture": {"auto_capture": True, "surface_lessons_on_start": False},
+            "decisions": {},
+        },
+    )
+
+    from entirecontext.hooks.handler import _handle_session_start
+
+    data = {
+        "cwd": ctx["repo_path"],
+        "session_id": ctx["session_id"],
+    }
+    _handle_session_start(data)
+
+    captured = capsys.readouterr()
+    assert "Relevant Lessons" not in captured.out
+
+
+def test_session_start_lesson_surfacing_records_telemetry(lesson_setup, monkeypatch):
+    """Lesson surfacing records retrieval_event and retrieval_selection."""
+    import entirecontext.core.config as config_mod
+
+    ctx = lesson_setup
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda *a, **kw: {
+            "capture": {"auto_capture": True, "surface_lessons_on_start": True},
+            "decisions": {},
+        },
+    )
+
+    from entirecontext.hooks.handler import _handle_session_start
+
+    data = {
+        "cwd": ctx["repo_path"],
+        "session_id": ctx["session_id"],
+    }
+    _handle_session_start(data)
+
+    conn = ctx["conn"]
+    events = conn.execute(
+        "SELECT * FROM retrieval_events WHERE search_type = 'lesson_surfacing'",
+    ).fetchall()
+    assert len(events) >= 1
+
+    selections = conn.execute(
+        "SELECT * FROM retrieval_selections WHERE result_type = 'assessment'",
+    ).fetchall()
+    assert len(selections) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v -k "session_start"`
+Expected: FAIL
+
+- [ ] **Step 3: Add lesson surfacing dispatch to handler.py**
+
+In `src/entirecontext/hooks/handler.py`, modify `_handle_session_start()` (lines 74-87):
+
+```python
+def _handle_session_start(data: dict[str, Any]) -> int:
+    from .session_lifecycle import on_session_start
+
+    on_session_start(data)
+
+    try:
+        from .decision_hooks import on_session_start_decisions
+
+        result = on_session_start_decisions(data)
+        if result:
+            print(result)
+    except Exception:
+        pass
+
+    try:
+        _surface_lessons_on_start(data)
+    except Exception:
+        pass
+
+    return 0
+
+
+def _surface_lessons_on_start(data: dict[str, Any]) -> None:
+    """Surface relevant lessons at SessionStart. Never raises to caller."""
+    from ..core.config import load_config
+    from ..core.project import find_git_root
+
+    cwd = data.get("cwd", ".")
+    repo_path = find_git_root(cwd)
+    if not repo_path:
+        return
+
+    config = load_config(repo_path)
+    if not config.get("capture", {}).get("surface_lessons_on_start", True):
+        return
+
+    session_id = data.get("session_id")
+
+    from ..core.decision_prompt_surfacing import (
+        _get_recent_commit_file_paths,
+        _get_uncommitted_file_paths,
+    )
+    from ..core.lesson_surfacing import (
+        format_lesson_entry,
+        rank_lessons_for_prompt,
+    )
+    from ..db import get_db
+
+    file_paths = _get_uncommitted_file_paths(repo_path)
+    commit_file_paths = _get_recent_commit_file_paths(repo_path, limit=5)
+    if commit_file_paths:
+        seen = set(file_paths)
+        for p in commit_file_paths:
+            if p not in seen:
+                seen.add(p)
+                file_paths.append(p)
+
+    conn = get_db(repo_path)
+    try:
+        lessons = rank_lessons_for_prompt(conn, file_paths=file_paths, limit=5)
+        if not lessons:
+            return
+
+        from ..core.context import transaction
+        from ..core.telemetry import record_retrieval_event, record_retrieval_selection
+
+        with transaction(conn):
+            event = record_retrieval_event(
+                conn,
+                source="hook",
+                search_type="lesson_surfacing",
+                target="assessment",
+                query=",".join(file_paths[:10]) if file_paths else "",
+                result_count=len(lessons),
+                latency_ms=0,
+                session_id=session_id,
+                file_filter=",".join(file_paths[:10]) if file_paths else None,
+            )
+            for idx, lesson in enumerate(lessons, start=1):
+                sel = record_retrieval_selection(
+                    conn,
+                    event["id"],
+                    result_type="assessment",
+                    result_id=lesson["id"],
+                    rank=idx,
+                    session_id=session_id,
+                )
+                lesson["selection_id"] = sel["id"]
+
+        entries = [format_lesson_entry(l, i + 1) for i, l in enumerate(lessons)]
+        output = "## Relevant Lessons\n\n" + "\n\n".join(entries)
+        print(output)
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v`
+Expected: PASS (all tests including new SessionStart tests)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q --timeout=60`
+Expected: All pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/hooks/handler.py tests/test_lesson_surfacing.py
+git commit -m "feat: SessionStart lesson surfacing with telemetry (2a)"
+```
+
+---
+
+## Task 5: PDI Lesson Surfacing (2b)
+
+**Files:**
+- Modify: `src/entirecontext/hooks/handler.py:90-191`
+- Modify: `tests/test_lesson_surfacing.py`
+
+Extend the sync PDI path to include lessons alongside decisions. Key constraints:
+1. **Decisions rank first, lessons fill remaining token budget**
+2. **Lesson ranking failure must never suppress decision injection**
+3. **Lesson ranking runs in a separate timeout thread** — uncapped work after the decision thread's join would undermine the 300ms gate. Lessons get their own 100ms timeout; if it expires, decisions still output.
+
+- [ ] **Step 1: Write PDI lesson integration tests**
+
+Append to `tests/test_lesson_surfacing.py`:
+
+```python
+def test_pdi_includes_lessons_after_decisions(lesson_setup, capsys, monkeypatch):
+    """PDI outputs both decisions and lessons in additionalContext."""
+    import entirecontext.core.config as config_mod
+    from entirecontext.core.decisions import create_decision, link_decision_to_file
+
+    ctx = lesson_setup
+    conn = ctx["conn"]
+
+    # Create a decision linked to the same file as the lesson
+    decision = create_decision(conn, title="Auth token approach", rationale="JWT refresh")
+    link_decision_to_file(conn, decision["id"], "src/auth.py")
+
+    # Write a file so git diff returns something
+    import pathlib
+    (pathlib.Path(ctx["repo_path"]) / "src").mkdir(exist_ok=True)
+    (pathlib.Path(ctx["repo_path"]) / "src" / "auth.py").write_text("# auth module\n")
+    import subprocess
+    subprocess.run(["git", "-C", ctx["repo_path"], "add", "src/auth.py"], capture_output=True)
+
+    config = {
+        "capture": {"auto_capture": True, "surface_lessons_on_start": True},
+        "decisions": {
+            "injection": {
+                "inject_on_user_prompt": True,
+                "top_k": 5,
+                "max_tokens": 800,
+                "min_confidence": 0.0,
+                "inject_timeout_ms": 5000,
+            },
+        },
+    }
+    monkeypatch.setattr(config_mod, "load_config", lambda *a, **kw: config)
+
+    from entirecontext.hooks.handler import _handle_user_prompt
+
+    data = {
+        "cwd": ctx["repo_path"],
+        "session_id": ctx["session_id"],
+        "prompt": "fix auth token refresh",
+    }
+    _handle_user_prompt(data)
+
+    captured = capsys.readouterr()
+    # The output should contain additionalContext JSON with both sections
+    import json as json_mod
+    for line in captured.out.strip().split("\n"):
+        try:
+            parsed = json_mod.loads(line)
+            ctx_text = parsed.get("hookSpecificOutput", {}).get("additionalContext", "")
+            if "Related Decisions" in ctx_text:
+                assert "Relevant Lessons" in ctx_text or "Lesson" in ctx_text.lower()
+                return
+        except json_mod.JSONDecodeError:
+            continue
+
+
+def test_pdi_lesson_failure_does_not_suppress_decisions(lesson_setup, capsys, monkeypatch):
+    """If lesson ranking throws, decisions still appear in output."""
+    import entirecontext.core.config as config_mod
+    from entirecontext.core.decisions import create_decision, link_decision_to_file
+
+    ctx = lesson_setup
+    conn = ctx["conn"]
+
+    decision = create_decision(conn, title="Auth decision", rationale="JWT approach")
+    link_decision_to_file(conn, decision["id"], "src/auth.py")
+
+    import pathlib
+    (pathlib.Path(ctx["repo_path"]) / "src").mkdir(exist_ok=True)
+    (pathlib.Path(ctx["repo_path"]) / "src" / "auth.py").write_text("# auth\n")
+    import subprocess
+    subprocess.run(["git", "-C", ctx["repo_path"], "add", "src/auth.py"], capture_output=True)
+
+    config = {
+        "capture": {"auto_capture": True},
+        "decisions": {
+            "injection": {
+                "inject_on_user_prompt": True,
+                "top_k": 5,
+                "max_tokens": 800,
+                "min_confidence": 0.0,
+                "inject_timeout_ms": 5000,
+            },
+        },
+    }
+    monkeypatch.setattr(config_mod, "load_config", lambda *a, **kw: config)
+
+    # Make lesson ranking blow up
+    monkeypatch.setattr(
+        "entirecontext.core.lesson_surfacing.rank_lessons_for_prompt",
+        lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("lesson boom")),
+    )
+
+    from entirecontext.hooks.handler import _handle_user_prompt
+
+    data = {
+        "cwd": ctx["repo_path"],
+        "session_id": ctx["session_id"],
+        "prompt": "fix auth",
+    }
+    result = _handle_user_prompt(data)
+    assert result == 0
+
+    captured = capsys.readouterr()
+    assert "Related Decisions" in captured.out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v -k "pdi"`
+Expected: FAIL
+
+- [ ] **Step 3: Extend PDI sync path in handler.py**
+
+Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace lines 173-187 (the stdout JSON output block) with:
+
+```python
+        if trimmed:
+            from ..core.decision_prompt_surfacing import _format_decision_entry
+
+            entries = [_format_decision_entry(d, i + 1) for i, d in enumerate(trimmed)]
+            md = "## Related Decisions\n\n" + "\n\n".join(entries)
+
+            # Best-effort lesson surfacing in separate timeout thread —
+            # lesson latency must never block decision output.
+            lesson_md = None
+            try:
+                remaining_tokens = max_tokens - _estimate_tokens(md)
+                _lesson_result: list[str | None] = []
+
+                def _lesson_wrapper() -> None:
+                    try:
+                        _lesson_result.append(
+                            _rank_and_format_lessons_for_pdi(
+                                repo_path, session_id, config, remaining_tokens
+                            )
+                        )
+                    except Exception:
+                        _lesson_result.append(None)
+
+                lt = threading.Thread(target=_lesson_wrapper, daemon=True)
+                lt.start()
+                lt.join(timeout=0.1)  # 100ms — lessons are best-effort
+                if not lt.is_alive() and _lesson_result and _lesson_result[0]:
+                    lesson_md = _lesson_result[0]
+            except Exception:
+                pass
+
+            if lesson_md:
+                md = md + "\n\n" + lesson_md
+
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "additionalContext": md,
+                        }
+                    }
+                )
+            )
+```
+
+Add this helper function after `_handle_user_prompt()`:
+
+```python
+def _rank_and_format_lessons_for_pdi(
+    repo_path: str, session_id: str | None, config: dict, remaining_tokens: int
+) -> str | None:
+    """Rank and format lessons for PDI. Returns Markdown or None. Never raises."""
+    if remaining_tokens < 100:
+        return None
+
+    from ..core.decision_prompt_surfacing import (
+        _get_recent_commit_file_paths,
+        _get_uncommitted_file_paths,
+    )
+    from ..core.lesson_surfacing import format_lesson_entry, rank_lessons_for_prompt
+    from ..db import get_db
+
+    file_paths = _get_uncommitted_file_paths(repo_path)
+    commit_file_paths = _get_recent_commit_file_paths(repo_path, limit=5)
+    if commit_file_paths:
+        seen = set(file_paths)
+        for p in commit_file_paths:
+            if p not in seen:
+                seen.add(p)
+                file_paths.append(p)
+
+    conn = get_db(repo_path)
+    try:
+        lessons = rank_lessons_for_prompt(conn, file_paths=file_paths, limit=3)
+        if not lessons:
+            return None
+
+        from ..core.context import transaction
+        from ..core.telemetry import record_retrieval_event, record_retrieval_selection
+
+        with transaction(conn):
+            event = record_retrieval_event(
+                conn,
+                source="hook",
+                search_type="lesson_surfacing",
+                target="assessment",
+                query=",".join(file_paths[:10]) if file_paths else "",
+                result_count=len(lessons),
+                latency_ms=0,
+                session_id=session_id,
+                file_filter=",".join(file_paths[:10]) if file_paths else None,
+            )
+            for idx, lesson in enumerate(lessons, start=1):
+                record_retrieval_selection(
+                    conn,
+                    event["id"],
+                    result_type="assessment",
+                    result_id=lesson["id"],
+                    rank=idx,
+                    session_id=session_id,
+                )
+
+        entries = [format_lesson_entry(l, i + 1) for i, l in enumerate(lessons)]
+        result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
+
+        if _estimate_tokens(result) > remaining_tokens:
+            while entries and _estimate_tokens("## Relevant Lessons\n\n" + "\n\n".join(entries)) > remaining_tokens:
+                entries.pop()
+            if not entries:
+                return None
+            result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
+
+        return result
+    finally:
+        conn.close()
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate: ~4 chars per token."""
+    return len(text) // 4
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_lesson_surfacing.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run existing PDI tests for regressions**
+
+Run: `uv run pytest tests/test_pdi_handler.py tests/test_pdi_optimizer.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/hooks/handler.py tests/test_lesson_surfacing.py
+git commit -m "feat: PDI lesson surfacing — decisions priority, lessons fill remainder (2b)"
+```
+
+---
+
+## Task 6: Auto-Apply Extension for Lessons
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_apply.py:74-186`
+- Create: `tests/test_lesson_auto_apply.py`
+
+Extend `_detect_overlapping_decisions()` to also detect surfaced assessment/lesson selections. For lessons, file overlap uses the checkpoint's `files_snapshot` keys instead of `decision_files`. Includes dedup guard (no duplicate `context_application` per `selection_id` in same session).
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/test_lesson_auto_apply.py
+"""Tests for auto_apply lesson extension — lesson file-overlap detection."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from entirecontext.core.auto_apply import infer_applied_decisions
+from entirecontext.core.checkpoint import create_checkpoint
+from entirecontext.core.futures import add_feedback, create_assessment
+from entirecontext.core.session import create_session
+from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
+from entirecontext.core.turn import create_turn
+
+
+@pytest.fixture
+def lesson_auto_apply_setup(ec_db, ec_repo):
+    """Seed: session with lesson surfaced + file overlap."""
+    conn = ec_db
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    # Origin session with lesson
+    origin_session = create_session(conn, project_id, session_type="claude")
+    origin_cp = create_checkpoint(
+        conn,
+        origin_session["id"],
+        git_commit_hash="origin123",
+        files_snapshot={"src/auth.py": "hash1", "src/middleware.py": "hash2"},
+    )
+    assessment = create_assessment(
+        conn,
+        checkpoint_id=origin_cp["id"],
+        verdict="expand",
+        impact_summary="Auth token improvement",
+    )
+    add_feedback(conn, assessment["id"], "agree", "Works well")
+
+    # Current session: lesson surfaced, then files modified
+    current_session = create_session(conn, project_id, session_type="claude")
+    current_session_id = current_session["id"]
+
+    turn = create_turn(
+        conn,
+        current_session_id,
+        turn_number=1,
+        user_message="improve auth",
+        files_touched=json.dumps(["src/auth.py", "src/utils.py"]),
+        tools_used=json.dumps(["Edit"]),
+    )
+
+    # Surfacing telemetry (lesson surfaced at session start)
+    event = record_retrieval_event(
+        conn,
+        source="hook",
+        search_type="lesson_surfacing",
+        target="assessment",
+        query="src/auth.py",
+        result_count=1,
+        latency_ms=0,
+        session_id=current_session_id,
+    )
+    selection = record_retrieval_selection(
+        conn,
+        event["id"],
+        result_type="assessment",
+        result_id=assessment["id"],
+        rank=1,
+        session_id=current_session_id,
+        turn_id=turn["id"],
+    )
+
+    return {
+        "conn": conn,
+        "repo_path": str(ec_repo),
+        "project_id": project_id,
+        "current_session_id": current_session_id,
+        "assessment_id": assessment["id"],
+        "selection_id": selection["id"],
+        "checkpoint_id": origin_cp["id"],
+    }
+
+
+def test_lesson_overlap_creates_context_application(lesson_auto_apply_setup):
+    """Lesson with file overlap creates context_application with source_type='assessment'."""
+    ctx = lesson_auto_apply_setup
+    conn = ctx["conn"]
+
+    result = infer_applied_decisions(conn, ctx["current_session_id"], repo_path=ctx["repo_path"])
+    assert result["applied_count"] >= 1
+
+    app_row = conn.execute(
+        "SELECT * FROM context_applications WHERE source_type = 'assessment' AND session_id = ?",
+        (ctx["current_session_id"],),
+    ).fetchone()
+    assert app_row is not None
+    assert app_row["application_type"] == "lesson_applied"
+    assert app_row["source_id"] == ctx["assessment_id"]
+
+
+def test_lesson_no_overlap_no_application(ec_db, ec_repo):
+    """Lesson whose checkpoint files don't overlap session files => no application."""
+    conn = ec_db
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    origin_session = create_session(conn, project_id)
+    origin_cp = create_checkpoint(
+        conn,
+        origin_session["id"],
+        git_commit_hash="abc",
+        files_snapshot={"unrelated/other.py": "hash"},
+    )
+    assessment = create_assessment(
+        conn,
+        checkpoint_id=origin_cp["id"],
+        verdict="neutral",
+        impact_summary="Unrelated lesson",
+    )
+    add_feedback(conn, assessment["id"], "agree")
+
+    current_session = create_session(conn, project_id)
+    turn = create_turn(
+        conn,
+        current_session["id"],
+        turn_number=1,
+        user_message="work",
+        files_touched=json.dumps(["src/totally_different.py"]),
+        tools_used=json.dumps(["Edit"]),
+    )
+
+    event = record_retrieval_event(
+        conn,
+        source="hook",
+        search_type="lesson_surfacing",
+        target="assessment",
+        query="",
+        result_count=1,
+        latency_ms=0,
+        session_id=current_session["id"],
+    )
+    record_retrieval_selection(
+        conn,
+        event["id"],
+        result_type="assessment",
+        result_id=assessment["id"],
+        rank=1,
+        session_id=current_session["id"],
+        turn_id=turn["id"],
+    )
+
+    result = infer_applied_decisions(conn, current_session["id"], repo_path=str(ec_repo))
+    # No decision applications either
+    apps = conn.execute(
+        "SELECT * FROM context_applications WHERE session_id = ?",
+        (current_session["id"],),
+    ).fetchall()
+    assert len(apps) == 0
+
+
+def test_lesson_idempotent_no_duplicates(lesson_auto_apply_setup):
+    """Running inference twice does not create duplicate context_applications."""
+    ctx = lesson_auto_apply_setup
+    conn = ctx["conn"]
+
+    infer_applied_decisions(conn, ctx["current_session_id"], repo_path=ctx["repo_path"])
+    infer_applied_decisions(conn, ctx["current_session_id"], repo_path=ctx["repo_path"])
+
+    apps = conn.execute(
+        "SELECT * FROM context_applications WHERE source_type = 'assessment' AND session_id = ?",
+        (ctx["current_session_id"],),
+    ).fetchall()
+    assert len(apps) == 1
+
+
+def test_lesson_and_decision_both_detected(lesson_auto_apply_setup):
+    """Both decision and lesson overlap detected in same session."""
+    from entirecontext.core.decisions import create_decision, link_decision_to_file
+
+    ctx = lesson_auto_apply_setup
+    conn = ctx["conn"]
+
+    decision = create_decision(conn, title="Use JWT refresh", rationale="Better UX")
+    link_decision_to_file(conn, decision["id"], "src/auth.py")
+
+    event = record_retrieval_event(
+        conn,
+        source="hook",
+        search_type="decision_surface",
+        target="decisions",
+        query="auth",
+        result_count=1,
+        latency_ms=5,
+        session_id=ctx["current_session_id"],
+    )
+    turn_row = conn.execute(
+        "SELECT id FROM turns WHERE session_id = ? LIMIT 1",
+        (ctx["current_session_id"],),
+    ).fetchone()
+    record_retrieval_selection(
+        conn,
+        event["id"],
+        result_type="decision",
+        result_id=decision["id"],
+        session_id=ctx["current_session_id"],
+        turn_id=turn_row["id"],
+    )
+
+    result = infer_applied_decisions(conn, ctx["current_session_id"], repo_path=ctx["repo_path"])
+
+    # Both types should be recorded
+    decision_apps = conn.execute(
+        "SELECT * FROM context_applications WHERE source_type = 'decision' AND session_id = ?",
+        (ctx["current_session_id"],),
+    ).fetchall()
+    lesson_apps = conn.execute(
+        "SELECT * FROM context_applications WHERE source_type = 'assessment' AND session_id = ?",
+        (ctx["current_session_id"],),
+    ).fetchall()
+    assert len(decision_apps) >= 1
+    assert len(lesson_apps) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_lesson_auto_apply.py -v`
+Expected: FAIL (lesson selections not detected by current auto_apply)
+
+- [ ] **Step 3: Extend auto_apply.py with lesson overlap detection**
+
+Add a new function `_detect_overlapping_lessons()` and integrate it into `infer_applied_decisions()`:
+
+```python
+# Add after _detect_overlapping_decisions() in auto_apply.py
+
+def _detect_overlapping_lessons(
+    conn: sqlite3.Connection, session_id: str, repo_path: str | None = None
+) -> list[dict[str, Any]]:
+    """Detect surfaced lessons/assessments with file overlap. No writes.
+
+    Checks retrieval_selections with result_type IN ('assessment', 'lesson'),
+    cross-references with checkpoint files_snapshot, and compares with
+    session-modified files. Deduplicates by result_id.
+    Skips if a context_application already exists for this selection+session.
+    """
+    modified_files = _collect_session_modified_files(conn, session_id, repo_path)
+    if not modified_files:
+        return []
+
+    rows = conn.execute(
+        """
+        SELECT rs.id AS selection_id, rs.result_id AS assessment_id,
+               rs.result_type, rs.turn_id, t.turn_number, rs.created_at
+        FROM retrieval_selections rs
+        JOIN retrieval_events re ON re.id = rs.retrieval_event_id
+        LEFT JOIN turns t ON t.id = rs.turn_id
+        WHERE rs.session_id = ?
+          AND rs.result_type IN ('assessment', 'lesson')
+          AND NOT EXISTS (
+              SELECT 1 FROM context_applications ca
+              WHERE ca.retrieval_selection_id = rs.id
+                AND ca.session_id = ?
+          )
+        ORDER BY rs.result_id, COALESCE(t.turn_number, 0) ASC, rs.created_at ASC
+        """,
+        (session_id, session_id),
+    ).fetchall()
+
+    seen_assessments: set[str] = set()
+    matches: list[dict[str, Any]] = []
+
+    repo_root = os.path.realpath(repo_path) if repo_path else None
+
+    for row in rows:
+        assessment_id = row["assessment_id"]
+        if assessment_id in seen_assessments:
+            continue
+
+        # Get file paths from the assessment's checkpoint's files_snapshot
+        checkpoint_files_row = conn.execute(
+            """
+            SELECT c.files_snapshot
+            FROM assessments a
+            JOIN checkpoints c ON c.id = a.checkpoint_id
+            WHERE a.id = ?
+              AND c.files_snapshot IS NOT NULL
+            """,
+            (assessment_id,),
+        ).fetchone()
+
+        if not checkpoint_files_row:
+            continue
+
+        try:
+            snapshot = json.loads(checkpoint_files_row["files_snapshot"])
+            if isinstance(snapshot, dict):
+                lesson_paths = set(snapshot.keys())
+            elif isinstance(snapshot, list):
+                lesson_paths = {str(p) for p in snapshot if p}
+            else:
+                continue
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        normalized_lesson_paths = {_normalize_file_path(p, repo_root) for p in lesson_paths}
+
+        surfaced_turn = row["turn_number"] or 0
+        overlap = {
+            path
+            for path in normalized_lesson_paths
+            if path in modified_files and any(t >= surfaced_turn for t in modified_files[path])
+        }
+        if not overlap:
+            continue
+
+        seen_assessments.add(assessment_id)
+        matches.append(
+            {
+                "assessment_id": assessment_id,
+                "selection_id": row["selection_id"],
+                "result_type": row["result_type"],
+                "turn_id": row["turn_id"],
+                "overlap_files": sorted(overlap),
+            }
+        )
+
+    return matches
+```
+
+Then modify `infer_applied_decisions()` to call both detectors:
+
+```python
+def infer_applied_decisions(
+    conn: sqlite3.Connection, session_id: str, *, dry_run: bool = False, repo_path: str | None = None
+) -> dict[str, Any]:
+    """Infer outcomes for decisions and lessons whose files were modified this session."""
+    matches = _detect_overlapping_decisions(conn, session_id, repo_path)
+    lesson_matches = _detect_overlapping_lessons(conn, session_id, repo_path)
+
+    if dry_run or (not matches and not lesson_matches):
+        return {"applied_count": len(matches) + len(lesson_matches), "applied_decisions": []}
+
+    applied: list[dict[str, Any]] = []
+
+    # Decision outcomes
+    for match in matches:
+        note = f"auto: session_end file_overlap ({', '.join(match['overlap_files'][:3])})"
+        infer_session = session_id
+        infer_turn = match["turn_id"]
+        if infer_session and not infer_turn:
+            infer_session = None
+        with transaction(conn):
+            record_context_application(
+                conn,
+                application_type="decision_change",
+                selection_id=match["selection_id"],
+                session_id=infer_session,
+                turn_id=infer_turn,
+                note=note,
+            )
+            record_decision_outcome(
+                conn,
+                match["decision_id"],
+                outcome_type="accepted",
+                retrieval_selection_id=match["selection_id"],
+                session_id=infer_session,
+                turn_id=infer_turn,
+                note=note,
+            )
+        applied.append(match)
+
+    # Lesson applications (no decision_outcome — assessments aren't decisions)
+    for match in lesson_matches:
+        note = f"auto: session_end lesson_overlap ({', '.join(match['overlap_files'][:3])})"
+        infer_session = session_id
+        infer_turn = match["turn_id"]
+        if infer_session and not infer_turn:
+            infer_session = None
+        with transaction(conn):
+            record_context_application(
+                conn,
+                application_type="lesson_applied",
+                selection_id=match["selection_id"],
+                session_id=infer_session,
+                turn_id=infer_turn,
+                note=note,
+            )
+        applied.append(match)
+
+    return {"applied_count": len(applied), "applied_decisions": applied}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_lesson_auto_apply.py -v`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Run existing auto_apply tests for regressions**
+
+Run: `uv run pytest tests/test_auto_apply.py tests/test_auto_apply_backfill.py -v`
+Expected: PASS (no regressions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/auto_apply.py tests/test_lesson_auto_apply.py
+git commit -m "feat: auto-apply lesson file-overlap detection with checkpoint files_snapshot"
+```
+
+---
+
+## Task 7: Outcome Inference Layer 2 (refined/replaced)
+
+**Files:**
+- Modify: `src/entirecontext/core/auto_apply.py`
+- Create: `tests/test_outcome_inference.py`
+
+Layer 2: When file-overlap is detected AND a new decision was created in the same session with overlapping `decision_files`, classify as `refined` (net additions) or `replaced` (net deletions/replacement). Gate: `decisions.infer_outcome_type` config.
+
+The session start commit is stored in `sessions.metadata->start_git_commit` (set at `session_lifecycle.py:122`). Diff analysis: `git diff --numstat <start_commit>..HEAD -- <overlapping_files>`.
+
+- [ ] **Step 1: Write tests**
+
+```python
+# tests/test_outcome_inference.py
+"""Tests for Layer 2 outcome inference: refined/replaced classification."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from entirecontext.core.auto_apply import infer_applied_decisions
+from entirecontext.core.decisions import create_decision, link_decision_to_file
+from entirecontext.core.session import create_session
+from entirecontext.core.telemetry import record_retrieval_event, record_retrieval_selection
+from entirecontext.core.turn import create_turn
+
+
+@pytest.fixture
+def outcome_setup(ec_db, ec_repo):
+    """Seed: surfaced decision + new decision in same session + file overlap."""
+    conn = ec_db
+    repo_path = str(ec_repo)
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    # Surfaced (old) decision
+    old_decision = create_decision(conn, title="Original auth approach", rationale="Basic token")
+    link_decision_to_file(conn, old_decision["id"], "src/auth.py")
+
+    # Session
+    session = create_session(conn, project_id, session_type="claude")
+    session_id = session["id"]
+
+    # Record start commit
+    start_sha = subprocess.run(
+        ["git", "-C", repo_path, "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    conn.execute(
+        "UPDATE sessions SET metadata = ? WHERE id = ?",
+        (json.dumps({"start_git_commit": start_sha}), session_id),
+    )
+
+    turn = create_turn(
+        conn,
+        session_id,
+        turn_number=1,
+        user_message="refine auth",
+        files_touched=json.dumps(["src/auth.py"]),
+        tools_used=json.dumps(["Edit"]),
+    )
+
+    # Surface old decision
+    event = record_retrieval_event(
+        conn,
+        source="hook",
+        search_type="decision_surface",
+        target="decisions",
+        query="auth",
+        result_count=1,
+        latency_ms=5,
+        session_id=session_id,
+        turn_id=turn["id"],
+    )
+    selection = record_retrieval_selection(
+        conn,
+        event["id"],
+        result_type="decision",
+        result_id=old_decision["id"],
+        session_id=session_id,
+        turn_id=turn["id"],
+    )
+
+    # New decision in same session (overlapping file)
+    new_decision = create_decision(conn, title="Refined auth with refresh tokens", rationale="Better UX")
+    link_decision_to_file(conn, new_decision["id"], "src/auth.py")
+
+    return {
+        "conn": conn,
+        "repo_path": repo_path,
+        "session_id": session_id,
+        "old_decision_id": old_decision["id"],
+        "new_decision_id": new_decision["id"],
+        "selection_id": selection["id"],
+        "turn_id": turn["id"],
+        "start_sha": start_sha,
+    }
+
+
+def test_refined_outcome_on_net_additions(outcome_setup):
+    """New decision + net additions in overlapping files => refined."""
+    import pathlib
+
+    ctx = outcome_setup
+    conn = ctx["conn"]
+    repo_path = ctx["repo_path"]
+
+    # Create file with net additions (more added than deleted)
+    auth_file = pathlib.Path(repo_path) / "src" / "auth.py"
+    auth_file.parent.mkdir(parents=True, exist_ok=True)
+    auth_file.write_text("# auth\ndef login():\n    pass\n\ndef refresh():\n    pass\n")
+    subprocess.run(["git", "-C", repo_path, "add", "src/auth.py"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", repo_path, "commit", "-m", "add auth"],
+        capture_output=True,
+    )
+
+    result = infer_applied_decisions(conn, ctx["session_id"], repo_path=repo_path)
+    assert result["applied_count"] == 1
+
+    outcome = conn.execute(
+        "SELECT * FROM decision_outcomes WHERE decision_id = ? AND session_id = ?",
+        (ctx["old_decision_id"], ctx["session_id"]),
+    ).fetchone()
+    assert outcome is not None
+    assert outcome["outcome_type"] == "refined"
+
+
+def test_replaced_outcome_on_net_deletions(outcome_setup):
+    """New decision + net deletions in overlapping files => replaced."""
+    import pathlib
+
+    ctx = outcome_setup
+    conn = ctx["conn"]
+    repo_path = ctx["repo_path"]
+
+    # Create initial file, commit, then delete most of it
+    auth_file = pathlib.Path(repo_path) / "src" / "auth.py"
+    auth_file.parent.mkdir(parents=True, exist_ok=True)
+    auth_file.write_text("# auth\ndef old_login():\n    pass\n\ndef old_refresh():\n    pass\n\ndef old_validate():\n    pass\n")
+    subprocess.run(["git", "-C", repo_path, "add", "src/auth.py"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", repo_path, "commit", "-m", "old auth"],
+        capture_output=True,
+    )
+
+    # Update start_sha to before the replacement
+    start_sha = subprocess.run(
+        ["git", "-C", repo_path, "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    conn.execute(
+        "UPDATE sessions SET metadata = ? WHERE id = ?",
+        (json.dumps({"start_git_commit": start_sha}), ctx["session_id"]),
+    )
+
+    # Now replace with less content
+    auth_file.write_text("# new auth\ndef login():\n    pass\n")
+    subprocess.run(["git", "-C", repo_path, "add", "src/auth.py"], capture_output=True)
+    subprocess.run(
+        ["git", "-C", repo_path, "commit", "-m", "replace auth"],
+        capture_output=True,
+    )
+
+    result = infer_applied_decisions(conn, ctx["session_id"], repo_path=repo_path)
+    assert result["applied_count"] == 1
+
+    outcome = conn.execute(
+        "SELECT * FROM decision_outcomes WHERE decision_id = ? AND session_id = ?",
+        (ctx["old_decision_id"], ctx["session_id"]),
+    ).fetchone()
+    assert outcome is not None
+    assert outcome["outcome_type"] == "replaced"
+
+
+def test_accepted_outcome_when_no_new_decision(ec_db, ec_repo):
+    """File overlap without new decision => accepted (existing behavior)."""
+    conn = ec_db
+    repo_path = str(ec_repo)
+    project_id = conn.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
+
+    decision = create_decision(conn, title="Original approach", rationale="Simple")
+    link_decision_to_file(conn, decision["id"], "src/foo.py")
+
+    session = create_session(conn, project_id)
+    turn = create_turn(
+        conn,
+        session["id"],
+        turn_number=1,
+        user_message="work",
+        files_touched=json.dumps(["src/foo.py"]),
+        tools_used=json.dumps(["Edit"]),
+    )
+
+    event = record_retrieval_event(
+        conn,
+        source="hook",
+        search_type="decision_surface",
+        target="decisions",
+        query="foo",
+        result_count=1,
+        latency_ms=5,
+        session_id=session["id"],
+        turn_id=turn["id"],
+    )
+    record_retrieval_selection(
+        conn,
+        event["id"],
+        result_type="decision",
+        result_id=decision["id"],
+        session_id=session["id"],
+        turn_id=turn["id"],
+    )
+
+    result = infer_applied_decisions(conn, session["id"], repo_path=repo_path)
+    assert result["applied_count"] == 1
+
+    outcome = conn.execute(
+        "SELECT * FROM decision_outcomes WHERE decision_id = ?",
+        (decision["id"],),
+    ).fetchone()
+    assert outcome["outcome_type"] == "accepted"
+
+
+def test_infer_outcome_type_config_off_falls_back_to_accepted(outcome_setup, monkeypatch):
+    """infer_outcome_type=False => always 'accepted' even with new decision."""
+    import pathlib
+
+    ctx = outcome_setup
+    conn = ctx["conn"]
+    repo_path = ctx["repo_path"]
+
+    auth_file = pathlib.Path(repo_path) / "src" / "auth.py"
+    auth_file.parent.mkdir(parents=True, exist_ok=True)
+    auth_file.write_text("# new\n")
+    subprocess.run(["git", "-C", repo_path, "add", "src/auth.py"], capture_output=True)
+    subprocess.run(["git", "-C", repo_path, "commit", "-m", "change"], capture_output=True)
+
+    # Disable Layer 2
+    import entirecontext.core.config as config_mod
+    original_load = config_mod.load_config
+
+    def patched_load(path):
+        c = original_load(path)
+        c.setdefault("decisions", {})["infer_outcome_type"] = False
+        return c
+
+    monkeypatch.setattr(config_mod, "load_config", patched_load)
+
+    result = infer_applied_decisions(conn, ctx["session_id"], repo_path=repo_path)
+
+    outcome = conn.execute(
+        "SELECT * FROM decision_outcomes WHERE decision_id = ? AND session_id = ?",
+        (ctx["old_decision_id"], ctx["session_id"]),
+    ).fetchone()
+    assert outcome["outcome_type"] == "accepted"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_outcome_inference.py -v`
+Expected: FAIL (refined/replaced outcomes not implemented yet)
+
+- [ ] **Step 3: Implement Layer 2 outcome classification**
+
+Add these functions to `auto_apply.py`:
+
+```python
+import subprocess
+
+
+def _has_new_decision_with_file_overlap(
+    conn: sqlite3.Connection, session_id: str, decision_id: str
+) -> bool:
+    """Check if a new decision was created in this session with overlapping decision_files."""
+    session_row = conn.execute(
+        "SELECT created_at FROM sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    if not session_row:
+        return False
+
+    session_start = session_row["created_at"]
+
+    original_files = {
+        r["file_path"]
+        for r in conn.execute(
+            "SELECT file_path FROM decision_files WHERE decision_id = ?", (decision_id,)
+        ).fetchall()
+    }
+    if not original_files:
+        return False
+
+    new_decisions = conn.execute(
+        """
+        SELECT DISTINCT d.id
+        FROM decisions d
+        JOIN decision_files df ON df.decision_id = d.id
+        WHERE d.created_at >= ?
+          AND d.id != ?
+        """,
+        (session_start, decision_id),
+    ).fetchall()
+
+    for row in new_decisions:
+        new_files = {
+            r["file_path"]
+            for r in conn.execute(
+                "SELECT file_path FROM decision_files WHERE decision_id = ?", (row["id"],)
+            ).fetchall()
+        }
+        if original_files & new_files:
+            return True
+
+    return False
+
+
+def _classify_diff_pattern(
+    repo_path: str, session_id: str, overlap_files: list[str], conn: sqlite3.Connection
+) -> str:
+    """Classify diff as 'refined' (net additions) or 'replaced' (net deletions).
+
+    Uses git diff --numstat between session start commit and HEAD,
+    filtered to overlapping files.
+    """
+    session_row = conn.execute(
+        "SELECT metadata FROM sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    if not session_row or not session_row["metadata"]:
+        return "accepted"
+
+    try:
+        metadata = json.loads(session_row["metadata"])
+        start_sha = metadata.get("start_git_commit")
+    except (json.JSONDecodeError, TypeError):
+        return "accepted"
+
+    if not start_sha:
+        return "accepted"
+
+    try:
+        cmd = ["git", "diff", "--numstat", f"{start_sha}..HEAD", "--"] + overlap_files
+        result = subprocess.run(
+            cmd, cwd=repo_path, capture_output=True, text=True, timeout=5
+        )
+        if result.returncode != 0:
+            return "accepted"
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return "accepted"
+
+    total_added = 0
+    total_deleted = 0
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            try:
+                added = int(parts[0]) if parts[0] != "-" else 0
+                deleted = int(parts[1]) if parts[1] != "-" else 0
+                total_added += added
+                total_deleted += deleted
+            except ValueError:
+                continue
+
+    if total_added == 0 and total_deleted == 0:
+        return "accepted"
+
+    if total_added > total_deleted:
+        return "refined"
+    else:
+        return "replaced"
+```
+
+Then modify the decision loop in `infer_applied_decisions()`:
+
+```python
+    # Decision outcomes — with Layer 2 classification
+    for match in matches:
+        note = f"auto: session_end file_overlap ({', '.join(match['overlap_files'][:3])})"
+        infer_session = session_id
+        infer_turn = match["turn_id"]
+        if infer_session and not infer_turn:
+            infer_session = None
+
+        # Layer 2: classify outcome type
+        outcome_type = "accepted"
+        if repo_path:
+            from .config import load_config
+
+            config = load_config(repo_path)
+            if config.get("decisions", {}).get("infer_outcome_type", True):
+                if _has_new_decision_with_file_overlap(conn, session_id, match["decision_id"]):
+                    outcome_type = _classify_diff_pattern(
+                        repo_path, session_id, match["overlap_files"], conn
+                    )
+                    note = f"auto: session_end {outcome_type} ({', '.join(match['overlap_files'][:3])})"
+
+        with transaction(conn):
+            record_context_application(
+                conn,
+                application_type="decision_change",
+                selection_id=match["selection_id"],
+                session_id=infer_session,
+                turn_id=infer_turn,
+                note=note,
+            )
+            record_decision_outcome(
+                conn,
+                match["decision_id"],
+                outcome_type=outcome_type,
+                retrieval_selection_id=match["selection_id"],
+                session_id=infer_session,
+                turn_id=infer_turn,
+                note=note,
+            )
+        applied.append(match)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_outcome_inference.py -v`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Run all auto_apply tests for regressions**
+
+Run: `uv run pytest tests/test_auto_apply.py tests/test_auto_apply_backfill.py tests/test_lesson_auto_apply.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/core/auto_apply.py tests/test_outcome_inference.py
+git commit -m "feat: Layer 2 outcome inference — refined/replaced via new-decision gate + diff pattern"
+```
+
+---
+
+## Task 8: Documentation + Full Verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `ROADMAP.md`
+
+- [ ] **Step 1: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- Lesson surfacing: SessionStart broad-context surfacing with file-overlap ranking
+- Lesson surfacing: PDI narrow-context injection (decisions priority, lessons fill remainder)
+- Git-evidence outcome inference: Layer 2 refined/replaced classification via new-decision gate + diff pattern
+- Auto-apply extension: lesson/assessment file-overlap detection using checkpoint files_snapshot
+- Config: `capture.surface_lessons_on_start`, `decisions.infer_outcome_type`
+
+### Changed
+- Performance test threshold: 250ms → 300ms (CI runner variance tolerance)
+- RELEASE_RULE.md: added Codex review pre-release gate
+
+### Fixed
+- Carry-forward: v0.9.3 retro items (perf threshold, release gate)
+```
+
+- [ ] **Step 2: Update ROADMAP.md v0.10.0 section**
+
+Update the v0.10.0 section to reflect completed items.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest tests/ -v --timeout=120`
+Expected: All pass
+
+- [ ] **Step 4: Run lint**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: Clean
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add CHANGELOG.md ROADMAP.md
+git commit -m "docs: v0.10.0 CHANGELOG and ROADMAP update"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (carry-forward) ─────────────────────────────────────────────┐
+Task 2 (config keys) ──┬──────────────────────────────────────────┐ │
+                        │                                          │ │
+                        ├─ Task 3 (lesson core) ──┐                │ │
+                        │                         ├─ Task 4 (2a) ─┤ │
+                        │                         │                │ │
+                        │                         └─ Task 5 (2b) ─┤ │
+                        │                                          │ │
+                        ├─ Task 6 (lesson auto-apply) ────────────┤ │
+                        │                                          │ │
+                        └─ Task 7 (outcome inference L2) ─────────┼─┤
+                                                                   │ │
+                                                          Task 8 ──┘─┘
+```
+
+Tasks 3→4→5 are sequential (each builds on the previous).
+Tasks 6 and 7 depend only on Task 2 and can run parallel to 3-5.
+Task 8 runs after all others.
+
+## Backfill (No Separate Task Needed)
+
+The existing `ec session backfill-applied` command (`session_cmds.py:583`) calls `infer_applied_decisions(conn, sid, dry_run=dry_run, repo_path=repo_path)` — the same function modified in Tasks 6 and 7. Since `repo_path` is already passed, both lesson detection and Layer 2 classification apply automatically to historical sessions. Verified via source read.
+
+## Out-of-Band Items (Manual, Not Auto-Executed)
+
+| Item | Action | Prerequisite |
+|------|--------|-------------|
+| 1a | `gh release delete v0.9.2 --yes` | User confirmation |
+| 1e | Run real SessionEnd, check `decision_candidates` table | Deployed v0.10.0 |

--- a/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-v0.10.0-implementation.md
@@ -742,6 +742,7 @@ def test_pdi_includes_lessons_after_decisions(lesson_setup, capsys, monkeypatch)
                 return
         except json_mod.JSONDecodeError:
             continue
+    pytest.fail("no hook output contained 'Related Decisions' — PDI emitted nothing")
 
 
 def test_pdi_lesson_failure_does_not_suppress_decisions(lesson_setup, capsys, monkeypatch):
@@ -813,10 +814,10 @@ Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace 
 
             # Best-effort lesson surfacing in separate timeout thread —
             # lesson latency must never block decision output.
-            lesson_md = None
+            lesson_payload = None
             try:
                 remaining_tokens = max_tokens - _estimate_tokens(md)
-                _lesson_result: list[str | None] = []
+                _lesson_result: list[tuple[str, list[dict], list[str]] | None] = []
 
                 def _lesson_wrapper() -> None:
                     try:
@@ -832,12 +833,20 @@ Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace 
                 lt.start()
                 lt.join(timeout=0.1)  # 100ms — lessons are best-effort
                 if not lt.is_alive() and _lesson_result and _lesson_result[0]:
-                    lesson_md = _lesson_result[0]
+                    lesson_payload = _lesson_result[0]
             except Exception:
                 pass
 
-            if lesson_md:
+            if lesson_payload:
+                lesson_md, emitted_lessons, lesson_files = lesson_payload
                 md = md + "\n\n" + lesson_md
+                # Selections are recorded only here, after the caller accepts
+                # the result — if the 100ms join timed out or entries were
+                # trimmed, nothing is written, so phantom selections cannot
+                # feed SessionEnd auto-apply and inflate lesson_reuse_rate.
+                _record_lesson_selections(
+                    repo_path, session_id, emitted_lessons, lesson_files
+                )
 
             print(
                 json.dumps(
@@ -851,13 +860,18 @@ Modify `_handle_user_prompt()` in `src/entirecontext/hooks/handler.py`. Replace 
             )
 ```
 
-Add this helper function after `_handle_user_prompt()`:
+Add these helper functions after `_handle_user_prompt()`:
 
 ```python
 def _rank_and_format_lessons_for_pdi(
     repo_path: str, session_id: str | None, config: dict, remaining_tokens: int
-) -> str | None:
-    """Rank and format lessons for PDI. Returns Markdown or None. Never raises."""
+) -> tuple[str, list[dict], list[str]] | None:
+    """Rank and format lessons for PDI. Never raises.
+
+    Returns (markdown, emitted_lessons, file_paths) or None. Writes NO
+    telemetry — the caller records selections only after accepting the
+    result, so trimmed or timed-out lessons never become phantom selections.
+    """
     if remaining_tokens < 100:
         return None
 
@@ -880,47 +894,62 @@ def _rank_and_format_lessons_for_pdi(
     conn = get_db(repo_path)
     try:
         lessons = rank_lessons_for_prompt(conn, file_paths=file_paths, limit=3)
-        if not lessons:
-            return None
-
-        from ..core.context import transaction
-        from ..core.telemetry import record_retrieval_event, record_retrieval_selection
-
-        with transaction(conn):
-            event = record_retrieval_event(
-                conn,
-                source="hook",
-                search_type="lesson_surfacing",
-                target="assessment",
-                query=",".join(file_paths[:10]) if file_paths else "",
-                result_count=len(lessons),
-                latency_ms=0,
-                session_id=session_id,
-                file_filter=",".join(file_paths[:10]) if file_paths else None,
-            )
-            for idx, lesson in enumerate(lessons, start=1):
-                record_retrieval_selection(
-                    conn,
-                    event["id"],
-                    result_type="assessment",
-                    result_id=lesson["id"],
-                    rank=idx,
-                    session_id=session_id,
-                )
-
-        entries = [format_lesson_entry(l, i + 1) for i, l in enumerate(lessons)]
-        result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
-
-        if _estimate_tokens(result) > remaining_tokens:
-            while entries and _estimate_tokens("## Relevant Lessons\n\n" + "\n\n".join(entries)) > remaining_tokens:
-                entries.pop()
-            if not entries:
-                return None
-            result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
-
-        return result
     finally:
         conn.close()
+    if not lessons:
+        return None
+
+    entries = [format_lesson_entry(l, i + 1) for i, l in enumerate(lessons)]
+    result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
+
+    if _estimate_tokens(result) > remaining_tokens:
+        while entries and _estimate_tokens("## Relevant Lessons\n\n" + "\n\n".join(entries)) > remaining_tokens:
+            entries.pop()
+        if not entries:
+            return None
+        result = "## Relevant Lessons\n\n" + "\n\n".join(entries)
+
+    return result, lessons[: len(entries)], file_paths
+
+
+def _record_lesson_selections(
+    repo_path: str, session_id: str | None, lessons: list[dict], file_paths: list[str]
+) -> None:
+    """Record retrieval event + selections for lessons actually injected. Never raises."""
+    if not lessons:
+        return
+    try:
+        from ..core.context import transaction
+        from ..core.telemetry import record_retrieval_event, record_retrieval_selection
+        from ..db import get_db
+
+        conn = get_db(repo_path)
+        try:
+            with transaction(conn):
+                event = record_retrieval_event(
+                    conn,
+                    source="hook",
+                    search_type="lesson_surfacing",
+                    target="assessment",
+                    query=",".join(file_paths[:10]) if file_paths else "",
+                    result_count=len(lessons),
+                    latency_ms=0,
+                    session_id=session_id,
+                    file_filter=",".join(file_paths[:10]) if file_paths else None,
+                )
+                for idx, lesson in enumerate(lessons, start=1):
+                    record_retrieval_selection(
+                        conn,
+                        event["id"],
+                        result_type="assessment",
+                        result_id=lesson["id"],
+                        rank=idx,
+                        session_id=session_id,
+                    )
+        finally:
+            conn.close()
+    except Exception:
+        pass
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1201,7 +1230,10 @@ def _detect_overlapping_lessons(
     Checks retrieval_selections with result_type IN ('assessment', 'lesson'),
     cross-references with checkpoint files_snapshot, and compares with
     session-modified files. Deduplicates by result_id.
-    Skips if a context_application already exists for this selection+session.
+    Skips if a context_application already exists for the same assessment in
+    this session — dual SessionStart+PDI surfacing can create multiple
+    selections per assessment, so the guard is per-assessment, not
+    per-selection.
     """
     modified_files = _collect_session_modified_files(conn, session_id, repo_path)
     if not modified_files:
@@ -1217,9 +1249,12 @@ def _detect_overlapping_lessons(
         WHERE rs.session_id = ?
           AND rs.result_type IN ('assessment', 'lesson')
           AND NOT EXISTS (
-              SELECT 1 FROM context_applications ca
-              WHERE ca.retrieval_selection_id = rs.id
-                AND ca.session_id = ?
+              SELECT 1
+              FROM context_applications ca
+              JOIN retrieval_selections rs2 ON rs2.id = ca.retrieval_selection_id
+              WHERE ca.session_id = ?
+                AND rs2.result_type IN ('assessment', 'lesson')
+                AND rs2.result_id = rs.result_id
           )
         ORDER BY rs.result_id, COALESCE(t.turn_number, 0) ASC, rs.created_at ASC
         """,
@@ -1647,12 +1682,20 @@ def _has_new_decision_with_file_overlap(
 ) -> bool:
     """Check if a new decision was created in this session with overlapping decision_files."""
     session_row = conn.execute(
-        "SELECT created_at FROM sessions WHERE id = ?", (session_id,)
+        "SELECT created_at, ended_at FROM sessions WHERE id = ?", (session_id,)
     ).fetchone()
     if not session_row:
         return False
 
     session_start = session_row["created_at"]
+    # Upper bound is mandatory: backfill runs over historical sessions, and
+    # without it a decision created days after an old session ended would
+    # retroactively reclassify that session's outcome as refined/replaced.
+    session_end = session_row["ended_at"]
+    if not session_end:
+        from datetime import datetime, timezone
+
+        session_end = datetime.now(timezone.utc).isoformat()
 
     original_files = {
         r["file_path"]
@@ -1669,9 +1712,10 @@ def _has_new_decision_with_file_overlap(
         FROM decisions d
         JOIN decision_files df ON df.decision_id = d.id
         WHERE d.created_at >= ?
+          AND d.created_at <= ?
           AND d.id != ?
         """,
-        (session_start, decision_id),
+        (session_start, session_end, decision_id),
     ).fetchall()
 
     for row in new_decisions:

--- a/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
+++ b/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
@@ -1,0 +1,181 @@
+# v0.10.0 Design Spec
+
+## Goal
+
+Close retro carry-forward debt, activate the lesson-reuse path for maturity 75,
+and add git-evidence outcome inference to satisfy the v1.0 autonomous-loop gate.
+
+## Success Criteria
+
+- `lesson_reuse_rate` > 0 (currently 0%)
+- Dogfooding maturity ≥ 75 (currently 69, target: Closed Loop)
+- `auto_extract` produces at least one `decision_candidate` after a real SessionEnd
+- Git-evidence outcome inference automatically records `accepted`/`refined`/`replaced`/`ignored`
+
+## 1. Carry-Forward (5 items from v0.9.3 retro)
+
+### 1a. v0.9.2 Ghost Release Cleanup
+
+Delete the orphaned GitHub release created when tag force-push + PyPI re-upload failed.
+
+`gh release delete v0.9.2 --yes`
+
+### 1b. RELEASE_RULE.md Update
+
+Add "Codex review → fix → tag push" ordering rule to `.omc/RELEASE_RULE.md` Step 4 checklist.
+Prevents PyPI immutability incidents (v0.9.2→v0.9.3 forced bump).
+
+### 1c. Codex Shift-Left Checklist
+
+Add "Codex review completed" checkbox to the release skill Step 4 pre-release checklist.
+Three consecutive releases missed this — will-based rules don't stick without structural enforcement.
+
+### 1d. Flaky Performance Test Tolerance
+
+Change `test_p95_under_250ms_at_1000` threshold from 250ms to 300ms in `tests/test_hooks_performance.py`.
+CI runner variance (254.3ms on Python 3.13) blocks merges unrelated to performance regressions.
+
+### 1e. auto_extract Production Verification
+
+After a real SessionEnd, verify `decision_candidates` table contains rows.
+Config `[decisions] auto_extract = true` has been set since v0.9.2 but zero qualifying
+SessionEnd events have occurred since. If candidates are not generated, debug the
+`SessionEnd → background worker → decision_candidates` pipeline.
+
+## 2. Lesson Surfacing
+
+### Problem
+
+`lesson_reuse_rate` is 0% because no lesson/assessment is ever surfaced automatically,
+so no `context_application` with `source_type IN ('assessment', 'lesson')` is recorded.
+This blocks 7 intervene points (`lesson_reuse_rate ≥ 0.2` threshold).
+
+### Design: Dual-Channel Surfacing
+
+#### 2a. SessionStart — Broad Context
+
+Add `_maybe_surface_lessons()` alongside existing `_maybe_surface_decisions()` in
+`hooks/session_lifecycle.py:on_session_start()`.
+
+**Retrieval logic:**
+- Query assessments with non-null feedback from recent checkpoints
+- Query lessons via the existing `ec_lessons` path (futures module)
+- Rank by recency and relevance to working-area files (reuse Signal A/B file paths)
+- Limit: top 3-5 lessons to avoid noise
+
+**Telemetry:**
+- Record `retrieval_event` (type='lesson_surfacing')
+- Record `retrieval_selection` per surfaced item (result_type='assessment' or 'lesson')
+- These selections feed into `auto_apply` file-overlap detection at SessionEnd
+
+**Config:** `[capture] surface_lessons_on_start` (default true)
+
+**Output:** stdout text block (same pattern as decision surfacing)
+
+#### 2b. PDI (UserPromptSubmit) — Narrow Context
+
+Extend the PDI pipeline to include lessons alongside decisions in `additionalContext`.
+
+**Implementation options (choose during planning):**
+- Option 1: Add lesson ranking to `rank_decisions_for_prompt()` directly
+- Option 2: Separate `rank_lessons_for_prompt()` with results merged before injection
+
+**Ranking signals:** Same as decision PDI — file-path overlap (Signal A + B), recency.
+
+**Token budget:** Lessons share the existing `context_budget_tokens` allocation with decisions.
+Decisions take priority; lessons fill remaining budget.
+
+**Telemetry:** Same as 2a — retrieval_event + retrieval_selection with appropriate result_type.
+
+### Lesson Reuse Rate Activation Path
+
+```
+SessionStart/PDI surfaces lesson → retrieval_selection (result_type='assessment'/'lesson')
+    ↓
+SessionEnd auto_apply detects file overlap → context_application (source_type='assessment'/'lesson')
+    ↓
+lesson_reuse_rate = count(source_type IN assessment/lesson) / count(all) ≥ 0.2
+    ↓
+intervene_score += 7
+```
+
+**Key invariant:** The existing `auto_apply` file-overlap logic already uses
+`retrieval_selection.result_type` as `context_application.source_type` (via
+`record_context_application` which copies from selection). No schema change needed —
+only the surfacing pipeline needs to produce selections with the right result_type.
+
+## 3. Git-Evidence Outcome Inference
+
+### Problem
+
+The v1.0 gate requires the `capture→distill→retrieve→intervene→outcome` loop to
+complete without manual intervention. Current gap: `accepted` requires explicit
+`ec_context_apply` calls, and `refined` has no automatic path.
+
+v0.9.0 added SessionEnd auto-apply (file-overlap → accepted), but it only produces
+`accepted` outcomes. The outcome vocabulary (`refined`, `replaced`) is unused by
+automation.
+
+### Design: Layered Rule-Based Inference
+
+Extend `auto_apply.py:infer_applied_decisions()` with a two-layer detection system.
+
+#### Layer 1: File-Overlap Gate (existing, extended)
+
+Detect intersection of:
+- Surfaced decision-linked files (`decision_files` table)
+- Session-modified files (from turn `files_touched`)
+
+Extension: include lesson/assessment-linked files in the overlap check.
+
+#### Layer 2: Outcome Classification (new)
+
+For each file-overlap match, determine outcome type:
+
+```
+file-overlap detected
+├── New decision created in same session touching same file area?
+│   ├── Yes → check commit diff pattern
+│   │   ├── net additions (lines added > deleted) → refined
+│   │   └── net replacement (lines deleted ≥ added) → replaced
+│   └── No → accepted (existing behavior)
+└── No overlap → ignored (existing behavior)
+```
+
+**"Same file area" definition:** The new decision's `decision_files` overlaps with
+the surfaced decision's `decision_files` by at least one path.
+
+**Diff analysis:** `git diff --stat <before>..<after>` for the session's commits,
+filtered to the overlapping file paths. Count insertions vs deletions.
+
+**`contradicted` auto-inference:** Deferred. Requires semantic judgment that
+rule-based analysis cannot reliably provide. False positives would corrupt
+F2 penalty scoring. Manual recording only.
+
+#### Backfill
+
+`ec session backfill-applied` updated to use the new layered inference logic,
+so historical sessions can retroactively get `refined`/`replaced` outcomes.
+
+#### Config
+
+- `[decisions] infer_outcome_type` (default true) — enable layered inference
+- When false, falls back to v0.9.0 behavior (file-overlap → accepted only)
+
+## 4. Out of Scope
+
+- `contradicted` auto-inference (semantic judgment, high misclassification cost)
+- LLM-based outcome attribution
+- Exploration candidates (TQL, ec blame, Git Archaeology, Alive Session Memory)
+- Alpha → stable status transition (v1.0)
+- New schema migrations (all changes use existing tables/columns)
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Lesson surfacing adds noise to PDI | Token budget sharing — decisions take priority, lessons fill remainder |
+| refined/replaced misclassification | Conservative gate: requires new decision + file overlap; diff pattern is secondary signal |
+| auto_extract still broken | Explicit verification step with debugging if needed |
+| Maturity 75 not reached despite features | lesson_reuse_rate threshold (0.2) requires sufficient session volume; may need soak time |
+| SessionEnd timeout (5s) with added work | Lesson surfacing is SessionStart only; outcome inference reuses existing SessionEnd pipeline |

--- a/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
+++ b/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
@@ -10,7 +10,8 @@ and add git-evidence outcome inference to satisfy the v1.0 autonomous-loop gate.
 - `lesson_reuse_rate` > 0 (currently 0%)
 - Dogfooding maturity ≥ 75 (currently 69, target: Closed Loop)
 - `auto_extract` produces at least one `decision_candidate` after a real SessionEnd
-- Git-evidence outcome inference automatically records `accepted`/`refined`/`replaced`/`ignored`
+- Git-evidence outcome inference automatically records `accepted`/`refined`/`replaced`
+  (`ignored` requires separate `infer_ignored_on_session_end = true` config, default false — not in v0.10.0 scope)
 
 ## 1. Carry-Forward (5 items from v0.9.3 retro)
 

--- a/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
+++ b/docs/superpowers/specs/2026-06-10-v0.10.0-design.md
@@ -38,8 +38,11 @@ CI runner variance (254.3ms on Python 3.13) blocks merges unrelated to performan
 ### 1e. auto_extract Production Verification
 
 After a real SessionEnd, verify `decision_candidates` table contains rows.
-Config `[decisions] auto_extract = true` has been set since v0.9.2 but zero qualifying
-SessionEnd events have occurred since. If candidates are not generated, debug the
+**Prerequisite:** `[decisions] auto_extract = true` must be set in the repo or global
+config — `DEFAULT_CONFIG` still defaults to `false` (`core/config.py:75`), and
+`maybe_extract_decisions()` returns immediately when unset (`decision_hooks.py:864`).
+Config has been set since v0.9.2 but zero qualifying SessionEnd events have occurred
+since. If candidates are not generated, debug the
 `SessionEnd → background worker → decision_candidates` pipeline.
 
 ## 2. Lesson Surfacing


### PR DESCRIPTION
## Summary

- Backfill five `docs/superpowers/plans/` implementation plan documents that guided already-shipped or upcoming releases:
  - v0.8.1 measurement accuracy (stale codex session auto-close, denominator normalization, verdict accuracy reporting)
  - v0.9.0 intervene automation (SessionEnd file-overlap auto-apply, backfill command, Signal C)
  - dev process conventions — companion plan to #165 (commit lint, ADR, measure-first, mypy strict)
  - v0.9.1 measurement calibration — companion plan to #164 (session-based `applied_context_rate`)
  - v0.10.0 implementation (dual-channel lesson surfacing + git-evidence outcome inference; companion to the design spec in `docs/superpowers/specs/2026-06-10-v0.10.0-design.md`)
- Regenerate `LESSONS.md` from 18 assessed changes (was 10): 3 new Expand entries, 5 new Neutral entries through 2026-06-07
- Add `.omc/` (oh-my-claudecode local session/team state cache) to `.gitignore`, same category as the existing `.claude`/`.codex/`/`.serena/` entries

One commit per plan document so each release's plan is independently reviewable.

## Test plan

Docs and `.gitignore` only — no code or schema changes, so no test run needed. Verified `git status` is clean after the ignore entry (only the intentionally untracked `EntireContext_Intro.pptx` remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)