### PR TITLE
fix(compact): VACUUM WAL fix + execute guard + docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Documentation surface refresh** — README/spec now align with package version 0.9.3, schema v14, the current CLI groups, the 29-tool MCP surface, and proposal-vs-current doc status labels.
 - Performance test threshold: 250ms → 300ms (CI runner variance tolerance).
 - `.omc/RELEASE_RULE.md`: added Codex review pre-release gate (shift-left checklist).
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,6 +1,6 @@
 # Lessons Learned
 
-_Generated from 18 assessed changes._
+_Generated from 22 assessed changes._
 
 ## 🟢 Expand (increases future options)
 
@@ -8,19 +8,19 @@ _Generated from 18 assessed changes._
 
 **Feedback:** agree — auto:committed
 
-_Assessment: d28a0263 | 2026-06-06T14:40:01.177319+00:00_ 
+_Assessment: d28a0263 | 2026-06-06T14:40:01.177319+00:00_
 
 ### ✅ chore(deps): bump sentence-transformers from 5.5.0 to 5.5.1
 
 **Feedback:** agree — auto:committed
 
-_Assessment: d58c0efa | 2026-06-06T14:40:01.169773+00:00_ 
+_Assessment: d58c0efa | 2026-06-06T14:40:01.169773+00:00_
 
 ### ✅ feat(distill): v0.8.0 auto-assess automation (#157)
 
 **Feedback:** agree — auto:committed
 
-_Assessment: dbe3569f | 2026-06-06T14:40:01.145677+00:00_ 
+_Assessment: dbe3569f | 2026-06-06T14:40:01.145677+00:00_
 
 ### ✅ MCP 입력 정규화와 FTS 오류 처리를 안정화해 에이전트가 검색·결정 도구를 더 예측 가능하게 사용할 수 있게 하므로 future option을 넓힌다.
 
@@ -30,7 +30,7 @@ _Assessment: dbe3569f | 2026-06-06T14:40:01.145677+00:00_
 
 **Feedback:** agree — MCP input normalization reduces agent-facing failure modes; rejected_alternatives dict-passthrough issue correctly flagged for v0.6.1 normalization
 
-_Assessment: c3efff0c | 2026-04-27T05:09:41.038581+00:00_ 
+_Assessment: c3efff0c | 2026-04-27T05:09:41.038581+00:00_
 
 ### ✅ 세션 고정 MCP 검색, PostToolUse 기반 결정 surfacing, 선택 telemetry 보강으로 과거 결정이 실제 편집 순간에 재등장할 가능성을 높여 향후 agent 판단 옵션을 넓힌다.
 
@@ -40,7 +40,7 @@ _Assessment: c3efff0c | 2026-04-27T05:09:41.038581+00:00_
 
 **Feedback:** agree — Decision hooks + MCP surfacing directly strengthens retrieve/intervene; session_id isolation and telemetry selection_id are key to loop closure
 
-_Assessment: 69228644 | 2026-04-27T05:09:40.291239+00:00_ 
+_Assessment: 69228644 | 2026-04-27T05:09:40.291239+00:00_
 
 ### ✅ 연결 수명 관리와 릴리스 검증을 정리해 ResourceWarning/누수 위험을 줄이고, 이후 결정 메모리 기능을 더 안전하게 확장할 수 있는 기반 옵션을 넓힌다.
 
@@ -50,7 +50,7 @@ _Assessment: 69228644 | 2026-04-27T05:09:40.291239+00:00_
 
 **Feedback:** agree — v0.2.0 release prep: connection lifetime management and release gates reduce ResourceWarning risk and stabilize the deployment foundation
 
-_Assessment: 4fbe6465 | 2026-04-27T05:09:26.385266+00:00_ 
+_Assessment: 4fbe6465 | 2026-04-27T05:09:26.385266+00:00_
 
 ### ✅ 현재 변경 파일, diff, assessment, commit 신호로 관련 결정을 랭킹해 과거 판단이 다음 코드 변경 시점에 재등장할 가능성을 높이므로 미래 선택지를 넓힌다.
 
@@ -60,7 +60,7 @@ _Assessment: 4fbe6465 | 2026-04-27T05:09:26.385266+00:00_
 
 **Feedback:** agree — Ranking weight config + multi-signal scoring in decisions.py is the foundation for Proactive Decision Injection; hardcoded weights extracted correctly
 
-_Assessment: fea07b4e | 2026-04-27T05:09:13.716317+00:00_ 
+_Assessment: fea07b4e | 2026-04-27T05:09:13.716317+00:00_
 
 ### ✅ 결정 검색, stale/contradicted 필터링, outcome 기록, hook 기반 proactive surfacing, MCP/CLI 표면과 테스트를 추가해 coding-agent decision memory의 재사용 경로를 크게 넓힌다.
 
@@ -70,7 +70,7 @@ _Assessment: fea07b4e | 2026-04-27T05:09:13.716317+00:00_
 
 **Feedback:** agree — Proactive retrieval with multi-signal ranking is core to the retrieve/intervene loop; aligns with v0.3 E4 and Proactive Decision Injection roadmap item
 
-_Assessment: 49c852ae | 2026-04-27T05:09:09.089900+00:00_ 
+_Assessment: 49c852ae | 2026-04-27T05:09:09.089900+00:00_
 
 ### ✅ 변경은 decision/rejected-alternative 처리와 CLI/MCP 노출, 회귀 테스트를 보강해 향후 decision memory 품질 개선 옵션을 넓힌다.
 
@@ -80,7 +80,7 @@ _Assessment: 49c852ae | 2026-04-27T05:09:09.089900+00:00_
 
 **Feedback:** agree — Lesson guidance + decision search tightens the distill step; rejected-alternative quality direction matches v0.6.1 scope
 
-_Assessment: bd7df7b7 | 2026-04-27T05:08:50.632894+00:00_ 
+_Assessment: bd7df7b7 | 2026-04-27T05:08:50.632894+00:00_
 
 ### ✅ decision 후보 추출, 검토, MCP/CLI 노출, schema v13 기반 후보 테이블을 추가해 raw history에서 검토 가능한 decision memory로 넘어가는 선택지를 크게 넓힌다.
 
@@ -90,7 +90,7 @@ _Assessment: bd7df7b7 | 2026-04-27T05:08:50.632894+00:00_
 
 **Feedback:** agree — Decision extraction + schema v13 — valid EXPAND; FTS triggers and schema migration are foundational for decision memory depth
 
-_Assessment: 134621fa | 2026-04-27T05:07:55.149737+00:00_ 
+_Assessment: 134621fa | 2026-04-27T05:07:55.149737+00:00_
 
 ### ✅ This change expands future options by adding both manual and hook-based checkpoint creation with shared git helpers while keeping heavier snapshot capture optional and reversible.
 
@@ -98,7 +98,7 @@ _Assessment: 134621fa | 2026-04-27T05:07:55.149737+00:00_
 
 **Suggestion:** Keep the new `core/git_utils.py` extraction, but tidy next by unifying CLI and session-end checkpoint logic behind one shared checkpoint service (including diff-base selection and metadata merge behavior) so future trigger types can be added without duplicating policy or silently diverging.
 
-_Assessment: 84288d4f | 2026-02-20T10:48:16.009213+00:00_ 
+_Assessment: 84288d4f | 2026-02-20T10:48:16.009213+00:00_
 
 ### ✅ Introducing a pluggable LLM backend with a CLI `--backend` option increases reversibility and execution options for futures assessment, though IDE-specific files add minor portability drag.
 
@@ -106,39 +106,63 @@ _Assessment: 84288d4f | 2026-02-20T10:48:16.009213+00:00_
 
 **Suggestion:** Keep the `core.llm` abstraction and `--backend` wiring, but tidy by isolating/removing committed `.idea` project-specific files and adding backend capability checks plus a small contract test for `get_backend(...).complete(...)` to prevent silent runtime divergence across providers.
 
-_Assessment: dd6184a2 | 2026-02-20T08:51:22.221135+00:00_ 
+_Assessment: dd6184a2 | 2026-02-20T08:51:22.221135+00:00_
 
 ## 🟡 Neutral
+
+### ❌ Auto-assessed checkpoint
+
+**Feedback:** disagree — Comprehensive project manual expands future onboarding, maintenance, and review options; neutral auto-assessment understates the docs deliverable value.
+
+_Assessment: 48c8431e | 2026-06-21T15:07:26.849554+00:00_
+
+### ❌ Auto-assessed checkpoint
+
+**Feedback:** disagree — Doc review found and fixed source-map drift plus evidence artifact terminology drift in the comprehensive manual plan, expanding future execution and review reliability rather than being neutral.
+
+_Assessment: bbb6a37b | 2026-06-21T13:15:39.090809+00:00_
+
+### ❌ Auto-assessed checkpoint
+
+**Feedback:** disagree — The comprehensive manual plan expands future onboarding, review, and execution options by defining a source-backed A-to-Z documentation deliverable, evidence matrix, and verification criteria rather than being merely neutral.
+
+_Assessment: 3cdb666b | 2026-06-20T06:53:53.103439+00:00_
+
+### ❌ Auto-assessed checkpoint
+
+**Feedback:** disagree — Docs refresh closes README/spec contract drift for version, schema, CLI, MCP, and proposal status; this should expand future review and onboarding options rather than neutral.
+
+_Assessment: 39ae7b45 | 2026-06-20T05:12:55.966118+00:00_
 
 ### ✅ Auto-assessed checkpoint
 
 **Feedback:** agree — auto:committed
 
-_Assessment: b5fed17f | 2026-06-07T04:04:23.897323+00:00_ 
+_Assessment: b5fed17f | 2026-06-07T04:04:23.897323+00:00_
 
 ### ✅ Merge branch 'docs/roadmap-direction-2026-06-02'
 
 **Feedback:** agree — auto:committed
 
-_Assessment: 5d19a93c | 2026-06-06T14:40:01.191856+00:00_ 
+_Assessment: 5d19a93c | 2026-06-06T14:40:01.191856+00:00_
 
 ### ✅ fix(hooks): prevent codex-notify stdin blocking that accumulates zombie processes
 
 **Feedback:** agree — auto:committed
 
-_Assessment: d9e00b3f | 2026-06-06T14:40:01.184484+00:00_ 
+_Assessment: d9e00b3f | 2026-06-06T14:40:01.184484+00:00_
 
 ### ✅ Auto-assessed checkpoint
 
 **Feedback:** agree — auto:committed
 
-_Assessment: be7950ff | 2026-06-06T14:40:01.161669+00:00_ 
+_Assessment: be7950ff | 2026-06-06T14:40:01.161669+00:00_
 
 ### ✅ Auto-assessed checkpoint
 
 **Feedback:** agree — auto:committed
 
-_Assessment: 4ac6facf | 2026-06-06T14:40:01.154162+00:00_ 
+_Assessment: 4ac6facf | 2026-06-06T14:40:01.154162+00:00_
 
 ### ✅ 릴리스 커밋의 closing reference를 기준으로 GitHub 이슈를 자동 종료해 운영 마찰은 줄이지만, 결정 메모리 루프 자체의 선택지를 크게 넓히거나 좁히지는 않는다.
 
@@ -148,5 +172,5 @@ _Assessment: 4ac6facf | 2026-06-06T14:40:01.154162+00:00_
 
 **Feedback:** agree — Release scripts + CI harden the deployment pipeline; enabling trust and auditability for the git-grounded memory model
 
-_Assessment: e5d01a13 | 2026-04-27T05:09:05.329211+00:00_ 
+_Assessment: e5d01a13 | 2026-04-27T05:09:05.329211+00:00_
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Git-anchored decision memory for coding agents.**
 
-![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue) ![Version 0.6.0](https://img.shields.io/badge/version-0.6.0-green) ![Status Experimental](https://img.shields.io/badge/status-experimental-orange) ![License MIT](https://img.shields.io/badge/license-MIT-lightgrey)
+![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue) ![Version 0.9.3](https://img.shields.io/badge/version-0.9.3-green) ![Status Experimental](https://img.shields.io/badge/status-experimental-orange) ![License MIT](https://img.shields.io/badge/license-MIT-lightgrey)
 
 > ⚠️ **Experimental** — API and data format may change without notice.
 
@@ -287,20 +287,32 @@ The sections below are reference material for the current CLI surface. They stay
 | Command | Description |
 |---------|-------------|
 | `ec init` | Initialize EntireContext in current git repo |
-| `ec enable [--no-git-hooks]` | Install Claude Code hooks and git hooks (skip git hooks with `--no-git-hooks`) |
-| `ec disable` | Remove Claude Code hooks |
+| `ec enable [--no-git-hooks]` | Install Claude Code hooks, git hooks, and user-level MCP config (skip git hooks with `--no-git-hooks`) |
+| `ec disable` | Remove Claude Code hooks and installed git hooks |
 | `ec status` | Show capture status (project, sessions, turns, active session) |
 | `ec config [KEY] [VALUE]` | Get or set configuration (dotted keys) |
-| `ec doctor` | Diagnose issues (schema, hooks, unsynced checkpoints) |
+| `ec doctor` | Diagnose issues (schema, hooks, unsynced checkpoints, MCP config) |
 | `ec search QUERY` | Search across sessions, turns, and events |
-| `ec blame FILE [-L START,END] [--summary]` | Show per-line human/agent attribution |
-| `ec rewind CHECKPOINT_ID` | Show or restore code state at a checkpoint |
-| `ec sync [--no-filter]` | Export to shadow branch, then push with one automatic artifact-merge retry on non-fast-forward (skip secret filtering with `--no-filter`) |
+| `ec sync [--no-filter] [--if-enabled]` | Export to shadow branch and push; `--if-enabled` gates pre-push sync by config |
 | `ec pull` | Fetch latest `origin` shadow branch snapshot and import |
+| `ec rewind CHECKPOINT_ID` | Show or restore code state at a checkpoint |
+| `ec blame FILE [-L START,END] [--summary]` | Show per-line human/agent attribution |
 | `ec index [--semantic] [--force] [--model NAME]` | Rebuild FTS5 indexes, optionally generate embeddings |
-| `ec dashboard [--since DATE] [--limit N]` | Show team dashboard: sessions, checkpoints, assessment trends |
+| `ec import --from-aline [PATH]` | Import sessions/turns/checkpoints from Aline DB |
 | `ec graph [--session ID] [--since DATE] [--limit N]` | Show knowledge graph of git entities |
 | `ec ast-search QUERY [--type TYPE] [--file PATH] [--limit N]` | Search indexed Python AST symbols |
+| `ec dashboard [--since DATE] [--limit N]` | Show team dashboard: sessions, checkpoints, assessment trends |
+| `ec compact [--execute] [--retention-days N] [--limit N]` | Compact storage; dry-run by default |
+| `ec session` | Session management |
+| `ec hook` | Hook handlers called by Claude Code and git hooks |
+| `ec checkpoint` | Checkpoint management |
+| `ec repo` | Repository registry management |
+| `ec event` | Event grouping and linking |
+| `ec mcp` | MCP server management |
+| `ec futures` | Futures assessment and lessons |
+| `ec purge` | Purge turns, sessions, or matching content (dry-run by default) |
+| `ec context` | Retrieval-selection and context-application telemetry |
+| `ec decision` | Decision memory management |
 
 ### `ec session` Subcommands
 
@@ -310,17 +322,21 @@ The sections below are reference material for the current CLI surface. They stay
 | `ec session show SESSION_ID` | Show session details and turn summaries |
 | `ec session current` | Show current active session |
 | `ec session export ID [--output FILE]` | Export session as Markdown (YAML frontmatter + sections) |
+| `ec session consolidate [--before DATE] [--session ID] [--limit N] [--execute]` | Compress old turn content (dry-run by default) |
 | `ec session graph [--agent ID] [--session ID] [--depth N]` | Visualise multi-agent session graph |
 | `ec session activate [--turn ID] [--session ID] [--hops N] [--limit N]` | Find related turns via spreading activation |
-| `ec session consolidate [--before DATE] [--session ID] [--limit N] [--execute]` | Compress old turn content (dry-run by default) |
+| `ec session backfill-ended-at` | Backfill missing `ended_at` values for sessions whose SessionEnd hook never fired |
+| `ec session backfill-applied` | Infer applied decisions for ended sessions with retrieval events |
 
 ### `ec checkpoint` Subcommands
 
 | Command | Description |
 |---------|-------------|
+| `ec checkpoint create` | Create a checkpoint at the current git state |
 | `ec checkpoint list` | List checkpoints (commit, branch, diff summary) |
 | `ec checkpoint show CHECKPOINT_ID` | Show checkpoint details and file snapshot |
 | `ec checkpoint diff ID1 ID2` | Diff between two checkpoints |
+| `ec checkpoint assess-accuracy` | Show verdict accuracy baseline from enrichment feedback |
 
 ### `ec event` Subcommands
 
@@ -339,6 +355,7 @@ The sections below are reference material for the current CLI surface. They stay
 | `ec futures list [-v VERDICT] [-n LIMIT]` | List assessments (filter by `--verdict`) |
 | `ec futures feedback ID FEEDBACK [-r REASON]` | Add agree/disagree feedback to an assessment |
 | `ec futures lessons [-o OUTPUT] [-s SINCE]` | Generate LESSONS.md from assessed changes with feedback |
+| `ec futures enrich-backlog` | Enrich rule-based assessments with LLM analysis or git-evidence feedback |
 | `ec futures trend [--since DATE] [--limit N]` | Show cross-repo assessment trend analysis |
 | `ec futures relate SRC TYPE TGT [--note TEXT]` | Add typed relationship between assessments |
 | `ec futures relationships ID [--direction DIR]` | List relationships for an assessment |
@@ -348,11 +365,40 @@ The sections below are reference material for the current CLI surface. They stay
 | `ec futures worker-status` | Show background assessment worker status |
 | `ec futures worker-stop` | Stop background assessment worker |
 | `ec futures worker-launch [--diff TEXT]` | Launch background assessment worker |
+
+### `ec decision` Subcommands
+
+| Command | Description |
+|---------|-------------|
 | `ec decision create TITLE [--rationale TEXT] [--scope TEXT]` | Create a decision record |
-| `ec decision list [--status STATUS] [--file PATH] [--limit N]` | List decisions (optional staleness/file filter) |
+| `ec decision list [--status STATUS] [--file PATH] [--limit N]` | List decisions with optional staleness/file filters |
 | `ec decision show DECISION_ID` | Show decision details and linked artifacts |
-| `ec decision link DECISION_ID [--assessment ID\|--checkpoint ID\|--commit SHA\|--file PATH]` | Link decision to assessment/checkpoint/commit/file |
-| `ec decision stale DECISION_ID --status STATUS` | Update decision staleness (`fresh\|stale\|superseded\|contradicted`) |
+| `ec decision rejected-alternatives DECISION_ID` | Show rejected alternatives for a decision |
+| `ec decision link DECISION_ID ...` | Link decision to assessment, checkpoint, commit, or file evidence |
+| `ec decision stale DECISION_ID [--status STATUS]` | Check or set decision staleness |
+| `ec decision outcome DECISION_ID --outcome TYPE` | Record accepted/ignored/contradicted/refined/replaced usage feedback |
+| `ec decision update DECISION_ID ...` | Update decision fields |
+| `ec decision supersede OLD NEW` | Mark a decision as superseded by another |
+| `ec decision unlink DECISION_ID ...` | Remove a decision link |
+| `ec decision search QUERY` | Search decisions by keyword |
+| `ec decision chain DECISION_ID` | Walk a supersession chain for debugging |
+| `ec decision stale-all` | Check staleness for all fresh decisions and persist results |
+| `ec decision extract-candidates SESSION_ID` | Extract candidate decisions from a session |
+| `ec decision candidates` | Candidate decision review flow |
+| `ec decision alternatives` | Rejected-alternative quality commands |
+
+### `ec context` Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `ec context select` | Record or inspect retrieval selections |
+| `ec context apply APPLICATION_TYPE` | Record how retrieved context was applied (`reference`, `decision_change`, `code_reuse`, or `lesson_applied`) |
+
+### `ec mcp` Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `ec mcp serve` | Start the MCP server over stdio |
 
 ### LLM Backends (`ec futures assess`)
 
@@ -478,7 +524,7 @@ ec mcp serve
 | `ec_session_context` | Get session details with recent turns. Auto-detects current session if `session_id` omitted |
 | `ec_turn_content` | Get full content for a specific turn (including JSONL content files) |
 | `ec_attribution` | Get human/agent attribution for a file, with optional line range |
-| `ec_context_apply` | Record how context was applied (e.g., `lesson_applied`, `accepted`) linking back to a prior retrieval selection |
+| `ec_context_apply` | Record how retrieved context was applied (`reference`, `decision_change`, `code_reuse`, or `lesson_applied`) linking back to a prior retrieval selection |
 | `ec_checkpoint_list` | List checkpoints, optionally filtered by `session_id` and `since` |
 | `ec_rewind` | Show state at a specific checkpoint |
 | `ec_assess` | Assess staged diff or checkpoint against roadmap via LLM |
@@ -520,19 +566,28 @@ Skip git hook installation with `ec enable --no-git-hooks`. Both hooks are remov
 
 Config merges in order: **defaults** ← **global** (`~/.entirecontext/config.toml`) ← **per-repo** (`.entirecontext/config.toml`).
 
-### Default Configuration
+### Common Configuration Defaults
+
+The source of truth is `src/entirecontext/core/config.py`. This excerpt lists operator-facing defaults; use `ec config` to inspect the merged global + per-repo value.
 
 ```toml
 [capture]
 auto_capture = true
 checkpoint_on_commit = true
+checkpoint_on_session_end = false
+auto_cleanup_no_changes = false
+content_retention_days = 30
+intent_summary = false
+emit_aar = true
+codex_session_idle_minutes = 60
+surface_lessons_on_start = true
 
 [capture.exclusions]
 enabled = false
-content_patterns = []    # regex — skip turns matching these
-file_patterns = []       # glob — exclude files from tracking
-tool_names = []          # exact — skip tool usage recording
-redact_patterns = []     # regex — replace matches with [FILTERED] before storage
+content_patterns = []
+file_patterns = []
+tool_names = []
+redact_patterns = []
 
 [search]
 default_mode = "regex"
@@ -540,6 +595,7 @@ semantic_model = "all-MiniLM-L6-v2"
 
 [sync]
 auto_sync = false
+auto_sync_on_push = false
 auto_pull = false
 cooldown_seconds = 300
 pull_staleness_seconds = 600
@@ -553,15 +609,44 @@ color = true
 [security]
 filter_secrets = true
 patterns = [
-    '(?i)(api[_-]?key|secret|password|token)\s*[=:]\s*[\'"]?[\w-]+',
-    '(?i)bearer\s+[\w.-]+',
-    'ghp_[a-zA-Z0-9]{36}',
-    'sk-[a-zA-Z0-9]{48}',
+  "(?i)(api[_-]?key|secret|password|token)\\s*[=:]\\s*['\"]?[\\w-]+",
+  "(?i)bearer\\s+[\\w.-]+",
+  "ghp_[a-zA-Z0-9]{36}",
+  "sk-[a-zA-Z0-9]{48}",
 ]
+
+[index]
+auto_embed = false
+embed_model = "all-MiniLM-L6-v2"
+
+[futures]
+auto_distill = false
+lessons_output = "LESSONS.md"
+default_backend = "claude"
+default_model = ""
+assess_enrich = true
+assess_backfill_window_days = 7
+
+[decisions]
+auto_stale_check = false
+auto_extract = false
+show_related_on_start = false
+surface_on_tool_use = false
+infer_applied_on_session_end = true
+infer_outcome_type = true
+auto_promotion_contradicted_threshold = 2
+auto_embed = true
+
+[decisions.injection]
+inject_on_user_prompt = true
+top_k = 5
+max_tokens = 800
+min_confidence = 0.4
+inject_timeout_ms = 250
 
 [filtering.query_redaction]
 enabled = false
-patterns = []            # regex — redact matches in search/MCP results
+patterns = []
 replacement = "[FILTERED]"
 ```
 
@@ -591,60 +676,51 @@ Shadow branch sync uses artifact-level merge only on `entirecontext/checkpoints/
 
 ## Architecture
 
-Sessions, turns, and checkpoints flow from Claude Code hooks through the core business logic into SQLite, with optional export via shadow branch sync.
+Sessions, turns, decisions, and checkpoints flow from Claude Code/git hooks through core services into SQLite, with optional export via shadow branch sync.
 
 ```
-CLI (Typer)  →  core/  →  db/  →  hooks/  →  sync/
-cli/             business    SQLite     Claude Code   shadow branch
-  project_cmds   logic       schema     integration   export/import
-  session_cmds   config      migration  turn capture  merge
-  search_cmds    security    connection session lifecycle
-  hook_cmds      cross_repo
-  checkpoint_cmds attribution
-  sync_cmds      event
-  rewind_cmds    indexing
-  repo_cmds      search
-  event_cmds     futures
-  blame_cmds     llm
-  index_cmds     import_aline
-  mcp_cmds       content_filter
-  futures_cmds   purge
-  import_cmds    export
-  purge_cmds     report
-  graph_cmds     tidy_pr
-  ast_cmds       dashboard
-  dashboard_cmds ast_index
-               knowledge_graph
-               agent_graph
-               activation
-               consolidation
-               hybrid_search
-               async_worker
+CLI (Typer)  →  core/ services  →  db/ SQLite  →  hooks/ capture  →  sync/ shadow branch
+  project_cmds     search              schema          session_lifecycle     coordinator
+  session_cmds     decisions           migration       turn_capture          merge
+  search_cmds      futures             connection      decision_hooks        export/import
+  sync_cmds        telemetry
+  checkpoint_cmds  attribution
+  decisions_cmds   content_filter
+  context_cmds     purge
+  futures_cmds     dashboard
+  compact_cmds     knowledge_graph
+  mcp_cmds         ast_index
+  ...              consolidation
 
-mcp/server.py — MCP server interface (optional dependency)
+mcp/server.py + mcp/tools/* expose the agent-facing MCP interface.
 ```
 
 ### Data Model
 
+Schema version: **14** (`src/entirecontext/db/schema.py`).
+
 | Table | Purpose |
 |-------|---------|
 | `projects` | Registered repos (name, path, remote URL) |
+| `agents` | Agent identities (type, role, parent agent) |
 | `sessions` | Captured sessions (type, title, summary, turn count) |
 | `turns` | Individual turns (user message, assistant summary, files touched) |
 | `turn_content` | JSONL content file references for full turn data |
 | `checkpoints` | Git-anchored snapshots (commit hash, branch, file snapshot, diff) |
-| `agents` | Agent identities (type, role, parent agent) |
-| `events` | Grouping mechanism (task / temporal / milestone) |
-| `event_sessions` | Many-to-many link between events and sessions |
-| `event_checkpoints` | Many-to-many link between events and checkpoints |
-| `assessments` | Futures assessment results (verdict, impact, feedback) |
-| `assessment_relationships` | Typed links between assessments (causes/fixes/contradicts) |
+| `events`, `event_sessions`, `event_checkpoints` | Task / temporal / milestone grouping and links |
+| `assessments`, `assessment_relationships` | Futures assessment results and typed assessment links |
+| `decisions` | Decision memory records, staleness, rejected alternatives, and supersession pointers |
+| `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments` | Evidence links from decisions to git/code/assessment context |
+| `decision_outcomes` | Usage feedback for decisions (`accepted`, `ignored`, `contradicted`, `refined`, `replaced`) |
+| `decision_candidates` | Auto-extracted candidate decisions before review/promotion |
+| `retrieval_events`, `retrieval_selections`, `context_applications` | Retrieval telemetry and context-application tracking |
 | `attributions` | Per-line human/agent file attribution |
 | `embeddings` | Semantic search vectors |
 | `ast_symbols` | Python AST symbol index (functions, classes, methods) |
 | `sync_metadata` | Shadow branch sync state |
+| `operation_events` | Durable operation/audit events |
 
-FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols` — auto-synced via triggers.
+FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols`, `fts_decisions`, `fts_decision_candidates` — synchronized by triggers where applicable.
 
 ### Data Locations
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 EntireContext captures AI coding work as it happens, distills decisions and lessons from it, and brings the right context back when similar code changes happen again.
 
+For a long-form A-to-Z orientation, see [the EntireContext Project Manual](docs/entirecontext-project-manual.md).
+
 ## Why It Exists
 
 AI coding tools generate changes quickly, but engineering judgment still gets buried in chat logs. Important decisions, rejected alternatives, and hard-won lessons disappear across sessions, repos, and agents, so teams keep rediscovering the same context.

--- a/docs/documentation_in_prs_proposal.md
+++ b/docs/documentation_in_prs_proposal.md
@@ -1,4 +1,5 @@
 # Proposal: Integrating Documentation into Feature PRs
+> **Status:** Proposal / historical process note. Current repository policy lives in `AGENTS.md` and release-history changes belong in `CHANGELOG.md`; use this document as background unless a future ADR adopts it.
 
 ## Motivation
 

--- a/docs/entirecontext-project-manual.md
+++ b/docs/entirecontext-project-manual.md
@@ -1,0 +1,834 @@
+# EntireContext Project Manual
+
+_Last reviewed: 2026-06-22_
+
+EntireContext is **git-anchored decision memory for coding agents**. It captures engineering work as it happens, distills reusable decisions and lessons, retrieves the right context when related work appears, and helps agents or maintainers intervene before repeating old mistakes.
+
+This manual is a long-form orientation and maintenance guide. It does not replace the narrower source-of-truth documents:
+
+- `README.md` remains the quick-start and product entry point.
+- `docs/spec.md` remains the compact implementation reference.
+- `docs/decisions_outcomes.md` owns the decision-outcome vocabulary.
+- `AGENTS.md` owns repository workflow policy for agents.
+- `CLAUDE.md` remains the compact contributor and compatibility reference.
+- `ROADMAP.md` owns product direction and future intent.
+
+When this manual summarizes a drift-prone fact, prefer the cited code path, contract test, or canonical document over the prose here.
+
+## 1. Executive Overview
+
+### 1.1 What EntireContext is
+
+EntireContext is a local-first memory system for software work. Its core object is not a chat transcript; it is reusable engineering judgment: decisions, rejected alternatives, lessons, feedback, checkpoints, and retrieval traces tied back to git repositories.
+
+The product wedge is narrow on purpose. Coding agents already produce plenty of raw history. The hard part is making previous reasoning reappear at the next useful moment. EntireContext focuses on this loop:
+
+```text
+capture -> distill -> retrieve -> intervene -> outcome
+```
+
+- **Capture** records sessions, turns, tool use, checkpoints, files, and git state.
+- **Distill** converts raw work into assessments, lessons, and decision candidates.
+- **Retrieve** searches turns, sessions, symbols, checkpoints, assessments, and decisions.
+- **Intervene** surfaces relevant decisions or lessons before and during related work.
+- **Outcome** records whether surfaced guidance was accepted, ignored, contradicted, refined, or replaced.
+
+The implementation is anchored in git and SQLite. Hooks collect local activity; CLI commands expose human workflows; MCP tools expose agent workflows; optional sync exports artifacts through a shadow branch.
+
+### 1.2 What problem it solves
+
+Without a dedicated memory loop, engineering judgment is scattered across terminal scrollback, agent chats, PR threads, commits, and local notes. A future agent can search code, but it usually cannot answer:
+
+- Why did this pattern win over the rejected alternative?
+- Which prior decision is now stale because the linked file changed?
+- Which lesson was confirmed by feedback rather than guessed by a model?
+- Which checkpoint or session explains the current shape of a file?
+- Which surfaced guidance actually changed the next implementation?
+
+EntireContext stores those relationships explicitly so agents can reuse them.
+
+### 1.3 What is current behavior versus intent
+
+Current behavior is implemented in the Python package under `src/entirecontext/`, the tests under `tests/`, and the user documentation in `README.md` and `docs/spec.md`. Roadmap items, brainstorms, research notes, and plan documents are useful context but are not shipped behavior unless code or tests confirm them.
+
+Treat these categories separately:
+
+| Category | Examples | How to read it |
+|---|---|---|
+| Current implementation | `src/entirecontext/**`, `tests/**`, `pyproject.toml` | Source of truth for behavior. |
+| Current user docs | `README.md`, `docs/spec.md`, `docs/decisions_outcomes.md` | Contract-oriented summaries; verify drift-prone facts against code/tests. |
+| Workflow policy | `AGENTS.md`, `CLAUDE.md` | Agent and contributor operating rules. |
+| Product direction | `ROADMAP.md` | Intent and planned work, not automatically shipped behavior. |
+| Design history | `docs/brainstorms/**`, `docs/research/**`, `docs/superpowers/**`, `docs/plans/**` | Context and rationale; label as historical/proposal/plan when cited. |
+
+### 1.4 Package and platform snapshot
+
+At the time of this review, package metadata and runtime constants agree on version **0.9.3** (`pyproject.toml`, `src/entirecontext/__init__.py`). Python support is **3.12+** in project metadata and CI. The local schema version is **14** (`src/entirecontext/db/schema.py`).
+
+Those facts are intentionally called out as drift-sensitive. If they change, update the package metadata, code constant, changelog/schema references, and docs together.
+
+## 2. Concepts and Terminology
+
+### 2.1 Repository memory versus chat memory
+
+Chat memory preserves conversation. Repository memory preserves work context in relation to a git repository. EntireContext records sessions, turns, files, checkpoints, events, assessments, decisions, outcomes, and retrieval telemetry so a future agent can relate a new task to past repository state.
+
+The distinction matters: a transcript can say what happened; a decision record should say what was chosen, why, what alternatives were rejected, and which files or checkpoints make the decision relevant.
+
+### 2.2 Core records
+
+| Term | Meaning | Primary storage/source |
+|---|---|---|
+| Project | A registered git repository. | `projects` table. |
+| Agent | An actor that produced work, optionally parented to another agent. | `agents` table. |
+| Session | A contiguous coding-agent or human-agent work session. | `sessions` table. |
+| Turn | A user prompt and assistant response summary, with files/tools metadata. | `turns`, `turn_content`. |
+| Checkpoint | A git-anchored snapshot of progress and diff state. | `checkpoints`. |
+| Event | A higher-level grouping of sessions/checkpoints. | `events`, `event_sessions`, `event_checkpoints`. |
+| Assessment | An evaluation of a diff/checkpoint against roadmap or product value. | `assessments`. |
+| Lesson | Guidance distilled from assessed work and feedback. | `LESSONS.md`, futures commands/tools. |
+| Decision | Reusable engineering intent: chosen direction, rationale, scope, alternatives, evidence, staleness. | `decisions` and decision link tables. |
+| Retrieval event | A recorded search or surfacing operation. | `retrieval_events`. |
+| Retrieval selection | A selected result from a retrieval event. | `retrieval_selections`. |
+| Context application | A record that retrieved context was used. | `context_applications`. |
+| Decision candidate | A proposed decision extracted from session/checkpoint/assessment material before review. | `decision_candidates`. |
+
+### 2.3 Data locations
+
+EntireContext uses local project state plus optional global state:
+
+- A repo-local `.entirecontext/` directory stores configuration, SQLite state, content files, fallback context files, and generated artifacts.
+- A global user-level configuration file can provide defaults that repo-local config overrides.
+- A global registry database tracks repositories for cross-repo workflows.
+- Optional sync uses a git shadow branch for portable artifacts.
+
+This manual avoids machine-specific absolute paths. Use command output and config values in your own environment to locate the concrete files.
+
+### 2.4 Decision states and outcomes
+
+Decision records carry `staleness_status` values such as fresh, stale, superseded, and contradicted. Retrieval treats those states differently: fresh guidance is preferred; stale guidance is demoted or optionally included; superseded guidance should resolve to the successor; contradicted guidance is hidden from normal retrieval surfaces.
+
+Decision outcomes are the feedback vocabulary: `accepted`, `ignored`, `contradicted`, `refined`, and `replaced`. The canonical semantics live in `docs/decisions_outcomes.md`; this manual links to that file instead of duplicating every rule.
+
+## 3. First Run and Daily Use
+
+### 3.1 Install and requirements
+
+The package is Python-based and currently targets Python 3.12+. The README is the source for installation commands and optional extras. At a conceptual level:
+
+1. Install the package and any desired extras.
+2. Initialize a git repository with `ec init`.
+3. Enable capture integrations with `ec enable` for the relevant agent surface.
+4. Use the agent normally.
+5. Inspect status, sessions, decisions, checkpoints, and lessons through CLI or MCP.
+
+Use safe placeholder values in examples. Do not put real tokens, private prompts, customer data, or secret keys into docs or demos.
+
+### 3.2 Initialize, enable, disable, and inspect status
+
+The project command surface is registered in `src/entirecontext/cli/project_cmds.py` and includes:
+
+- `ec init` — create or initialize repo-local EntireContext state.
+- `ec enable` — install supported hooks or notification wiring.
+- `ec disable` — remove supported hook or notification wiring.
+- `ec status` — show capture/project/session status.
+- `ec config` — read or write configuration values.
+- `ec doctor` — inspect installation and integration health.
+
+Enable/disable commands can modify local hook files or local agent configuration. Review their output before assuming capture is active.
+
+### 3.3 Day-to-day workflows
+
+Common workflows are grouped by intent rather than by module:
+
+| Workflow | Commands to start with | Notes |
+|---|---|---|
+| Search memory | `ec search`, `ec related`, `ec ast-search` | Regex/FTS/session-related and symbol search. |
+| Inspect sessions | `ec session list`, `ec session show`, `ec session current`, `ec session export` | Session commands live under the `session` typer group. |
+| Create checkpoints | `ec checkpoint create`, `ec checkpoint list`, `ec checkpoint show`, `ec checkpoint diff` | Checkpoints are git-anchored and can be created manually or by hooks. |
+| Rewind context | `ec rewind` | Shows state at a checkpoint; it is not a magic rollback guarantee. |
+| Record decisions | `ec decision create`, `ec decision link`, `ec decision outcome`, `ec decision supersede` | Link decisions to files, commits, checkpoints, or assessments when possible. |
+| Assess and learn | `ec futures assess`, `ec futures feedback`, `ec futures lessons` | Feedback is what turns assessments into durable lessons. |
+| Sync artifacts | `ec sync`, `ec pull` | Uses shadow-branch artifact flow when configured. |
+| Serve MCP | `ec mcp serve` | Starts stdio MCP transport when MCP dependencies are installed. |
+| Maintain storage | `ec purge`, `ec compact`, `ec index` | Use with care; inspect command help and output. |
+
+For exhaustive flags, run `ec <command> --help` instead of relying on this manual.
+
+### 3.4 Safe examples
+
+Use placeholders:
+
+```bash
+ec decision create "Prefer explicit parser errors" \
+  --rationale "It makes agent-visible failures easier to diagnose" \
+  --scope "src/example/parser.py"
+
+ec decision outcome <decision-id> --outcome accepted --note "Applied to the parser refactor"
+```
+
+Avoid examples containing real keys, private repository paths, or raw production data.
+
+## 4. Agent Integration Guide
+
+### 4.1 MCP as the agent-facing interface
+
+MCP tools are the preferred surface for agents that need context during work. The stdio MCP server is in `src/entirecontext/mcp/server.py`; tools are registered from modules under `src/entirecontext/mcp/tools/`.
+
+Tool categories:
+
+| Category | MCP tools |
+|---|---|
+| Search and related context | `ec_search`, `ec_related`, `ec_ast_search`, `ec_activate` |
+| Sessions and content | `ec_session_context`, `ec_turn_content`, `ec_attribution`, `ec_context_apply` |
+| Checkpoints | `ec_checkpoint_list`, `ec_rewind` |
+| Futures and lessons | `ec_assess`, `ec_assess_create`, `ec_feedback`, `ec_lessons`, `ec_assess_trends` |
+| Dashboard and graph | `ec_dashboard`, `ec_graph` |
+| Decisions | `ec_decision_context`, `ec_decision_create`, `ec_decision_get`, `ec_decision_list`, `ec_decision_outcome`, `ec_decision_related`, `ec_decision_search`, `ec_decision_stale` |
+| Decision candidates | `ec_decision_candidate_list`, `ec_decision_candidate_get`, `ec_decision_candidate_confirm`, `ec_decision_candidate_reject` |
+
+`tests/test_contract_sync.py` checks that the exported MCP tool set and README tool table stay aligned. Update code, README, and contract tests together when this surface changes.
+
+### 4.2 When an agent should retrieve context
+
+Agents should prefer proactive context when available, then explicit retrieval when the task needs more grounding.
+
+Use `ec_decision_context` when:
+
+- The agent is starting a non-trivial task.
+- The current session has files, diff, checkpoint, or recent-turn signals.
+- The agent wants ranked decisions and `selection_id` values without assembling a query.
+
+Use `ec_decision_related` when:
+
+- The agent has explicit files, assessment IDs, or diff text.
+- It needs a more targeted decision lookup than the current session provides.
+
+Use `ec_lessons` or futures lessons when:
+
+- Prior assessed work may contain actionable guidance.
+- The task revisits an area with repeated bugs or refactors.
+
+Use `ec_checkpoint_list`, `ec_session_context`, or `ec_related` when:
+
+- The agent needs historical work context rather than decision records alone.
+- It needs to inspect what happened in a prior session or checkpoint.
+
+After applying retrieved context, record usage with `ec_context_apply` or decision outcomes where appropriate. This closes the feedback loop and improves future ranking.
+
+### 4.3 Proactive decision injection
+
+The `UserPromptSubmit` hook can rank top decisions against the current prompt and inject them as additional context. This is controlled by `[decisions.injection]` config keys such as `inject_on_user_prompt`, `top_k`, `max_tokens`, `min_confidence`, and `inject_timeout_ms`.
+
+The hook path is timeout-aware. If injection cannot complete within the configured budget, the agent should continue and optionally use explicit MCP retrieval.
+
+### 4.4 Mid-session surfacing
+
+When configured, `PostToolUse` can surface decisions linked to files just edited. The current implementation writes a session-scoped fallback file named like `.entirecontext/decisions-context-tooluse-<session>.md` and avoids colliding with the SessionStart fallback.
+
+This is meant to catch decisions at edit time, not only at session start. It is deduplicated to reduce repeated noise.
+
+### 4.5 Templates
+
+`docs/templates/` contains reusable agent guidance:
+
+- `entirecontext-maintainer-decision-reuse-template.md`
+- `entirecontext-user-decision-reuse-template.md`
+- `entirecontext-proactive-guidance.md`
+
+Use those templates as policy snippets for agents; keep them aligned with implemented MCP tools and hook behavior.
+
+## 5. Architecture Walkthrough
+
+### 5.1 System topology
+
+```mermaid
+flowchart LR
+  User[User / agent] --> CLI[Typer CLI]
+  Agent[Agent runtime] --> Hooks[Hook handlers]
+  Agent --> MCP[MCP stdio server]
+  CLI --> Core[core services]
+  Hooks --> Core
+  MCP --> Core
+  Core --> DB[(Repo SQLite DB)]
+  Core --> Content[External content files]
+  Core --> Git[Git repository]
+  Core --> Sync[Shadow-branch sync]
+  Sync --> Git
+  Core --> Global[(Global registry DB)]
+```
+
+Key layers:
+
+- **CLI layer** (`src/entirecontext/cli/`) registers Typer command modules.
+- **Hook layer** (`src/entirecontext/hooks/`) receives agent and git lifecycle events.
+- **MCP layer** (`src/entirecontext/mcp/`) exposes context tools to agents.
+- **Core services** (`src/entirecontext/core/`) implement search, decisions, futures, telemetry, config, checkpoints, compacting, and related behavior.
+- **Database layer** (`src/entirecontext/db/`) owns schema, migrations, connections, and global registry schema.
+- **Sync layer** (`src/entirecontext/sync/`) exports/imports artifacts and coordinates the shadow branch flow.
+
+### 5.2 CLI layer
+
+`src/entirecontext/cli/__init__.py` creates the root Typer app and imports command modules. Each module exposes `register(app)` and either adds a command or a Typer sub-application. This keeps the CLI grouped by workflow while preserving a single `ec` entry point.
+
+Major command groups include project setup, search, sessions, hooks, checkpoints, sync/pull, rewind, repo, events, blame, indexing, MCP serving, import, futures, purge, graph, dashboard, context telemetry, decision memory, and compacting.
+
+### 5.3 Hook layer
+
+`src/entirecontext/hooks/handler.py` dispatches hook types to implementation functions:
+
+```text
+SessionStart -> session_lifecycle.on_session_start
+UserPromptSubmit -> turn_capture.on_user_prompt plus proactive surfacing
+Stop -> turn_capture.on_stop
+PostToolUse -> turn_capture.on_tool_use plus decision surfacing
+SessionEnd -> session_lifecycle.on_session_end
+PostCommit -> session_lifecycle.on_post_commit
+```
+
+The hook layer is intentionally defensive: hook failures should not crash the host agent session. It records warnings or operation events where possible.
+
+### 5.4 Hook-to-storage sequence
+
+```mermaid
+sequenceDiagram
+  participant A as Agent runtime
+  participant H as hook handler
+  participant C as core services
+  participant D as SQLite
+  participant F as .entirecontext files
+
+  A->>H: SessionStart
+  H->>C: create/resume session
+  C->>D: upsert project/session
+  H->>F: optional decision/lesson fallback context
+  A->>H: UserPromptSubmit
+  H->>C: redact/filter and rank context
+  C->>D: create turn / retrieval telemetry
+  H-->>A: optional additionalContext
+  A->>H: PostToolUse
+  H->>D: record tool/files touched
+  H->>F: optional file-linked decision context
+  A->>H: Stop
+  H->>D: update assistant summary/content
+  A->>H: SessionEnd
+  H->>D: close session, optional assessment/distill/sync work
+```
+
+### 5.5 Core services
+
+The core package is intentionally broad. Important modules include:
+
+- `config.py` — default/global/repo-local TOML config merge.
+- `search.py`, `embedding.py`, `ast_index.py` — retrieval and indexing.
+- `decisions.py`, `decision_candidates.py`, `decision_extraction.py`, `decision_prompt_surfacing.py` — decision memory lifecycle.
+- `futures.py`, `auto_assess.py`, `lesson_surfacing.py` — assessments, feedback, lessons.
+- `checkpoint.py`, `session.py`, `turn.py`, `event.py` — captured work records.
+- `telemetry.py`, `context.py` — retrieval/context instrumentation and transaction helpers.
+- `content_filter.py`, `security.py` — capture-time filtering and secret redaction.
+- `compact.py`, `consolidation.py` — retention and compaction workflows.
+
+### 5.6 Sync flow
+
+```mermaid
+flowchart TD
+  A[Repo SQLite] --> B[export sessions/checkpoints]
+  B --> C[shadow worktree artifacts]
+  C --> D[commit to shadow branch]
+  D --> E[push shadow branch]
+  E --> F[pull/fetch elsewhere]
+  F --> G[merge artifacts]
+  G --> H[import sessions/checkpoints]
+```
+
+The sync coordinator initializes or updates a shadow branch, exports artifacts, commits changes, pushes when configured, and can fetch/merge/import remote artifacts. Security filtering is enabled by default for exported session text unless explicitly disabled.
+
+## 6. Data Model and Storage
+
+### 6.1 Schema version and SQLite posture
+
+The local schema version is **14** and the minimum SQLite version is **3.38.0+**. Schema definitions live in `src/entirecontext/db/schema.py`; migrations live under `src/entirecontext/db/migrations/`.
+
+### 6.2 Table groups
+
+The schema is best understood by group:
+
+| Group | Tables | Purpose |
+|---|---|---|
+| Project/session capture | `projects`, `agents`, `sessions`, `turns`, `turn_content` | Record who worked, where, and what happened. |
+| Git checkpoints and events | `checkpoints`, `events`, `event_sessions`, `event_checkpoints`, `attributions` | Tie memory to git state and higher-level work groupings. |
+| Retrieval and indexing | `embeddings`, `ast_symbols`, FTS tables, retrieval telemetry | Make content searchable and audit retrieval. |
+| Assessments and lessons | `assessments`, `assessment_relationships` | Evaluate changes and feed lesson generation. |
+| Decisions | `decisions`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`, `decision_candidates` | Store reusable engineering decisions and their lifecycle. |
+| Sync/operations | `sync_metadata`, `operation_events` | Track sync state and background/operation telemetry. |
+| Context use | `retrieval_events`, `retrieval_selections`, `context_applications` | Record what was retrieved and how it was used. |
+
+### 6.3 FTS and embeddings
+
+The project uses FTS5 virtual tables for searchable text surfaces, including turns, events, sessions, AST symbols, decisions, and decision candidates. Embeddings are stored separately by source type, source ID, model, dimensions, vector blob, and text hash. Semantic search is optional and should degrade gracefully if the semantic extra is unavailable.
+
+### 6.4 Content externalization
+
+Large turn content can be stored outside the main row and referenced by `turn_content.content_path`, size, and hash. This keeps the core turn table compact while preserving full content when enabled and retained.
+
+### 6.5 Local and global databases
+
+The repo-local database owns repository-specific sessions, turns, decisions, and checkpoints. The global registry schema tracks repositories and supports cross-repo discovery. Cross-repo behavior should not be described as a replacement for local source-of-truth data; it is a registry and retrieval aid.
+
+### 6.6 Migration and compatibility posture
+
+Migrations are versioned Python modules. When changing schema or long-lived data contracts, update migrations, schema constants, docs, changelog/schema references, and contract tests together. Repository policy requires extra care around version/schema drift.
+
+## 7. Configuration and Environment
+
+### 7.1 Config precedence
+
+Configuration merges in this order:
+
+```text
+defaults <- global config <- repo-local config
+```
+
+`src/entirecontext/core/config.py` defines defaults and merge behavior. Repo-local config is under `.entirecontext/config.toml`; global config is user-level.
+
+### 7.2 Major config sections
+
+| Section | Purpose |
+|---|---|
+| `[capture]` | Auto-capture, checkpoint hooks, content retention, AAR, Codex idle closing, lesson surfacing. |
+| `[capture.exclusions]` | Capture-time content/file/tool exclusions and redaction patterns. |
+| `[search]` | Default search mode and semantic model. |
+| `[sync]` | Auto-sync, pull/push timing, cooldowns, quiet mode. |
+| `[display]` | Result count and color preferences. |
+| `[security]` | Secret filtering toggle and redaction regex patterns. |
+| `[filtering.query_redaction]` | Query redaction before external or semantic processing. |
+| `[index]` | Embedding/indexing defaults. |
+| `[futures]` | Assessment backend/model, lesson output, enrichment/backfill behavior. |
+| `[decisions]` | Decision stale/extract/surfacing/inference behavior. |
+| `[decisions.ranking]` | Weights for staleness, assessment relations, files, commits, and directory proximity. |
+| `[decisions.quality]` | Decision quality scoring parameters. |
+| `[decisions.extraction]` | Outcome-feedback influence on candidate extraction. |
+| `[decisions.injection]` | Proactive decision injection limits and timeout. |
+
+### 7.3 Safe config examples
+
+Use placeholders and local-only dummy values:
+
+```toml
+[capture]
+auto_capture = true
+content_retention_days = 30
+
+[security]
+filter_secrets = true
+
+[decisions.injection]
+inject_on_user_prompt = true
+top_k = 5
+max_tokens = 800
+```
+
+Do not publish real API keys or model-provider credentials in config snippets.
+
+### 7.4 Defaults that affect side effects
+
+Important defaults include automatic capture, checkpoint-on-commit, secret filtering, decision auto-embedding, and proactive injection. Some automation remains opt-in, such as auto-sync and selected decision extraction/surfacing paths. Always inspect current defaults in `config.py` before documenting exact behavior.
+
+## 8. CLI Reference by Workflow
+
+This chapter is intentionally workflow-oriented. Use `ec --help` and `ec <group> --help` for exhaustive flags.
+
+### 8.1 Project setup and status
+
+- `ec init`
+- `ec enable`
+- `ec disable`
+- `ec status`
+- `ec config`
+- `ec doctor`
+
+These commands manage repo state, hooks, supported agent integration, configuration, and diagnostics.
+
+### 8.2 Session inspection and export
+
+- `ec session list`
+- `ec session show`
+- `ec session current`
+- `ec session export`
+- `ec session consolidate`
+- `ec session graph`
+- `ec session activate`
+- `ec session backfill-ended-at`
+- `ec session backfill-applied`
+
+Use these to inspect captured work, export session content, build session graphs, and repair/backfill session metadata.
+
+### 8.3 Search and graph exploration
+
+- `ec search`
+- `ec related`
+- `ec ast-search`
+- `ec graph`
+- `ec dashboard`
+- `ec blame`
+
+Search commands can operate over turns/sessions and symbols. Graph/dashboard/blame commands provide higher-level views of memory and attribution.
+
+### 8.4 Checkpoints, rewind, events, and attribution
+
+- `ec checkpoint create/list/show/diff/assess-accuracy`
+- `ec rewind`
+- `ec event list/show/create/link`
+- `ec context select/apply`
+
+Use checkpoints to preserve git-anchored state, events to group work, rewind to inspect checkpoint state, and context telemetry to record retrieval use.
+
+### 8.5 Decision memory
+
+- `ec decision create`
+- `ec decision list`
+- `ec decision show`
+- `ec decision rejected-alternatives`
+- `ec decision link`
+- `ec decision stale`
+- `ec decision outcome`
+- `ec decision update`
+- `ec decision supersede`
+- `ec decision unlink`
+- `ec decision search`
+- `ec decision chain`
+- `ec decision stale-all`
+- `ec decision extract-candidates`
+- `ec decision extract-from-session`
+- `ec decision surface-prompt`
+- `ec decision candidates ...`
+- `ec decision alternatives ...`
+
+Decision commands are central to the product. Prefer linking decisions to files/checkpoints/assessments and recording outcomes after use.
+
+### 8.6 Futures, feedback, lessons, and workers
+
+- `ec futures assess`
+- `ec futures list`
+- `ec futures feedback`
+- `ec futures lessons`
+- `ec futures enrich-backlog`
+- `ec futures relate/relationships/unrelate`
+- `ec futures trend/report/tidy-pr`
+- `ec futures worker-status/worker-stop/worker-launch`
+
+Futures commands evaluate change impact, capture feedback, generate lessons, and manage related background processing.
+
+### 8.7 Sync, import, purge, compact, MCP serving
+
+- `ec sync`
+- `ec pull`
+- `ec import`
+- `ec purge session/turn/match`
+- `ec compact`
+- `ec index`
+- `ec mcp serve`
+
+These commands affect storage, import/export, or agent-server behavior. Treat destructive cleanup and sync operations as operational actions; inspect help/output before use.
+
+## 9. MCP Reference by Workflow
+
+### 9.1 Search and retrieval
+
+- `ec_search` searches captured turns/sessions.
+- `ec_related` finds related sessions/turns by query or files.
+- `ec_ast_search` searches indexed symbols.
+- `ec_activate` performs spread-activation retrieval from a seed.
+
+### 9.2 Session and checkpoint context
+
+- `ec_session_context` returns session details and recent turns.
+- `ec_turn_content` returns full content for a turn.
+- `ec_attribution` returns attribution for files or lines.
+- `ec_checkpoint_list` lists checkpoints.
+- `ec_rewind` shows state at a checkpoint.
+
+### 9.3 Decision workflows
+
+- `ec_decision_context` performs one-call proactive decision retrieval.
+- `ec_decision_related` ranks linked decisions against explicit signals.
+- `ec_decision_search` searches decision records.
+- `ec_decision_get` resolves a decision.
+- `ec_decision_list` lists decisions with filters.
+- `ec_decision_create` creates a decision.
+- `ec_decision_outcome` records usage feedback.
+- `ec_decision_stale` probes staleness.
+
+Decision candidate tools list, inspect, confirm, or reject candidate decisions before they become durable records.
+
+### 9.4 Futures, lessons, and telemetry
+
+- `ec_assess` and `ec_assess_create` work with assessments.
+- `ec_feedback` records agreement/disagreement feedback.
+- `ec_lessons` generates lessons from assessed feedback.
+- `ec_assess_trends` summarizes trends.
+- `ec_context_apply` records how retrieved context was applied.
+
+### 9.5 Error and repo-resolution expectations
+
+MCP tools resolve repository context through the MCP runtime and repo database helpers. They should return structured or JSON-like payloads rather than crashing the agent host. Input normalization is especially important for agent callers; repository filters may accept strings or lists depending on the tool implementation.
+
+## 10. Hook Lifecycle and Automation
+
+### 10.1 SessionStart
+
+Creates or resumes a session and can surface broad-context decisions or lessons. It may write fallback Markdown under `.entirecontext/` when direct context injection is unavailable or inappropriate.
+
+### 10.2 UserPromptSubmit
+
+Records the start of a turn and can run proactive decision injection. The prompt path applies capture exclusions and redaction before storage or surfacing work. Injection is bounded by configuration limits so the agent session can continue if ranking times out.
+
+### 10.3 Stop
+
+Records assistant response summary and, where available, transcript-derived content. Content is redacted according to config before storage.
+
+### 10.4 PostToolUse
+
+Tracks tool usage and files touched for the active turn. When enabled, decision surfacing can identify decisions linked to just-edited files and write a session-scoped fallback file.
+
+### 10.5 SessionEnd
+
+Marks sessions ended, updates global counts, may infer applied or ignored decisions, can emit after-action review output, consolidate old turns, create auto-checkpoints, backfill or catch up assessments, trigger embedding/distillation, check stale decisions, extract candidates, and trigger background sync depending on configuration.
+
+### 10.6 PostCommit and pre-push sync
+
+`PostCommit` creates checkpoints for active sessions and can trigger assessment-related work. Git pre-push sync is documented in repository policy and should be treated as enabled only when the local hook/config actually installs it.
+
+### 10.7 Capture-disabled and fallback behavior
+
+Capture can be disabled globally or per session. Filtering can skip turns, files, or tools. Fallback context files are operational artifacts, not source files; they should not be confused with durable documentation.
+
+## 11. Decision Memory Deep Dive
+
+### 11.1 Decision creation and linking
+
+A decision should contain:
+
+- A concise title.
+- Rationale explaining why this option was chosen.
+- Scope describing where it applies.
+- Rejected alternatives when known.
+- Supporting evidence or links to commits, checkpoints, files, or assessments.
+
+Linking matters because retrieval uses file, commit, assessment, and session signals. A decision with no links can still be searched by text, but it is less likely to surface at the right moment.
+
+### 11.2 Staleness and supersession
+
+Staleness prevents old guidance from dominating new work. Decisions can be fresh, stale, superseded, or contradicted. Supersession chains point from older decisions to newer successors; the CLI includes a chain-walk command for debugging.
+
+### 11.3 Outcome recording
+
+Outcomes record what happened when guidance was surfaced or applied:
+
+- `accepted`: the decision was followed.
+- `ignored`: the decision was surfaced but not used.
+- `contradicted`: later evidence showed the decision was wrong.
+- `refined`: the decision was partially adapted.
+- `replaced`: a newer decision superseded it.
+
+Use `docs/decisions_outcomes.md` for canonical semantics and edge cases.
+
+### 11.4 Quality signals and ranking
+
+Decision ranking uses text, file overlap, git commit signals, assessment relationships, staleness, and quality/outcome signals. Defaults are configurable under `[decisions.ranking]`, `[decisions.quality]`, and `[decisions.extraction]`.
+
+### 11.5 Context applications
+
+A context application records that a retrieved item influenced work. This is separate from raw retrieval. Recording applications and outcomes is what turns retrieval into a closed feedback loop.
+
+### 11.6 Candidate extraction
+
+Decision candidates are extracted from sessions, checkpoints, or assessments and remain pending until confirmed or rejected. This avoids automatically turning noisy history into durable policy. Candidate promotion should preserve rationale, alternatives, source links, and confidence context.
+
+### 11.7 Lessons and assessments
+
+Assessments evaluate changes; feedback confirms or rejects that evaluation; lessons distill repeated guidance. Lessons are not a replacement for decisions. Decisions capture engineering choices; lessons capture generalized guidance from assessed outcomes.
+
+## 12. Sync, Filtering, and Cross-Repo Memory
+
+### 12.1 Shadow branch purpose
+
+Shadow-branch sync exports portable artifacts rather than raw local database files. This makes sync git-native while keeping the working branch separate from memory artifacts.
+
+### 12.2 Export/import model
+
+`perform_sync` exports sessions and checkpoints since the last export, commits artifacts in a shadow worktree, pushes when configured, fetches remote shadow state when needed, merges artifacts, and records sync metadata. `perform_pull` imports remote artifacts into the local database.
+
+### 12.3 Filtering boundaries
+
+There are multiple filtering layers:
+
+- Capture-time exclusions can skip turns, files, or tools and redact content.
+- Query redaction can filter prompts before semantic or external processing.
+- Sync/export secret filtering redacts exported text by default.
+
+Filtering reduces exposure risk but is not a license to store secrets. Prefer not capturing secrets in the first place.
+
+### 12.4 Cross-repo memory
+
+The global registry and cross-repo tools help locate memory across repositories. They do not remove the need to verify current repo state. A decision from another repo can be useful context, but local code and current tests decide applicability.
+
+### 12.5 Operational risks and recovery
+
+Sync can fail due to missing shadow refs, merge conflicts, transport errors, or filtering assumptions. Inspect `sync_metadata`, operation events, command output, and shadow branch artifacts before retrying blindly.
+
+## 13. Development and Maintenance
+
+### 13.1 Repository layout
+
+| Path | Role |
+|---|---|
+| `src/entirecontext/cli/` | Typer CLI command surface. |
+| `src/entirecontext/core/` | Business logic and services. |
+| `src/entirecontext/db/` | Schema, migrations, connection helpers. |
+| `src/entirecontext/hooks/` | Agent/git hook handlers. |
+| `src/entirecontext/mcp/` | MCP server and tools. |
+| `src/entirecontext/sync/` | Shadow-branch sync and artifact flow. |
+| `tests/` | Contract, unit, integration, and real-git fixture tests. |
+| `docs/` | Specs, ADRs, research, plans, templates, and manuals. |
+| `.github/workflows/ci.yml` | CI validation surfaces. |
+
+### 13.2 Development setup and tests
+
+CI runs linting with ruff, type checking with mypy, and tests on Python 3.12 and 3.13. Repository policy says that when modifying a source module, run the existing tests for that module, not only newly written tests.
+
+Useful validation commands from repo docs and CI include:
+
+```bash
+uv run ruff check .
+uv run mypy src/entirecontext/
+uv run pytest
+uv run pytest tests/test_contract_sync.py
+```
+
+If local cache permissions fail, use a writable cache location such as a temporary directory and record that choice in verification evidence.
+
+### 13.3 Adding CLI commands
+
+Repository policy requires new CLI commands to:
+
+1. Create or update `cli/<name>_cmds.py` with Typer command decorators.
+2. Import and register the module in `cli/__init__.py`.
+3. Keep business logic in `core/` where possible.
+4. Add a corresponding MCP tool when useful for agent workflows.
+5. Update compact reference docs such as `CLAUDE.md` when a new module surface matters.
+
+### 13.4 Adding MCP tools
+
+MCP tools should be implemented in `src/entirecontext/mcp/tools/`, registered through `register_tools()`, exported in `server.__all__`, and documented in the README Available Tools table. `tests/test_contract_sync.py` is the guard for registration/README drift.
+
+### 13.5 ADR and decision reuse policy
+
+Durable architecture decisions belong in `docs/adr/` using the ADR process. EC decisions can stay lightweight, but decisions that become project-wide policy should graduate to an ADR or reference one.
+
+Agents working in this repository must retrieve and apply relevant decisions and lessons for non-trivial work. Decisions are inputs to judgment, not unquestioned rules; verify fit against current code and task intent.
+
+### 13.6 Measure-first principle
+
+Before implementing feature or behavior changes, define the measurable success criterion and verify the measurement infrastructure. This is especially important for dashboard, assessment, telemetry, retrieval, and ranking work.
+
+### 13.7 Release/version alignment
+
+Version and schema drift have been a repeated risk. When releasing or changing schema:
+
+- Keep `pyproject.toml` and `src/entirecontext/__init__.py` aligned.
+- Keep `SCHEMA_VERSION`, migrations, changelog schema references, README/spec mentions, and contract tests aligned.
+- Verify `tests/test_contract_sync.py` when touching MCP tools, README tool docs, fallback filenames, or schema/changelog references.
+
+## 14. Troubleshooting and Runbooks
+
+| Symptom | Likely cause | First checks |
+|---|---|---|
+| `ec` command not found | Package not installed or environment not activated | Check install environment, `uv run ec --help`, and PATH. |
+| Not a git repository | Commands requiring repo root cannot resolve project | Run inside a git repo or initialize one. |
+| No active session | Hooks not enabled, capture disabled, or session ended | `ec status`, hook config, `.entirecontext/config.toml`. |
+| Hook not firing | Agent hook config missing or overwritten | `ec doctor`, `ec enable`, hook files/config. |
+| Capture missing turns | `capture.auto_capture=false`, per-session disabled, or exclusions matched | Config `[capture]` and `[capture.exclusions]`. |
+| MCP server unavailable | MCP extra missing or stdio server not configured | `ec mcp serve`, package extras, agent MCP settings. |
+| MCP tool list mismatch | Registration/export/docs drift | `tests/test_contract_sync.py`, `mcp/server.py`, README Available Tools. |
+| SQLite migration issue | Schema version mismatch or migration failure | `src/entirecontext/db/schema.py`, migrations, command output. |
+| Sync conflict or missing snapshot | Shadow branch missing, fetch/push failed, merge conflict | `ec sync` output, `sync_metadata`, shadow branch refs. |
+| Decisions not surfacing | Config disabled, no links/signals, timeout, stale/contradicted filtering | `[decisions]`, retrieval telemetry, decision links, PDI config. |
+| Lessons stale or absent | No assessed feedback, lessons not regenerated, SessionStart surfacing disabled | `ec futures lessons`, `LESSONS.md`, `[capture] surface_lessons_on_start`. |
+| Docs contract failure | README/tool/schema/fallback drift | Read failure message in `tests/test_contract_sync.py` and update both sides. |
+| Long docs automation timed out | Agent automation produced partial artifacts but did not finish | Inspect `.agent-loop/runs/*/artifacts/*` and summaries before rerunning. |
+
+## 15. Documentation Ownership and Evidence Appendix
+
+### 15.1 Documentation ownership map
+
+| Topic | Owner document/source | Notes |
+|---|---|---|
+| Product quick start and MCP tool table | `README.md` | Keep skimmable; contract-tested tool table. |
+| Implementation reference | `docs/spec.md` | Compact current-behavior reference. |
+| Decision outcome semantics | `docs/decisions_outcomes.md` | Canonical outcome vocabulary. |
+| Agent workflow policy | `AGENTS.md` | Repository-level autonomous-agent rules. |
+| Contributor reference | `CLAUDE.md` | Compact compatibility/contributor guide. |
+| Product direction | `ROADMAP.md` | Separate shipped behavior from intent. |
+| Durable architecture decisions | `docs/adr/` | Use ADR template/process. |
+| Historical ideas and proposals | `docs/brainstorms/`, `docs/research/`, proposal docs | Label as historical/proposal unless code confirms. |
+| Comprehensive orientation | This manual | Summarize and link; avoid becoming the only source of truth. |
+
+### 15.2 Evidence matrix
+
+| Manual area | Major claims | Evidence sources |
+|---|---|---|
+| Product wedge and loop | Decision memory for coding agents; capture/distill/retrieve/intervene spine | `README.md`, `ROADMAP.md`, decision `629f4a79-61b5-46d5-8a22-8311bb83d1ae`. |
+| Version/runtime snapshot | Version 0.9.3, Python 3.12+, schema v14 | `pyproject.toml`, `src/entirecontext/__init__.py`, `src/entirecontext/db/schema.py`, `.github/workflows/ci.yml`. |
+| CLI registration | Root Typer app and command modules | `src/entirecontext/cli/__init__.py`, `src/entirecontext/cli/*_cmds.py`. |
+| Project setup commands | init/enable/disable/status/config/doctor | `src/entirecontext/cli/project_cmds.py`, `README.md`. |
+| MCP tool surface | 29 exported `ec_*` tools grouped by workflow | `src/entirecontext/mcp/server.py`, `src/entirecontext/mcp/tools/*.py`, `tests/test_contract_sync.py`, `README.md`. |
+| Hook lifecycle | SessionStart, UserPromptSubmit, Stop, PostToolUse, SessionEnd, PostCommit | `src/entirecontext/hooks/handler.py`, `session_lifecycle.py`, `turn_capture.py`, `decision_hooks.py`, `README.md`. |
+| Data model | Schema v14, table groups, FTS, candidates, retrieval telemetry | `src/entirecontext/db/schema.py`, `docs/spec.md`. |
+| Configuration | Defaults and merge order | `src/entirecontext/core/config.py`, `README.md`, `docs/spec.md`. |
+| Search and indexing | Regex/FTS/AST/semantic concepts | `src/entirecontext/core/search.py`, `embedding.py`, `ast_index.py`, MCP search tools. |
+| Decision lifecycle | Staleness, outcomes, supersession, candidates | `src/entirecontext/core/decisions.py`, `src/entirecontext/cli/decisions_cmds.py`, `src/entirecontext/mcp/tools/decisions.py`, `docs/decisions_outcomes.md`. |
+| Futures and lessons | Assessments, feedback, generated lessons | `src/entirecontext/core/futures.py`, `src/entirecontext/cli/futures_cmds.py`, `LESSONS.md`. |
+| Sync/filtering | Shadow branch, export/import, secret filtering | `src/entirecontext/sync/coordinator.py`, `export_flow.py`, `security.py`, `core/content_filter.py`, `docs/spec-ec-sync-no-filter.md`. |
+| Development policy | Tests, ADRs, measure-first, decision reuse | `AGENTS.md`, `CLAUDE.md`, `docs/adr/README.md`, `.github/workflows/ci.yml`, `tests/conftest.py`. |
+| Contract drift prevention | README/MCP/schema/fallback guards | `tests/test_contract_sync.py`, decision `dffae62d-0d8b-4c17-9102-f77eca1532e8`. |
+| Release/version alignment | `__version__` and schema drift risk | decision `b148ba4d-702c-4dac-97a7-aa5551a70246`, `CHANGELOG.md`, `pyproject.toml`, `src/entirecontext/__init__.py`. |
+| Historical/proposal status | Brainstorms/research/proposals are not shipped behavior by default | `docs/brainstorms/**`, `docs/research/**`, `docs/documentation_in_prs_proposal.md`, `docs/tiered_review_policy_proposal.md`, `docs/plans/**`. |
+| Prior automation artifacts | Useful research prompts, not authoritative source | `.agent-loop/runs/*/artifacts/*`, run summaries, current source files. |
+
+### 15.3 Contract-tested facts
+
+`tests/test_contract_sync.py` currently guards:
+
+1. MCP `server.__all__` `ec_*` exports against registered tool functions.
+2. README Available Tools entries against MCP exports, bidirectionally.
+3. Decision-hook fallback filenames against README documentation.
+4. Current `SCHEMA_VERSION` against a schema-related changelog paragraph.
+
+These are not full documentation tests. They are targeted drift guards for surfaces that have drifted before.
+
+### 15.4 Manual-review-only facts and gaps
+
+The repository does not currently have a dedicated Markdown link checker or prose documentation linter. Manual review must cover:
+
+- Internal relative links.
+- Whether proposal/history docs are labeled correctly.
+- Whether examples use placeholders only.
+- Whether code path summaries still match source.
+- Whether new version/schema/tool names are reflected in all owning documents.
+
+### 15.5 Requirements coverage summary
+
+| Requirement | Coverage |
+|---|---|
+| R1-R4 product and audience value | Chapters 1-2 plus ownership/evidence appendix. |
+| R5-R8 operational and agent workflows | Chapters 3-4, 10, 12. |
+| R9-R12 implementation and maintainer knowledge | Chapters 5-9, 11, 13. |
+| R13-R17 accuracy and reviewability | Evidence matrix, contract-tested facts, verification gaps, and manual-review-only section. |
+
+### 15.6 Known limitations
+
+- This manual groups CLI and MCP surfaces by workflow and intentionally does not duplicate every flag.
+- The evidence matrix is compact; reviewers should inspect cited files directly for line-level verification.
+- Proposal and research documents are summarized only as categories, not exhaustively indexed.
+- Link validation is manual because no dedicated link-checking tool is configured in the repository.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -8,3 +8,5 @@ Collected research informing EntireContext roadmap and architecture decisions.
 |-------|------|------|---------|
 | Agent Memory Landscape | [agent-memory-landscape.md](agent-memory-landscape.md) | 2026-02-23 | Analysis of 20 GitHub agent-memory projects; cross-project themes; roadmap candidates |
 | GitHub Release Asset Automation | [github-release-assets-automation.md](github-release-assets-automation.md) | 2026-04-15 | Rationale and source notes for attaching built wheel/sdist artifacts to GitHub Releases |
+| v0.7.0 Hook Contract Spike | [v0-7-0-hook-contract-spike.md](v0-7-0-hook-contract-spike.md) | 2026-05-20 | Hook contract investigation for proactive decision injection, surfacing, and fallback-file behavior |
+| Redesign Direction: Loop-First Architecture | [redesign-direction-2026-06-21.md](redesign-direction-2026-06-21.md) | 2026-06-21 | 6-retro pain point analysis → loop health contract + decisions.py decomposition along loop-stage boundaries |

--- a/docs/research/redesign-direction-2026-06-21.md
+++ b/docs/research/redesign-direction-2026-06-21.md
@@ -1,0 +1,185 @@
+# Redesign Direction: Loop-First Architecture
+
+Date: 2026-06-21
+Method: EC decision/lesson/assessment ledger analysis → code-review → Architect expert (GPT via Codex)
+
+## Bottom Line
+
+The loudest signal across 6 retrospectives (v0.6.0–v0.9.3) is not "split the big file" — it's that **the core loop (capture→distill→retrieve→intervene→outcome) doesn't close by default**. Every stage exists as code but requires manual config toggling or CLI invocation. Nothing measures whether the loop fired. The system designed to track decisions doesn't use its own lifecycle fields (all 50 decisions `staleness_status=fresh`, every `superseded_by_id=null`).
+
+Primary recommendation: add a loop health contract, then decompose `decisions.py` along loop-stage boundaries. This is a Medium effort, not a rewrite.
+
+## Evidence: Recurring Pain Points (6 retros)
+
+| # | Pattern | Occurrences | Root Cause |
+|---|---------|-------------|------------|
+| 1 | distill=0 (auto-assess not firing) | 4 cycles (v0.6.0–v0.7.0) | `auto_extract=false` for 2 months; code existed, wasn't enabled |
+| 2 | Codex shift-left missed | 3 consecutive | Will-based process change; no structural enforcement |
+| 3 | Decision lifecycle fields unused | All 50 decisions | Staleness/supersession machinery never exercised |
+| 4 | Measurement infrastructure broke | 3 times | ended_at NULL (175/290), rate formula unreachable, unstable metrics |
+| 5 | Doc/code contract drift | Persistent | `__version__` 5 releases behind, MCP stale after uv sync |
+| 6 | decisions.py God module | Continuous | 1878 lines, 58 functions, 5 responsibility areas mixed |
+
+Source: EC decision ledger (50 decisions), MEMORY retrospectives, direct code analysis.
+
+## Evidence: Source Code Hotspots
+
+| File | Lines | Functions | Classes | Issue |
+|------|-------|-----------|---------|-------|
+| `core/decisions.py` | 1878 | 58 | 3 | God module: staleness + quality + CRUD + ranking(660L) + search + normalization |
+| `core/decision_extraction.py` | 1142 | 37 | 7 | Complex extraction pipeline |
+| `cli/decisions_cmds.py` | 965 | — | — | Thick CLI layer |
+| `hooks/decision_hooks.py` | 929 | — | — | Policy logic in hook package |
+| `hooks/session_lifecycle.py` | 731 | 23 | — | 13 `_maybe_*` wrappers mix dispatch + business logic |
+| `mcp/tools/decisions.py` | 668 | — | — | MCP surface |
+
+Decision-related code = ~6,432 lines = **27% of total source** (23,969 lines).
+
+MCP boilerplate: 29+ instances of `resolve_repo()` + `try/finally/conn.close()`. `repos is not None and repos != ""` in 6+ locations.
+
+## Meta-Problem: Why the Loop Doesn't Close
+
+Each stage is implemented as **optional side effects** behind independent config flags and manual CLI invocations. The architecture has "features that can run," not "a session lifecycle that must progress through observable stages."
+
+```
+Current: SessionEnd → 13 _maybe_*() → each checks own config flag → silently skips
+Missing: no record of "distill skipped because config disabled" vs "distill failed" vs "distill ran"
+```
+
+The structural fix: a **loop-stage contract** where every lifecycle event records whether each expected stage fired, skipped, or failed, with a reason. Once "disabled by config" becomes visible in the same surface as "worker failed" or "no candidates produced," issues like `auto_extract=false` for two months become impossible to miss.
+
+## Target Architecture: Loop-Stage Modules
+
+```
+core/
+  loop_health.py        ← NEW: stage contract (fired/skipped/failed + reason)
+  decisions/
+    __init__.py          ← re-exports for backward compat
+    store.py             ← CRUD, links, successor-chain (from decisions.py 316-970)
+    distill.py           ← extraction, candidates, quality gates (from decision_extraction.py + normalization)
+    retrieve.py          ← ranking, FTS/hybrid search, staleness filtering (from decisions.py 998-1810)
+    outcome.py           ← outcome recording, supersession, contradiction promotion (from decisions.py)
+    intervene.py         ← surfacing, prompt formatting, context application (from decision_prompt_surfacing.py)
+hooks/
+  session_lifecycle.py   ← thin dispatch only: SESSION_END_STAGES list → stage modules
+  decision_hooks.py      ← surfacing policy moves to core/decisions/intervene.py
+mcp/
+  runtime.py             ← add with_repo() context manager
+  tools/*.py             ← use with_repo(), shared normalization
+```
+
+Mapping to loop stages:
+- **capture**: `core/session.py` + `hooks/turn_capture.py` (already separate)
+- **distill**: `core/decisions/distill.py` (extract + confirm + quality)
+- **retrieve**: `core/decisions/retrieve.py` (rank + search + filter)
+- **intervene**: `core/decisions/intervene.py` (surface + format + apply)
+- **outcome**: `core/decisions/outcome.py` (record + supersede + promote)
+- **health**: `core/loop_health.py` (stage contract + observability)
+
+## Surgical Refactors (ordered by impact/risk)
+
+### 1. Add Loop Health Contract
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Create `core/loop_health.py` (~100 lines). Record stage status for SessionStart, UserPromptSubmit, SessionEnd, PostCommit. Include "skipped:config_disabled" as first-class status. |
+| **Blast radius** | Low-medium. Mostly additive; hook callsites only. |
+| **Benefit** | Directly addresses the #1 failure mode: code existed but didn't fire and nobody noticed. Makes v1.0 gate ("loop completes without human intervention") measurable. |
+| **Effort** | Medium (1-2d) |
+| **Priority** | **Highest** — this is the meta-fix. |
+
+### 2. Replace `_maybe_*` Sprawl With Declarative Stage Dispatch
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Keep 3 entry points in `session_lifecycle.py`. Move each `_maybe_*` body to stage modules. Dispatch via `SESSION_END_STAGES` list. |
+| **Blast radius** | Medium. Tests already cover ordering and failures. Preserve order exactly. |
+| **Benefit** | Makes default loop closure visible. Removes hidden business logic from hook dispatch. Enables per-stage health reporting (pairs with #1). |
+| **Effort** | Medium (1-2d) |
+
+### 3. Extract Retrieval Stage From decisions.py
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Move `RankingWeights`, ranking helpers, `rank_related_decisions`, `fts_search_decisions`, `hybrid_search_decisions` → `core/decisions/retrieve.py` (~660 lines). Keep re-export shims. |
+| **Blast radius** | Medium. Many tests import from `core.decisions`; compatibility exports keep it manageable. |
+| **Benefit** | Highest complexity reduction. Retrieval is already relatively cohesive and heavily tested. |
+| **Effort** | Short-Medium (4h-1d) |
+
+### 4. Extract Outcome Lifecycle + Dogfood Staleness
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Move `record_decision_outcome`, contradiction promotion, `supersede_decision`, successor-chain, staleness policy → `core/decisions/outcome.py`. Add SessionEnd health check reporting fresh/stale/superseded/contradicted counts. |
+| **Blast radius** | Medium-high. Outcome semantics are central; do this AFTER retrieval extraction. |
+| **Benefit** | Converts `staleness_status` and `superseded_by_id` from dormant schema into the product's own feedback loop. |
+| **Effort** | Medium (1-2d) |
+
+### 5. Add MCP Repo Context Helper + Adopt Existing RepoContext
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Add `runtime.with_repo()` context manager for MCP tools. Replace `resolve_repo()` + `try/finally conn.close()` incrementally. **Note:** `RepoContext` already exists in `core/context.py` (lines 88-156) with `__enter__`/`__exit__` — the connection lifecycle problem is an adoption gap, not missing infrastructure (same pattern as distill=0, Codex shift-left). |
+| **Blast radius** | Low. Start with one MCP module, then repeat. |
+| **Benefit** | Removes 29+ instances of boilerplate. Reduces repo normalization drift. |
+| **Effort** | Quick-Short (<1h-4h) |
+| **Risk note** | Will-based adoption ("use this pattern consistently") has a 3-peat failure history in this project. Consider removing the old `get_db()` + `try/finally` path entirely in migrated modules, not just adding an alternative. |
+
+### Quick Win: Deduplicate `_find_git_root`
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Remove duplicate definition in `hooks/session_lifecycle.py:15-29`, import from `core/context.py:72`. |
+| **Blast radius** | Very low. Tests monkeypatching `_find_git_root` on session_lifecycle need redirect. |
+| **Benefit** | Single source of truth for git root discovery. |
+| **Effort** | Quick (<1h) |
+
+### Quick Win: Extract `decisions_normalization.py`
+
+| Dimension | Detail |
+|-----------|--------|
+| **Scope** | Move lines 1805-1878 (3 functions: `normalize_alternative`, `normalize_rejected_alternatives`, `audit_rejected_alternatives`) to `core/decisions_normalization.py`. |
+| **Blast radius** | Very low. 3 import sites in source, 1 test file. Zero coupling to ranking or CRUD. |
+| **Benefit** | First step in decisions.py decomposition with near-zero risk. Establishes the pattern. |
+| **Effort** | Quick (<1h) |
+
+## Counterarguments Against Refactoring Now
+
+1. **v1.0 might only need one config flip.** If `auto_extract` verification passes and the loop closes with current code, shipping v1.0 first and refactoring v1.1 avoids regression risk during the final push.
+
+2. **1800+ test import surface.** Splitting `decisions.py` touches many test files. Even with re-export shims, subtle import-order or mock-target changes can cause flaky failures. Stage the split across multiple PRs.
+
+3. **Opportunity cost.** Every day spent refactoring is a day not spent on `lesson_reuse_rate` activation or production `auto_extract` verification — the two items that directly unlock the remaining maturity points.
+
+4. **"It works."** The current architecture, while messy, has shipped 10+ releases. The God module is well-tested. Refactoring for aesthetics without a concrete v1.0 blocker is vanity.
+
+5. **Don't introduce a workflow engine.** The product needs five observable stages, not a framework. `loop_health.py` should be ~100 lines recording events, not an orchestrator.
+
+## Recommended Execution Order
+
+```
+Phase 0 (immediate): Loop health contract (#1) — additive, low risk, unblocks measurement
+Phase 1 (next release): Extract retrieval (#3) + MCP helper (#5) — highest cleanup/risk ratio
+Phase 2 (post-v1.0): Stage dispatch (#2) + outcome lifecycle (#4) — higher blast radius, better after v1.0 stability
+```
+
+## Methodology Note
+
+This analysis used three parallel review lanes:
+- **Decision-analyzer**: EC decision ledger (50 decisions), all returned findings
+- **Direct code analysis**: AST function counts, grep for patterns, file metrics
+- **Architect expert (GPT via Codex)**: independent advisory review
+
+Two additional subagents (code-reviewer, architect-review as Plan agent) were spawned but went idle without returning results; their analysis was fully substituted by direct file reads and the Codex Architect consultation.
+
+### Simplify skill scope mismatch
+
+The original goal included the `simplify` skill, which reviews changed code and applies fixes. This task produced a redesign *direction* with no source code changes — the skill has no legitimate diff target. The simplification lens is captured in:
+- Refactor #3 (extract retrieval for cohesion — removes 660 lines from God module)
+- Refactor #5 (MCP `with_repo()` — removes 29+ boilerplate sites)
+
+These are where `simplify`-type thinking landed. Actual `simplify` execution belongs in the PRs that implement each refactor.
+
+## Next Steps
+
+When implementing the surgical refactors, invoke `/simplify` after each PR's code changes to verify the decomposition actually simplified rather than just moved code. The redesign direction itself is a research deliverable, not a code change.

--- a/docs/spec-ec-sync-no-filter.md
+++ b/docs/spec-ec-sync-no-filter.md
@@ -1,9 +1,10 @@
 # Spec: `ec sync --no-filter` Runtime Propagation
 
 ## Status
-- Proposed
+- Implemented / historical specification
 - Owner: EntireContext CLI/Sync
 - Scope: `ec sync` command path only
+- Current reference: `README.md`, `docs/spec.md`, `src/entirecontext/cli/sync_cmds.py`, sync CLI tests
 
 ## Problem Statement
 `ec sync` currently accepts `--no-filter`, but the option is not propagated to the runtime sync config passed to `perform_sync(...)`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,25 +1,30 @@
 # EntireContext Specification
 
-> Time-travel searchable agent memory anchored to your codebase.
+> Git-anchored decision memory for coding agents.
 
-**Version**: 0.1.0
-**Status**: Implementation-aligned specification (as of 2026-03-07)
+**Package version**: 0.9.3
+**Reference status**: Current implementation reference, refreshed 2026-06-20
+**Primary source of truth**: `src/entirecontext/`, `pyproject.toml`, and contract tests
 
 ---
 
 ## 1. Scope and Source of Truth
 
-This document describes the behavior implemented in the current codebase.
+This document describes the behavior implemented in the current codebase at a reference level. For user onboarding and product framing, start with `README.md`; for exact runtime behavior, use the source modules named below and the corresponding tests.
 
-- Primary source of truth (runtime behavior):
-  - `src/entirecontext/`
-- Supporting docs (user-facing):
-  - `README.md`
+- Runtime behavior: `src/entirecontext/`
+- CLI surface: `src/entirecontext/cli/__init__.py` and `src/entirecontext/cli/*_cmds.py`
+- MCP surface: `src/entirecontext/mcp/server.py` and `src/entirecontext/mcp/tools/*.py`
+- Data schema: `src/entirecontext/db/schema.py`
+- Hook behavior: `src/entirecontext/hooks/handler.py`, `session_lifecycle.py`, `turn_capture.py`, `decision_hooks.py`
+- Public user guide: `README.md`
+- Contract drift guard: `tests/test_contract_sync.py`
 
 ### Status tags used in this spec
 
 - `[Implemented]`: behavior is present in code now.
 - `[Partial]`: partially implemented or implemented with known caveats.
+- `[Historical]`: retained as provenance, not a current behavior claim.
 - `[Planned]`: intentionally not implemented yet.
 
 ---
@@ -37,9 +42,11 @@ User / Agent
 Core Engine
   ├─ Capture (sessions/turns)
   ├─ Checkpoint
-  ├─ Search (regex/FTS/semantic)
+  ├─ Search (regex/FTS/semantic/hybrid)
+  ├─ Decision memory + context telemetry
   ├─ Attribution
-  ├─ Futures assessment
+  ├─ Futures assessment + lessons
+  ├─ Dashboard/graph/AST/compaction
   └─ Cross-repo orchestration
 
 Storage
@@ -60,7 +67,7 @@ Storage
 
 ## 3. Data Model
 
-Schema version: **6**.
+Schema version: **14**.
 Minimum SQLite version: **3.38.0+**.
 
 Reference:
@@ -71,15 +78,17 @@ Reference:
 
 - `projects`, `agents`, `sessions`, `turns`, `turn_content`
 - `checkpoints`, `events`, `event_sessions`, `event_checkpoints`
-- `attributions`, `embeddings`
-- `assessments` (futures), `assessment_relationships` (typed links between assessments)
-- `ast_symbols` (Python AST symbol index)
-- `sync_metadata` (`last_sync_error`, `last_sync_duration_ms`, `sync_pid` included)
+- `attributions`, `embeddings`, `ast_symbols`
+- `assessments`, `assessment_relationships`
+- `decisions`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`
+- `retrieval_events`, `retrieval_selections`, `context_applications`
+- `operation_events`, `decision_candidates`
+- `sync_metadata`
 
 ### 3.2 Search indexes `[Implemented]`
 
-- FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols`
-- Trigger-based synchronization for insert/update/delete
+- FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols`, `fts_decisions`, `fts_decision_candidates`
+- Trigger-based synchronization for insert/update/delete where defined in `schema.py`
 
 ### 3.3 Global DB `[Implemented]`
 
@@ -91,41 +100,61 @@ Reference:
 
 ## 4.1 CLI interface `[Implemented]`
 
-Validated command set (from `ec --help`):
+Validated command set (from `ec --help`, 2026-06-20):
 
-- Top-level: `init`, `enable`, `disable`, `status`, `config`, `doctor`, `search`, `sync`, `pull`, `rewind`, `blame`, `index`, `import`, `dashboard`, `graph`, `ast-search`
-- Groups: `session`, `hook`, `checkpoint`, `repo`, `event`, `mcp`, `futures`, `purge`
+- Top-level commands: `init`, `enable`, `disable`, `status`, `config`, `doctor`, `search`, `sync`, `pull`, `rewind`, `blame`, `index`, `import`, `graph`, `ast-search`, `dashboard`, `compact`
+- Groups: `session`, `hook`, `checkpoint`, `repo`, `event`, `mcp`, `futures`, `purge`, `context`, `decision`
 
 ### Key command groups
 
-- `ec checkpoint`: `create`, `list`, `show`, `diff`
-- `ec futures`: `assess`, `list`, `feedback`, `lessons`, `trend`, `relate`, `relationships`, `unrelate`, `tidy-pr`, `report`, `worker-status`, `worker-stop`, `worker-launch`
-- `ec session`: `list`, `show`, `current`, `export`, `consolidate`, `graph`, `activate`
+- `ec session`: `list`, `show`, `current`, `export`, `consolidate`, `graph`, `activate`, `backfill-ended-at`, `backfill-applied`
+- `ec checkpoint`: `create`, `list`, `show`, `diff`, `assess-accuracy`
+- `ec decision`: `create`, `list`, `show`, `rejected-alternatives`, `link`, `stale`, `outcome`, `update`, `supersede`, `unlink`, `search`, `chain`, `stale-all`, `extract-candidates`, `extract-from-session`, `surface-prompt`, `candidates`, `alternatives`
+- `ec context`: `select`, `apply`
+- `ec futures`: `assess`, `list`, `feedback`, `lessons`, `enrich-backlog`, `relate`, `relationships`, `unrelate`, `trend`, `report`, `tidy-pr`, `worker-status`, `worker-stop`, `worker-launch`
 - `ec purge`: `session`, `turn`, `match`
-- `ec sync`: supports `--no-filter`
+- `ec mcp`: `serve`
+- `ec sync`: supports `--no-filter` and `--if-enabled`
 
 ## 4.2 MCP interface `[Implemented]`
 
-Transport: stdio.
+Transport: stdio. Source of truth is `src/entirecontext/mcp/server.py` plus the `register_tools()` functions under `src/entirecontext/mcp/tools/`. `tests/test_contract_sync.py` asserts that this registered set matches the README `### Available Tools` table.
 
-Implemented tools (12):
+Implemented tools (29):
 
-1. `ec_search`
-2. `ec_checkpoint_list`
-3. `ec_session_context`
-4. `ec_attribution`
-5. `ec_rewind`
-6. `ec_related`
-7. `ec_turn_content`
-8. `ec_assess`
-9. `ec_assess_create`
-10. `ec_feedback`
-11. `ec_lessons`
-12. `ec_assess_trends`
+1. `ec_activate`
+2. `ec_assess`
+3. `ec_assess_create`
+4. `ec_assess_trends`
+5. `ec_ast_search`
+6. `ec_attribution`
+7. `ec_checkpoint_list`
+8. `ec_context_apply`
+9. `ec_dashboard`
+10. `ec_decision_candidate_confirm`
+11. `ec_decision_candidate_get`
+12. `ec_decision_candidate_list`
+13. `ec_decision_candidate_reject`
+14. `ec_decision_context`
+15. `ec_decision_create`
+16. `ec_decision_get`
+17. `ec_decision_list`
+18. `ec_decision_outcome`
+19. `ec_decision_related`
+20. `ec_decision_search`
+21. `ec_decision_stale`
+22. `ec_feedback`
+23. `ec_graph`
+24. `ec_lessons`
+25. `ec_related`
+26. `ec_rewind`
+27. `ec_search`
+28. `ec_session_context`
+29. `ec_turn_content`
 
 Cross-repo support:
 
-- tools support `repos` parameter (`null` current repo, `["*"]` all repos, `["name"]` selected repos)
+- Tools accept a `repos` parameter (`null` current repo, `["*"]` all repos, `["name"]` selected repos) where applicable; MCP runtime normalizes scalar/list/wildcard shapes at the boundary.
 
 ## 4.3 Hook contract `[Implemented]`
 
@@ -136,6 +165,7 @@ Hook dispatcher handles:
 - `Stop`
 - `PostToolUse`
 - `SessionEnd`
+- `PostCommit`
 
 Runtime entrypoint:
 
@@ -143,8 +173,8 @@ Runtime entrypoint:
 
 Install location and format:
 
-- Installed by `ec enable` into `.claude/settings.local.json`
-- Uses Claude hook object format with `matcher` + nested `hooks`
+- Claude Code hooks are installed by `ec enable` into `.claude/settings.local.json` using Claude hook object format with `matcher` + nested `hooks`.
+- User-level MCP config is installed by `ec enable` into `~/.claude/settings.json` under `mcpServers.entirecontext`.
 
 Exit codes:
 
@@ -153,7 +183,7 @@ Exit codes:
 
 ## 4.4 Git hooks `[Implemented]`
 
-Installed by `ec enable`:
+Installed by `ec enable` unless `--no-git-hooks` is passed:
 
 - `.git/hooks/post-commit` -> invokes `ec hook handle --type PostCommit`
 - `.git/hooks/pre-push` -> invokes `ec sync --if-enabled`
@@ -233,25 +263,27 @@ Artifacts:
 
 ## 7.1 Data and CLI `[Implemented]`
 
-- `assessments` table stores verdict/feedback metadata
-- CLI:
-  - `ec futures assess`
-  - `ec futures list`
-  - `ec futures feedback`
-  - `ec futures lessons`
+- `assessments` table stores verdict/feedback metadata.
+- `assessment_relationships` stores typed relationships between assessments.
+- CLI commands: `assess`, `list`, `feedback`, `lessons`, `enrich-backlog`, `trend`, `relate`, `relationships`, `unrelate`, `tidy-pr`, `report`, `worker-status`, `worker-stop`, `worker-launch`.
 
 ## 7.2 MCP exposure `[Implemented]`
 
-- `ec_assess` (read assessment)
-- `ec_lessons` (read distilled lessons inputs)
+- `ec_assess`
+- `ec_assess_create`
+- `ec_feedback`
+- `ec_lessons`
+- `ec_assess_trends`
 
-## 7.3 Auto-distill behavior `[Implemented]`
+## 7.3 Auto-distill and feedback behavior `[Implemented]`
 
-- `futures feedback` triggers auto-distill check
-- session end lifecycle also triggers auto-distill check
-- gated by config: `futures.auto_distill`
+- `futures feedback` triggers auto-distill checks.
+- Session end lifecycle can trigger auto-distill checks.
+- Assessment enrichment/backlog processing is controlled by `[futures]` config keys such as `auto_distill`, `assess_enrich`, and `assess_backfill_window_days`.
 
 ---
+
+## 7b. Content Filtering and Purge `[Implemented]`
 
 ## 7b. Content Filtering and Purge `[Implemented]`
 
@@ -297,11 +329,19 @@ Source:
 
 - `src/entirecontext/core/config.py`
 
+This is an operator-facing excerpt, not a replacement for `DEFAULT_CONFIG`.
+
 ```toml
 [capture]
 auto_capture = true
 checkpoint_on_commit = true
 checkpoint_on_session_end = false
+auto_cleanup_no_changes = false
+content_retention_days = 30
+intent_summary = false
+emit_aar = true
+codex_session_idle_minutes = 60
+surface_lessons_on_start = true
 
 [capture.exclusions]
 enabled = false
@@ -316,6 +356,7 @@ semantic_model = "all-MiniLM-L6-v2"
 
 [sync]
 auto_sync = false
+auto_sync_on_push = false
 auto_pull = false
 cooldown_seconds = 300
 pull_staleness_seconds = 600
@@ -329,20 +370,45 @@ color = true
 [security]
 filter_secrets = true
 patterns = [
-  "(?i)(api[_-]?key|secret|password|token)\\s*[=:]\\s*[\\'\"]?[\\w-]+",
+  "(?i)(api[_-]?key|secret|password|token)\\s*[=:]\\s*['\"]?[\\w-]+",
   "(?i)bearer\\s+[\\w.-]+",
   "ghp_[a-zA-Z0-9]{36}",
   "sk-[a-zA-Z0-9]{48}",
 ]
 
-[filtering.query_redaction]
-enabled = false
-patterns = []
-replacement = "[FILTERED]"
+[index]
+auto_embed = false
+embed_model = "all-MiniLM-L6-v2"
 
 [futures]
 auto_distill = false
 lessons_output = "LESSONS.md"
+default_backend = "claude"
+default_model = ""
+assess_enrich = true
+assess_backfill_window_days = 7
+
+[decisions]
+auto_stale_check = false
+auto_extract = false
+show_related_on_start = false
+surface_on_tool_use = false
+infer_applied_on_session_end = true
+infer_outcome_type = true
+auto_promotion_contradicted_threshold = 2
+auto_embed = true
+
+[decisions.injection]
+inject_on_user_prompt = true
+top_k = 5
+max_tokens = 800
+min_confidence = 0.4
+inject_timeout_ms = 250
+
+[filtering.query_redaction]
+enabled = false
+patterns = []
+replacement = "[FILTERED]"
 ```
 
 ---
@@ -355,50 +421,49 @@ lessons_output = "LESSONS.md"
 
 ## Phase 2: Git integration
 
-- `[Partial]` Checkpoint + sync/pull + rewind are present
-- `[Implemented]` post-commit automation path dispatches `PostCommit` and creates checkpoints when policy allows
+- `[Implemented]` Checkpoint, rewind, sync/pull, post-commit checkpoint path, and pre-push sync gate
 
 ## Phase 3: Semantic + MCP
 
-- `[Implemented]` semantic indexing/search and MCP tools
-- `[Implemented]` MCP toolset expanded beyond initial draft (9 tools)
+- `[Implemented]` Semantic indexing/search when optional dependencies are installed
+- `[Implemented]` MCP server with 29 registered `ec_*` tools guarded by `tests/test_contract_sync.py`
 
 ## Phase 4: Attribution + Multi-agent
 
 - `[Implemented]` line attribution CLI/API and agent hierarchy fields
+- `[Implemented]` session graph and spreading activation retrieval
 
 ## Phase 5: Sharing + Cross-repo
 
 - `[Implemented]` global repo index and cross-repo query paths
-- `[Partial]` advanced sync conflict policy described in old draft is not fully wired in runtime path
+- `[Implemented]` artifact-level shadow-branch sync/pull with one non-fast-forward retry
 
-## Phase 6: Futures (added)
+## Phase 6: Futures and lessons
 
-- `[Implemented]` futures CLI, table, feedback loop, lessons generation
-- `[Implemented]` LLM backend abstraction and MCP read tools (`ec_assess`, `ec_lessons`)
+- `[Implemented]` futures CLI, assessment table, typed assessment relationships, feedback loop, lessons generation, enrichment worker, and LLM backend abstraction
 
-## Phase 7: Content Filtering & Purge (added)
+## Phase 7: Content Filtering & Purge
 
 - `[Implemented]` 3-layer content filtering: capture exclusion, query redaction, post-hoc purge
 - `[Implemented]` `ec purge session/turn/match` CLI with dry-run safety
-- `[Implemented]` per-session and global capture toggle
-- `[Implemented]` query-time redaction in search and MCP tools
+- `[Implemented]` per-session and global capture toggles
 
-## Phase 8: Dashboard, Graph, AST & Advanced Features (added)
+## Phase 8: Dashboard, Graph, AST & Advanced Features
 
-- `[Implemented]` Team dashboard (`ec dashboard`) — session/checkpoint/assessment aggregation
-- `[Implemented]` Knowledge graph (`ec graph`) — git entity traversal (6 node types, 6 edge types)
-- `[Implemented]` Code AST search (`ec ast-search`) — Python AST symbol indexing with FTS5
-- `[Implemented]` Memory consolidation (`ec session consolidate`) — old turn content compression
-- `[Implemented]` Multi-agent session graph (`ec session graph`) — BFS hierarchy traversal
-- `[Implemented]` Spreading activation (`ec session activate`) — related turn discovery via shared files/commits
-- `[Implemented]` Hybrid search (`--hybrid`) — FTS5 + recency RRF reranking
-- `[Implemented]` Assessment relationships (`ec futures relate/relationships/unrelate`) — typed links between assessments
-- `[Implemented]` Tidy PR generation (`ec futures tidy-pr`) — rule-based PR draft from narrow assessments
-- `[Implemented]` Futures report (`ec futures report`) — team-shareable Markdown report
-- `[Implemented]` Async assessment worker (`ec futures worker-*`) — background analysis without capture blocking
-- `[Implemented]` Session export (`ec session export`) — Markdown export with YAML frontmatter
-- `[Implemented]` MCP tools expanded: `ec_assess_create`, `ec_feedback`, `ec_assess_trends` (9 → 12)
+- `[Implemented]` Team dashboard (`ec dashboard`)
+- `[Implemented]` Knowledge graph (`ec graph`)
+- `[Implemented]` Code AST search (`ec ast-search`)
+- `[Implemented]` Memory consolidation (`ec session consolidate`) and storage compaction (`ec compact`)
+- `[Implemented]` Hybrid search (`--hybrid`)
+- `[Implemented]` Session export (`ec session export`)
+
+## Phase 9: Decision memory and proactive retrieval
+
+- `[Implemented]` first-class decisions, rejected alternatives, staleness/supersession, outcome tracking, and auto-promotion to `contradicted`
+- `[Implemented]` candidate decision extraction/review pipeline
+- `[Implemented]` Proactive Decision Injection on `UserPromptSubmit`
+- `[Implemented]` decision surfacing on `SessionStart` and optional `PostToolUse`
+- `[Implemented]` context telemetry (`retrieval_events`, `retrieval_selections`, `context_applications`)
 
 ---
 
@@ -414,37 +479,38 @@ Sync policy notes:
 
 ---
 
-## 11. Validation Checklist (2026-03-07)
+## 11. Validation Checklist (2026-06-20)
 
 ## CLI shape checks
 
-- `ec --help` confirms command groups including `futures`, `mcp`, `import`, `checkpoint`, `purge`, `dashboard`, `graph`, `ast-search`
-- `ec checkpoint --help` confirms `create/list/show/diff`
-- `ec futures --help` confirms `assess/list/feedback/lessons/trend/relate/relationships/unrelate/tidy-pr/report/worker-status/worker-stop/worker-launch`
-- `ec session --help` confirms `list/show/current/export/consolidate/graph/activate`
-- `ec purge --help` confirms `session/turn/match`
-- `ec sync --help` confirms `--no-filter` option exposure
+- `ec --help` confirms top-level commands including `compact`, `dashboard`, `graph`, `ast-search`, and groups including `context` and `decision`.
+- `ec checkpoint --help` confirms `create/list/show/diff/assess-accuracy`.
+- `ec decision --help` confirms decision CRUD, staleness, outcome, supersession, candidate extraction/review, and alternatives commands.
+- `ec context --help` confirms `select/apply`.
+- `ec futures --help` confirms assessment, feedback, lessons, enrichment, relationship, reporting, tidy-pr, and worker commands.
+- `ec session --help` confirms `list/show/current/export/consolidate/graph/activate/backfill-ended-at/backfill-applied`.
+- `ec sync --help` confirms `--no-filter` and `--if-enabled` option exposure.
 
 ## MCP checks
 
-- Source-level confirmation of 12 tools in `mcp/server.py`
-- Query-time redaction applied to `ec_search`, `ec_session_context`, `ec_turn_content`
+- `tests/test_contract_sync.py` source-extracts `mcp/server.py` registration modules and confirms 29 `ec_*` tools match `server.__all__` and README.
+- Query-time redaction applies to search/session/turn MCP responses where implemented by tool modules.
 
 ## Config checks
 
-- Source-level confirmation against `DEFAULT_CONFIG` in `core/config.py`
-- `capture.exclusions` and `filtering.query_redaction` sections present
+- Source-level confirmation against `DEFAULT_CONFIG` in `core/config.py`.
+- `capture.exclusions`, `[decisions]`, `[decisions.injection]`, `[futures]`, `[index]`, and `filtering.query_redaction` sections are present.
 
 ## Hook checks
 
-- Source-level confirmation of handled hook types, including `PostCommit` dispatch
-- Content filtering integrated in `on_user_prompt`, `on_stop`, `on_tool_use`
+- Source-level confirmation of handled hook types, including `PostCommit` dispatch.
+- Decision fallback filenames are guarded by `tests/test_contract_sync.py`: `decisions-context.md` and `decisions-context-tooluse`.
+- Content filtering integrated in `on_user_prompt`, `on_stop`, and `on_tool_use` paths.
 
 ## Sync policy checks
 
-- `uv run pytest tests/test_sync.py tests/test_sync_engine.py tests/test_sync_cmds.py`
-- `uv run pytest`
-- `uv build`
+- `ec sync --no-filter` propagates runtime filtering config and is covered by CLI tests.
+- Shadow-branch export/import and artifact-level merge behavior remain covered by sync tests.
 
 ---
 

--- a/docs/tiered_review_policy_proposal.md
+++ b/docs/tiered_review_policy_proposal.md
@@ -1,4 +1,5 @@
 # Tiered Review Policy Proposal
+> **Status:** Proposal / historical process note. Current review principles live in `AGENTS.md`; this file records an unadopted tiering idea and is not itself binding policy.
 
 ## Motivation
 

--- a/src/entirecontext/cli/compact_cmds.py
+++ b/src/entirecontext/cli/compact_cmds.py
@@ -29,7 +29,7 @@ def compact_cmd(
         None,
         "--retention-days",
         "-r",
-        help="Keep content files newer than N days (default: from config, fallback 30)",
+        help="Consolidate turns older than N days by turn timestamp (default: from config, fallback 30)",
     ),
     limit: int = typer.Option(10000, "--limit", "-n", help="Max turns to consolidate per run"),
 ) -> None:
@@ -52,7 +52,10 @@ def compact_cmd(
         retention_days = config.get("capture", {}).get("content_retention_days", 30)
 
     db_path = Path(repo_path) / ".entirecontext" / "db" / "local.db"
-    if not execute and not db_path.exists():
+    if not db_path.exists():
+        if execute:
+            console.print("[red]No EntireContext database — refusing to execute (would treat all content as orphans).[/red]")
+            raise typer.Exit(1)
         console.print("[dim]No EntireContext database found — nothing to compact.[/dim]")
         return
 

--- a/src/entirecontext/core/compact.py
+++ b/src/entirecontext/core/compact.py
@@ -95,8 +95,10 @@ def measure_storage(repo_path: str) -> dict[str, int]:
         db_bytes = db_path.stat().st_size
         for suffix in ("-wal", "-shm"):
             sidecar = db_path.with_name(db_path.name + suffix)
-            if sidecar.exists():
+            try:
                 db_bytes += sidecar.stat().st_size
+            except (FileNotFoundError, OSError):
+                continue
 
     return {
         "content_bytes": content_bytes,
@@ -110,8 +112,10 @@ def _db_total_size(db_path: Path) -> int:
     total = db_path.stat().st_size if db_path.exists() else 0
     for suffix in ("-wal", "-shm"):
         sidecar = db_path.with_name(db_path.name + suffix)
-        if sidecar.exists():
+        try:
             total += sidecar.stat().st_size
+        except (FileNotFoundError, OSError):
+            continue
     return total
 
 

--- a/src/entirecontext/core/compact.py
+++ b/src/entirecontext/core/compact.py
@@ -84,8 +84,11 @@ def measure_storage(repo_path: str) -> dict[str, int]:
     content_count = 0
     if content_dir.exists():
         for f in content_dir.rglob("*.jsonl"):
-            content_bytes += f.stat().st_size
-            content_count += 1
+            try:
+                content_bytes += f.stat().st_size
+                content_count += 1
+            except (FileNotFoundError, OSError):
+                continue
 
     db_bytes = 0
     if db_path.exists():
@@ -102,31 +105,41 @@ def measure_storage(repo_path: str) -> dict[str, int]:
     }
 
 
+def _db_total_size(db_path: Path) -> int:
+    """Return total size of DB file including WAL/SHM sidecars."""
+    total = db_path.stat().st_size if db_path.exists() else 0
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(db_path.name + suffix)
+        if sidecar.exists():
+            total += sidecar.stat().st_size
+    return total
+
+
 def vacuum_db(repo_path: str) -> dict[str, int]:
     """Run VACUUM on the local DB and return before/after sizes.
 
-    Opens a dedicated connection for VACUUM (it cannot run inside a
-    transaction). Failures are logged but never propagate — VACUUM is
-    a minor hygiene step and must not abort a successful compact run.
+    Opens a dedicated connection because compact_repo() borrows (but
+    does not own) the caller's connection.  Failures are logged but
+    never propagate — VACUUM is a minor hygiene step and must not
+    abort a successful compact run.
     """
-    import sqlite3
-
     db_path = Path(repo_path) / ".entirecontext" / "db" / "local.db"
     if not db_path.exists():
         return {"db_before": 0, "db_after": 0}
 
-    db_before = db_path.stat().st_size
+    db_before = _db_total_size(db_path)
 
     try:
         conn = sqlite3.connect(str(db_path))
         conn.execute("PRAGMA busy_timeout=5000")
         conn.execute("VACUUM")
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         conn.close()
     except sqlite3.OperationalError as exc:
         logger.warning("VACUUM skipped: %s", exc)
         return {"db_before": db_before, "db_after": db_before}
 
-    db_after = db_path.stat().st_size
+    db_after = _db_total_size(db_path)
     return {"db_before": db_before, "db_after": db_after}
 
 
@@ -173,7 +186,7 @@ def compact_repo(
     if not dry_run:
         vacuum = vacuum_db(repo_path)
 
-    after = measure_storage(repo_path)
+    after = measure_storage(repo_path) if not dry_run else before
 
     return {
         "before": before,

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -46,6 +46,16 @@ class TestFindOrphanContentFiles:
         assert len(orphans) == 1
         assert orphans[0] == orphan_file
 
+    def test_recent_orphan_preserved_by_min_age(self, ec_repo, ec_db):
+        """min_age_seconds safety guard preserves files with recent mtime."""
+        content_dir = Path(str(ec_repo)) / ".entirecontext" / "content" / "recent-session"
+        content_dir.mkdir(parents=True)
+        orphan_file = content_dir / "recent-turn.jsonl"
+        orphan_file.write_text('{"recent": true}')
+
+        orphans = find_orphan_content_files(ec_db, str(ec_repo), min_age_seconds=3600)
+        assert orphans == []
+
 
 class TestRemoveOrphanContentFiles:
     def test_dry_run_does_not_delete(self, ec_repo, ec_db):
@@ -93,6 +103,18 @@ class TestVacuumDb:
         result = vacuum_db(str(ec_repo))
         assert "db_before" in result
         assert "db_after" in result
+        assert result["db_after"] <= result["db_before"]
+
+    def test_vacuum_reclaims_space(self, ec_repo, ec_db):
+        """VACUUM should report actual reclamation even with another conn open."""
+        ec_db.execute("CREATE TABLE _inflate (data TEXT)")
+        ec_db.execute("INSERT INTO _inflate VALUES (?)", ("x" * 50000,))
+        ec_db.commit()
+        ec_db.execute("DELETE FROM _inflate")
+        ec_db.execute("DROP TABLE _inflate")
+        ec_db.commit()
+
+        result = vacuum_db(str(ec_repo))
         assert result["db_after"] <= result["db_before"]
 
 

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -208,10 +208,13 @@ class TestCompactCLI:
             call_kwargs = mock_compact.call_args
             assert call_kwargs.kwargs.get("dry_run", True) is True
 
-    def test_execute_flag(self):
+    def test_execute_flag(self, tmp_path):
         mock_conn = MagicMock()
+        db_file = tmp_path / ".entirecontext" / "db" / "local.db"
+        db_file.parent.mkdir(parents=True)
+        db_file.touch()
         with (
-            patch("entirecontext.core.project.find_git_root", return_value="/tmp/test"),
+            patch("entirecontext.core.project.find_git_root", return_value=str(tmp_path)),
             patch("entirecontext.db.get_db", return_value=mock_conn),
             patch("entirecontext.db.check_and_migrate"),
             patch(

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -174,6 +174,13 @@ class TestCompactCLI:
             assert result.exit_code == 0
             assert "nothing to compact" in result.output.lower()
 
+    def test_execute_no_db_refuses(self, tmp_path):
+        """--execute with no DB must abort to prevent treating all content as orphans."""
+        with patch("entirecontext.core.project.find_git_root", return_value=str(tmp_path)):
+            result = runner.invoke(app, ["compact", "--execute"])
+            assert result.exit_code == 1
+            assert "refusing" in result.output.lower()
+
     def test_dry_run_by_default(self, tmp_path):
         mock_conn = MagicMock()
         db_file = tmp_path / ".entirecontext" / "db" / "local.db"


### PR DESCRIPTION
## Summary

Post-merge follow-up for `ec compact` (PR #169). Fixes two compact bugs found via code-review, adds redesign direction research, and refreshes documentation surface.

## Changes

### Bug fixes (`core/compact.py`, `cli/compact_cmds.py`)
- **VACUUM WAL reporting** — `_db_total_size()` helper includes WAL/SHM sidecars in size measurement; `PRAGMA wal_checkpoint(TRUNCATE)` forces WAL fold-back before measuring. Fixes incorrect `db_after == db_before` when another connection holds the WAL open.
- **Execute guard for missing DB** — `--execute` now refuses to run when `local.db` is absent, preventing empty-DB orphan cleanup from deleting all content files.
- **Dry-run I/O optimization** — skip `measure_storage()` for after snapshot in dry-run mode.
- **OSError guard** in `measure_storage()` for concurrent file removal.
- **Docstring accuracy** — separate connection needed because `compact_repo()` borrows the caller's connection, not because "VACUUM can't run in a transaction".
- **Help text accuracy** — `--retention-days` clarified as "by turn timestamp" (not file mtime).

### Tests (2 new, 22 total)
- `test_recent_orphan_preserved_by_min_age` — verifies `min_age_seconds` safety guard
- `test_vacuum_reclaims_space` — verifies VACUUM reports actual reclamation with another connection open
- `test_execute_no_db_refuses` — verifies execute mode aborts when DB is missing

### Research
- `docs/research/redesign-direction-2026-06-21.md` — 6-retro pain point analysis → loop health contract + decisions.py decomposition along loop-stage boundaries

### Documentation
- `docs/entirecontext-project-manual.md` — comprehensive project manual
- README, spec.md, CHANGELOG, LESSONS refreshed to match v0.9.3 (schema v14, 29-tool MCP surface)
- Status banners on historical proposal docs
- Research index updated

## Test plan

- [x] `uv run pytest tests/test_compact.py` — 22 tests pass
- [x] VACUUM reclaim test verifies WAL reporting accuracy
- [x] min_age safety guard test verifies recent orphan preservation
- [x] Execute-no-DB guard test verifies abort on missing database

🤖 Generated with [Claude Code](https://claude.com/claude-code)