### PR TITLE
feat: v0.13.0 Git Archaeology — retroactive decision extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Dogfooding maturity: 61/100 (capture=22, distill=17, retrieve=17, intervene=5).
 ### Added
 
 - **`archaeology_processed` table + `decision_candidates.source_type` expansion (schema v16)** — foundation for Git Archaeology decision extraction. `archaeology_processed` tracks which commits have been scanned for candidates (`commit_sha`, `candidate_count`, `processed_at`). `decision_candidates.source_type` CHECK now accepts `'archaeology'` alongside the existing `session`/`checkpoint`/`assessment` values. Table rebuild migration (FTS5 triggers dropped/recreated), no data loss.
+- **`ec archaeologize` command** — retroactive decision extraction from `git log --patch`. Streams commit history through the existing extraction pipeline to produce `source:archaeology` candidates. Supports `--since`, `--until`, `--limit` (default 100), `--pr-bodies` (GitHub API), `--dry-run` (cost estimate), `--batch-size`. Implicit resume via dedup. Addresses the 91% file-link gap and cold-start adoption barrier.
+- **`[decisions.archaeology]` config section** — `enabled`, `batch_size`, `pr_body_fetch` settings.
+- **`run_extraction` bundles injection** — optional `bundles` parameter allows external callers to bypass `collect_signals` while sharing the full extraction pipeline.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Carry-forward graduation: all 8 v0.11.0 retro items diagnosed and recorded. Zero
 
 Dogfooding maturity: 61/100 (capture=22, distill=17, retrieve=17, intervene=5).
 
+### Added
+
+- **`archaeology_processed` table + `decision_candidates.source_type` expansion (schema v16)** — foundation for Git Archaeology decision extraction. `archaeology_processed` tracks which commits have been scanned for candidates (`commit_sha`, `candidate_count`, `processed_at`). `decision_candidates.source_type` CHECK now accepts `'archaeology'` alongside the existing `session`/`checkpoint`/`assessment` values. Table rebuild migration (FTS5 triggers dropped/recreated), no data loss.
+
 ### Changed
 
 - **ROADMAP v0.11.0 section** — retroactively added (was skipped during v0.11.0 release).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Return codes: 0=success, 2=block.
 
 TOML deep merge: defaults ← `~/.entirecontext/config.toml` (global) ← `.entirecontext/config.toml` (per-repo)
 
-Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `security`, `filtering.query_redaction`, `index`, `futures`, `decisions`, `decisions.ranking`, `decisions.quality`, `decisions.extraction`, `decisions.injection`
+Sections: `capture`, `capture.exclusions`, `search`, `sync`, `display`, `security`, `filtering.query_redaction`, `index`, `futures`, `decisions`, `decisions.ranking`, `decisions.quality`, `decisions.extraction`, `decisions.injection`, `decisions.archaeology`
 
 ## Code Review Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ cli/             business    SQLite     Claude Code   shadow branch
   import_cmds    async_worker
   compact_cmds   compact
   mcp_cmds
+  archaeology_cmds
 ```
 
 `mcp/server.py` — MCP server interface (optional dependency).
@@ -42,9 +43,9 @@ cli/             business    SQLite     Claude Code   shadow branch
 
 **Per-repo DB**: `.entirecontext/db/local.db`
 **Global DB**: `~/.entirecontext/db/ec.db`
-**Schema version**: 15
+**Schema version**: 16
 
-Key tables: `projects`, `sessions`, `turns`, `turn_content`, `checkpoints`, `agents`, `events`, `assessments`, `assessment_relationships`, `attributions`, `embeddings`, `ast_symbols`, `sync_metadata`, `decisions`, `decision_candidates`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`, `ranking_snapshots`
+Key tables: `projects`, `sessions`, `turns`, `turn_content`, `checkpoints`, `agents`, `events`, `assessments`, `assessment_relationships`, `attributions`, `embeddings`, `ast_symbols`, `sync_metadata`, `decisions`, `decision_candidates`, `decision_commits`, `decision_checkpoints`, `decision_files`, `decision_assessments`, `decision_outcomes`, `ranking_snapshots`, `archaeology_processed`
 
 FTS5 virtual tables: `fts_turns`, `fts_events`, `fts_sessions`, `fts_ast_symbols`, `fts_decisions`, `fts_decision_candidates` (auto-synced via triggers)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -304,7 +304,7 @@ Theme: close the 91% file-link gap via retroactive git archaeology, push interve
 - [x] **7/21 experiment validity analysis** — VERDICT: insufficient data for hypothesis testing. Block 1 (ON) started 7/5, 6 days elapsed, only 2/5 qualifying sessions reached. Zero crossover (no flip to OFF ever occurred). 64 ranking_snapshots accumulated, cron active (625 log entries), infra healthy. Root cause: low session frequency post-v0.11.0 (63 total qualifying sessions, but only 2 since experiment start). Options: (a) lower N from 5→3, (b) wait for natural session accumulation, (c) pause experiment and revisit when session volume recovers. Carry-forward: experiment remains active but deprioritized — focus shifts to Git Archaeology which has immediate impact.
 
 ### Git Archaeology
-- [ ] **`ec archaeologize` command** — `git log --patch` + merged PR bodies through existing extraction pipeline; `source:inferred` bootstrapped decision corpus. Addresses 91% file-link gap and cold-start adoption barrier. Plan reference: `docs/brainstorms/retroactive-git-archaeology.md`.
+- [x] **`ec archaeologize` command** — `git log --patch` + merged PR bodies through existing extraction pipeline; `source:archaeology` bootstrapped decision corpus. Addresses 91% file-link gap and cold-start adoption barrier. Plan reference: `docs/brainstorms/retroactive-git-archaeology.md`.
 
 Carry-forward conditions:
 - Experiment analysis may carry forward if qualifying session count insufficient

--- a/docs/superpowers/plans/2026-07-11-v0.13.0-git-archaeology.md
+++ b/docs/superpowers/plans/2026-07-11-v0.13.0-git-archaeology.md
@@ -1,0 +1,1450 @@
+# v0.13.0 Git Archaeology Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `ec archaeologize` — retroactive decision extraction from git history to close the 91% file-link gap and eliminate the cold-start adoption barrier.
+
+**Architecture:** `core/archaeology.py` orchestrates `git log --patch` streaming, per-commit dedup via `archaeology_processed` table, and extraction via `run_extraction` with injected `SignalBundle`. Schema v16 adds the tracking table and widens `decision_candidates.source_type` CHECK. CLI is a top-level `ec archaeologize` command.
+
+**Tech Stack:** Python 3.12+, SQLite (WAL), Typer CLI, subprocess (`git log`), existing LLM extraction pipeline
+
+## Global Constraints
+
+- Python 3.12+ required
+- `uv sync` after any dependency change; restart Claude Code after touching `mcp/` or `core/decisions.py`
+- SQLite WAL mode; all migrations forward-only (no downgrade functions)
+- Run existing module tests before committing changes to that module
+- `_MAX_PROMPT_CHARS = 8000` limits patch text per extraction call
+- Existing `min_confidence = 0.35` threshold applies to archaeology candidates
+- All candidates land in `decision_candidates` with `review_status='pending'` — no auto-promotion
+
+---
+
+### Task 1: Schema v16 Migration — `archaeology_processed` table + `source_type` CHECK expansion
+
+**Files:**
+- Create: `src/entirecontext/db/migrations/v016.py`
+- Modify: `src/entirecontext/db/migrations/__init__.py:10` (range upper bound 16→17)
+- Modify: `src/entirecontext/db/schema.py:3` (SCHEMA_VERSION 15→16)
+- Modify: `src/entirecontext/db/schema.py:430` (CHECK constraint)
+- Test: `tests/test_migration_v016.py`
+
+**Interfaces:**
+- Consumes: `src/entirecontext/db/migration.py:apply_migrations` (existing migration runner)
+- Produces: `archaeology_processed` table, widened `decision_candidates.source_type` CHECK accepting `'archaeology'`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_migration_v016.py
+"""Tests for schema v15 → v16 migration."""
+
+import sqlite3
+import pytest
+from entirecontext.db.migration import bootstrap_schema, apply_migrations
+
+
+@pytest.fixture
+def v15_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    bootstrap_schema(conn)
+    return conn
+
+
+def test_archaeology_processed_table_exists(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    row = v15_db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_source_type_accepts_archaeology(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key) "
+        "VALUES ('test1', 'Test', 'archaeology', 'abc123', 0.5, 'dk1')"
+    )
+    row = v15_db.execute(
+        "SELECT source_type FROM decision_candidates WHERE id = 'test1'"
+    ).fetchone()
+    assert row["source_type"] == "archaeology"
+
+
+def test_source_type_rejects_invalid(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    with pytest.raises(sqlite3.IntegrityError):
+        v15_db.execute(
+            "INSERT INTO decision_candidates "
+            "(id, title, source_type, source_id, confidence, dedup_key) "
+            "VALUES ('test2', 'Test', 'bogus', 'abc123', 0.5, 'dk2')"
+        )
+
+
+def test_existing_candidates_preserved(v15_db):
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key, rationale) "
+        "VALUES ('pre1', 'Existing', 'session', 's1', 0.7, 'dk0', 'reason')"
+    )
+    apply_migrations(v15_db, 15, 16)
+    row = v15_db.execute(
+        "SELECT title, source_type, rationale FROM decision_candidates WHERE id = 'pre1'"
+    ).fetchone()
+    assert row["title"] == "Existing"
+    assert row["source_type"] == "session"
+    assert row["rationale"] == "reason"
+
+
+def test_fts_triggers_work_after_migration(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key, rationale) "
+        "VALUES ('fts1', 'Archaeology FTS Test', 'archaeology', 'abc', 0.5, 'dk3', 'test rationale')"
+    )
+    rows = v15_db.execute(
+        "SELECT * FROM fts_decision_candidates WHERE fts_decision_candidates MATCH 'Archaeology'"
+    ).fetchall()
+    assert len(rows) >= 1
+
+
+def test_archaeology_processed_schema(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc123', 3)"
+    )
+    row = v15_db.execute(
+        "SELECT commit_sha, candidate_count, processed_at FROM archaeology_processed WHERE commit_sha = 'abc123'"
+    ).fetchone()
+    assert row["commit_sha"] == "abc123"
+    assert row["candidate_count"] == 3
+    assert row["processed_at"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_migration_v016.py -v`
+Expected: FAIL — `v016` module not found
+
+- [ ] **Step 3: Create migration file**
+
+```python
+# src/entirecontext/db/migrations/v016.py
+"""Migration to schema v16 — add archaeology_processed table, widen decision_candidates.source_type."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _create_archaeology_processed(conn: sqlite3.Connection) -> None:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'"
+    ).fetchone()
+    if row is not None:
+        return
+    conn.execute(
+        """
+        CREATE TABLE archaeology_processed (
+            commit_sha TEXT PRIMARY KEY,
+            candidate_count INTEGER NOT NULL DEFAULT 0,
+            processed_at TEXT DEFAULT (datetime('now'))
+        )
+        """
+    )
+
+
+_WIDENED_DDL = """
+CREATE TABLE decision_candidates_new (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    rationale TEXT,
+    scope TEXT,
+    rejected_alternatives TEXT,
+    supporting_evidence TEXT,
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment','archaeology')),
+    source_id TEXT NOT NULL,
+    session_id TEXT,
+    checkpoint_id TEXT,
+    assessment_id TEXT,
+    files TEXT,
+    confidence REAL NOT NULL DEFAULT 0.0,
+    confidence_breakdown TEXT,
+    review_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(review_status IN ('pending','confirmed','rejected')),
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    review_note TEXT,
+    promoted_decision_id TEXT,
+    dedup_key TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+    FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON DELETE SET NULL,
+    FOREIGN KEY (promoted_decision_id) REFERENCES decisions(id) ON DELETE SET NULL
+)
+"""
+
+_COLUMNS = (
+    "id, title, rationale, scope, rejected_alternatives, supporting_evidence, "
+    "source_type, source_id, session_id, checkpoint_id, assessment_id, "
+    "files, confidence, confidence_breakdown, review_status, "
+    "reviewed_at, reviewed_by, review_note, promoted_decision_id, "
+    "dedup_key, created_at, updated_at"
+)
+
+
+def _rebuild_decision_candidates(conn: sqlite3.Connection) -> None:
+    existing = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='decision_candidates'"
+    ).fetchone()
+
+    if existing is None:
+        conn.execute(_WIDENED_DDL.replace("decision_candidates_new", "decision_candidates"))
+        _create_indexes(conn)
+        _create_fts(conn)
+        return
+
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_ai")
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_ad")
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_au")
+    conn.execute("DROP TABLE IF EXISTS fts_decision_candidates")
+
+    conn.execute(_WIDENED_DDL)
+    conn.execute(
+        f"INSERT INTO decision_candidates_new SELECT {_COLUMNS} FROM decision_candidates"
+    )
+    conn.execute("DROP TABLE decision_candidates")
+    conn.execute("ALTER TABLE decision_candidates_new RENAME TO decision_candidates")
+
+    _create_indexes(conn)
+    _create_fts(conn)
+
+
+def _create_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uniq_decision_candidates_source_dedup "
+        "ON decision_candidates(source_type, source_id, dedup_key)"
+    )
+
+
+def _create_fts(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS fts_decision_candidates USING fts5(
+            title, rationale,
+            content='decision_candidates',
+            content_rowid='rowid'
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO fts_decision_candidates(rowid, title, rationale) "
+        "SELECT rowid, title, COALESCE(rationale, '') FROM decision_candidates"
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ai AFTER INSERT ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, COALESCE(new.rationale, ''));
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ad AFTER DELETE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, COALESCE(old.rationale, ''));
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_au AFTER UPDATE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, COALESCE(old.rationale, ''));
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, COALESCE(new.rationale, ''));
+        END
+        """
+    )
+
+
+MIGRATION_STEPS = [
+    _create_archaeology_processed,
+    _rebuild_decision_candidates,
+]
+```
+
+- [ ] **Step 4: Update migration range and schema version**
+
+In `src/entirecontext/db/migrations/__init__.py:10`, change:
+```python
+    for version in range(2, 17):  # was range(2, 16)
+```
+
+In `src/entirecontext/db/schema.py:3`, change:
+```python
+SCHEMA_VERSION = 16  # was 15
+```
+
+In `src/entirecontext/db/schema.py:430`, change the CHECK constraint:
+```python
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment','archaeology')),
+```
+
+Add `archaeology_processed` to `TABLES` dict in `src/entirecontext/db/schema.py` (fresh installs never run migrations — they bootstrap from `TABLES`):
+
+```python
+    "archaeology_processed": """
+CREATE TABLE IF NOT EXISTS archaeology_processed (
+    commit_sha TEXT PRIMARY KEY,
+    candidate_count INTEGER NOT NULL DEFAULT 0,
+    processed_at TEXT DEFAULT (datetime('now'))
+);
+""",
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_migration_v016.py -v`
+Expected: all 6 tests PASS
+
+Run: `uv run pytest tests/ -k "migration" -v`
+Expected: existing migration tests still PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/entirecontext/db/migrations/v016.py src/entirecontext/db/migrations/__init__.py \
+  src/entirecontext/db/schema.py tests/test_migration_v016.py
+git commit -m "feat(db): schema v16 — archaeology_processed table + source_type expansion"
+```
+
+---
+
+### Task 2: `run_extraction` Seam — `bundles` injection + `session_id: str | None`
+
+**Files:**
+- Modify: `src/entirecontext/core/decision_extraction.py:57` (`_VALID_SOURCE_TYPES`)
+- Modify: `src/entirecontext/core/decision_extraction.py:59-63` (`_BASE_CONFIDENCE_WEIGHTS`)
+- Modify: `src/entirecontext/core/decision_extraction.py:85-107` (`SignalBundle`, `CandidateDraft` types)
+- Modify: `src/entirecontext/core/decision_extraction.py:521-559` (`_SYSTEM_PROMPT_BY_SOURCE`)
+- Modify: `src/entirecontext/core/decision_extraction.py:1109-1192` (`run_extraction`)
+- Test: `tests/test_extraction_archaeology_seam.py`
+
+**Interfaces:**
+- Consumes: schema v16 from Task 1 (`source_type='archaeology'` now valid in DB)
+- Produces: `run_extraction(conn, session_id=None, repo_path, *, bundles=[...])` — callable with injected bundles and no session
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_extraction_archaeology_seam.py
+"""Tests for run_extraction archaeology seam (injected bundles, session_id=None)."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from entirecontext.core.decision_extraction import (
+    SignalBundle,
+    run_extraction,
+    _VALID_SOURCE_TYPES,
+    _BASE_CONFIDENCE_WEIGHTS,
+    _SYSTEM_PROMPT_BY_SOURCE,
+)
+
+
+def test_archaeology_in_valid_source_types():
+    assert "archaeology" in _VALID_SOURCE_TYPES
+
+
+def test_archaeology_in_base_confidence_weights():
+    assert "archaeology" in _BASE_CONFIDENCE_WEIGHTS
+
+
+def test_archaeology_in_system_prompt():
+    assert "archaeology" in _SYSTEM_PROMPT_BY_SOURCE
+
+
+def test_signal_bundle_accepts_none_session_id():
+    bundle = SignalBundle(
+        source_type="archaeology",
+        source_id="abc123",
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=["diff --git a/foo.py b/foo.py"],
+        files=["foo.py"],
+    )
+    assert bundle.session_id is None
+    assert bundle.source_type == "archaeology"
+
+
+def test_run_extraction_with_injected_bundles(ec_db):
+    bundle = SignalBundle(
+        source_type="archaeology",
+        source_id="abc123",
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=["No decision content here."],
+        files=[],
+    )
+
+    mock_response = "[]"
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        outcome = run_extraction(
+            ec_db,
+            session_id=None,
+            repo_path="/tmp/fake",
+            bundles=[bundle],
+        )
+    assert outcome.bundles_collected == 1
+    assert outcome.marked is False  # no session to mark
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_extraction_archaeology_seam.py -v`
+Expected: FAIL — `run_extraction` does not accept `bundles` kwarg, `SignalBundle.session_id` type error
+
+- [ ] **Step 3: Update `_VALID_SOURCE_TYPES` and `_BASE_CONFIDENCE_WEIGHTS`**
+
+In `src/entirecontext/core/decision_extraction.py:57`:
+```python
+_VALID_SOURCE_TYPES = frozenset({"session", "checkpoint", "assessment", "archaeology"})
+```
+
+In `src/entirecontext/core/decision_extraction.py:59-63`:
+```python
+_BASE_CONFIDENCE_WEIGHTS: dict[str, float] = {
+    "assessment": 0.55,
+    "checkpoint": 0.40,
+    "session": 0.30,
+    "archaeology": 0.25,
+}
+```
+
+- [ ] **Step 4: Add archaeology system prompt**
+
+In `src/entirecontext/core/decision_extraction.py`, add to `_SYSTEM_PROMPT_BY_SOURCE` dict after the `"assessment"` entry:
+
+```python
+    "archaeology": (
+        "You are reviewing a git commit patch for architectural or technical decisions. "
+        "The patch shows what was changed and the commit message explains why. "
+        "Extract decisions where the developer chose one approach over another. "
+        "Return a JSON array: "
+        '[{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [{"alternative": str, "reason": str}]}]. '
+        "Return [] if the commit is a routine refactor, dependency bump, formatting, "
+        "or test-only change with no architectural choice. "
+        "For each rejected alternative, provide the reason it was not chosen — "
+        "only if the reason is explicit in the commit message or code comments. "
+        'If no reason is stated, omit the "reason" key entirely (do not invent one).'
+    ),
+```
+
+- [ ] **Step 5: Update `SignalBundle.session_id` and `CandidateDraft.session_id` types**
+
+In `src/entirecontext/core/decision_extraction.py:88`:
+```python
+    session_id: str | None  # was: str
+```
+
+In `src/entirecontext/core/decision_extraction.py:104`:
+```python
+    session_id: str | None  # was: str
+```
+
+- [ ] **Step 6: Add `bundles` parameter to `run_extraction`**
+
+Replace the `run_extraction` function (lines 1109-1192):
+
+```python
+def run_extraction(
+    conn,
+    session_id: str | None,
+    repo_path: str,
+    *,
+    bundles: list[SignalBundle] | None = None,
+    min_confidence: float = 0.35,
+    extraction_weights: ExtractionWeights | None = None,
+) -> ExtractionOutcome:
+    outcome = ExtractionOutcome()
+
+    if session_id is not None and is_session_extracted(conn, session_id):
+        return outcome
+
+    if bundles is None:
+        if session_id is None:
+            return outcome
+        bundles = collect_signals(conn, session_id, repo_path)
+
+    outcome.bundles_collected = len(bundles)
+    if not bundles:
+        return outcome
+
+    if extraction_weights is None:
+        from entirecontext.core.config import load_config
+
+        try:
+            extraction_weights = _load_extraction_weights(load_config(repo_path))
+        except Exception as exc:
+            outcome.warnings.append(f"extraction_weights_load:{exc}")
+            extraction_weights = ExtractionWeights()
+
+    for bundle in bundles:
+        prompt_text = assemble_prompt(bundle)
+        if not prompt_text.strip():
+            continue
+        redacted = apply_redaction(prompt_text, repo_path)
+        try:
+            raw = call_extraction_llm(redacted, repo_path, source_type=bundle.source_type)
+        except DecisionExtractionError as exc:
+            outcome.warnings.append(f"llm_call:{bundle.source_type}:{exc}")
+            continue
+        try:
+            drafts = parse_llm_response(raw, bundle)
+        except DecisionExtractionError as exc:
+            outcome.warnings.append(f"parse:{bundle.source_type}:{exc}")
+            continue
+        outcome.parsed_ok = True
+        outcome.drafts_parsed += len(drafts)
+        for draft in drafts:
+            dedup_result = dedup(conn, draft)
+            score, breakdown = score_confidence(draft, dedup_result)
+            if extraction_weights.outcome_feedback_enabled and draft.files:
+                stats = get_file_outcome_stats(
+                    conn,
+                    list(draft.files),
+                    extraction_weights.outcome_feedback_lookback_days,
+                )
+                score, breakdown = apply_outcome_feedback_to_confidence(
+                    score,
+                    breakdown,
+                    stats,
+                    penalty=extraction_weights.contradicted_penalty,
+                    boost=extraction_weights.accepted_boost_amount,
+                    boost_threshold=extraction_weights.accepted_boost_threshold,
+                )
+            if score < min_confidence:
+                outcome.low_confidence_skipped += 1
+                continue
+            persist_result = persist_candidate(conn, draft, score, breakdown, dedup_result)
+            if persist_result.inserted:
+                outcome.candidates_inserted += 1
+            elif persist_result.reason == "duplicate":
+                outcome.duplicates_skipped += 1
+
+    if outcome.bundles_collected > 0 and outcome.drafts_parsed == 0:
+        outcome.warnings.append(
+            f"no_drafts: {outcome.bundles_collected} bundles collected but 0 drafts parsed"
+        )
+
+    if outcome.parsed_ok and session_id is not None:
+        mark_session_extracted(conn, session_id)
+        outcome.marked = True
+
+    return outcome
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `uv run pytest tests/test_extraction_archaeology_seam.py -v`
+Expected: all tests PASS
+
+Run: `uv run pytest tests/ -k "extraction" -v`
+Expected: existing extraction tests still PASS (no regression)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/entirecontext/core/decision_extraction.py tests/test_extraction_archaeology_seam.py
+git commit -m "feat(extraction): add bundles injection seam and archaeology source type"
+```
+
+---
+
+### Task 3: `core/archaeology.py` — Orchestration Module
+
+**Files:**
+- Create: `src/entirecontext/core/archaeology.py`
+- Test: `tests/test_archaeology.py`
+
+**Interfaces:**
+- Consumes: `run_extraction(conn, session_id=None, repo_path, bundles=[bundle])` from Task 2; `archaeology_processed` table from Task 1
+- Produces: `archaeologize(conn, repo_path, ...)` — main orchestrator; `ArchaeologyResult` dataclass
+
+- [ ] **Step 1: Write unit tests for helper functions**
+
+```python
+# tests/test_archaeology.py
+"""Unit tests for core/archaeology.py helper functions."""
+
+import sqlite3
+import subprocess
+import pytest
+from unittest.mock import patch, MagicMock
+from entirecontext.core.archaeology import (
+    _extract_files_from_patch,
+    _build_signal_bundle,
+    _is_processed,
+    _mark_processed,
+    _stream_commits,
+    _get_github_token,
+    ArchaeologyResult,
+)
+
+
+class TestExtractFilesFromPatch:
+    def test_basic_diff(self):
+        patch = "diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        assert _extract_files_from_patch(patch) == ["src/foo.py"]
+
+    def test_multiple_files(self):
+        patch = (
+            "diff --git a/a.py b/a.py\n+++ b/a.py\n"
+            "diff --git a/b.py b/b.py\n+++ b/b.py\n"
+        )
+        files = _extract_files_from_patch(patch)
+        assert "a.py" in files
+        assert "b.py" in files
+
+    def test_rename(self):
+        patch = "diff --git a/old.py b/new.py\nrename from old.py\nrename to new.py\n"
+        files = _extract_files_from_patch(patch)
+        assert "new.py" in files
+
+    def test_empty_patch(self):
+        assert _extract_files_from_patch("") == []
+
+    def test_binary_file(self):
+        patch = "diff --git a/img.png b/img.png\nBinary files differ\n"
+        assert _extract_files_from_patch(patch) == ["img.png"]
+
+
+class TestBuildSignalBundle:
+    def test_basic(self):
+        bundle = _build_signal_bundle("abc123", "diff content", None)
+        assert bundle.source_type == "archaeology"
+        assert bundle.source_id == "abc123"
+        assert bundle.session_id is None
+        assert "diff content" in bundle.text_blocks
+
+    def test_with_pr_body(self):
+        bundle = _build_signal_bundle("abc123", "diff", "PR description")
+        assert "PR description" in bundle.text_blocks
+        assert "diff" in bundle.text_blocks
+
+
+class TestDedup:
+    @pytest.fixture
+    def arch_db(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE archaeology_processed "
+            "(commit_sha TEXT PRIMARY KEY, candidate_count INTEGER NOT NULL DEFAULT 0, "
+            "processed_at TEXT DEFAULT (datetime('now')))"
+        )
+        return conn
+
+    def test_not_processed(self, arch_db):
+        assert _is_processed(arch_db, "abc123") is False
+
+    def test_mark_and_check(self, arch_db):
+        _mark_processed(arch_db, "abc123", 2)
+        assert _is_processed(arch_db, "abc123") is True
+
+    def test_mark_zero_candidates(self, arch_db):
+        _mark_processed(arch_db, "abc123", 0)
+        assert _is_processed(arch_db, "abc123") is True
+
+
+class TestStreamCommits:
+    def test_stream_from_fixture(self, git_repo):
+        for i in range(3):
+            (git_repo / f"file{i}.txt").write_text(f"content {i}")
+            subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"commit {i}"],
+                cwd=git_repo,
+                check=True,
+                env={
+                    "GIT_AUTHOR_NAME": "Test",
+                    "GIT_AUTHOR_EMAIL": "test@test.com",
+                    "GIT_COMMITTER_NAME": "Test",
+                    "GIT_COMMITTER_EMAIL": "test@test.com",
+                    "PATH": subprocess.check_output(
+                        ["bash", "-c", "echo $PATH"]
+                    ).decode().strip(),
+                },
+            )
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=10))
+        assert len(commits) >= 3
+        for sha, subject, patch_text in commits:
+            assert len(sha) == 40
+            assert isinstance(subject, str)
+            assert isinstance(patch_text, str)
+
+    def test_limit(self, git_repo):
+        for i in range(5):
+            (git_repo / f"f{i}.txt").write_text(f"c{i}")
+            subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"c{i}"],
+                cwd=git_repo,
+                check=True,
+                env={
+                    "GIT_AUTHOR_NAME": "Test",
+                    "GIT_AUTHOR_EMAIL": "test@test.com",
+                    "GIT_COMMITTER_NAME": "Test",
+                    "GIT_COMMITTER_EMAIL": "test@test.com",
+                    "PATH": subprocess.check_output(
+                        ["bash", "-c", "echo $PATH"]
+                    ).decode().strip(),
+                },
+            )
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=2))
+        assert len(commits) == 2
+
+    def test_empty_range(self, git_repo):
+        commits = list(
+            _stream_commits(str(git_repo), since="HEAD", until="HEAD", limit=10)
+        )
+        assert len(commits) == 0
+
+
+class TestGetGithubToken:
+    def test_env_var_priority(self, monkeypatch):
+        monkeypatch.setenv("EC_GITHUB_TOKEN", "env-token-123")
+        assert _get_github_token() == "env-token-123"
+
+    def test_gh_cli_fallback(self, monkeypatch):
+        monkeypatch.delenv("EC_GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="gh-token-456\n"
+            )
+            assert _get_github_token() == "gh-token-456"
+
+    def test_no_token_returns_none(self, monkeypatch):
+        monkeypatch.delenv("EC_GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert _get_github_token() is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_archaeology.py -v`
+Expected: FAIL — `entirecontext.core.archaeology` module not found
+
+- [ ] **Step 3: Implement `core/archaeology.py`**
+
+```python
+# src/entirecontext/core/archaeology.py
+"""Retroactive decision extraction from git history."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Iterator
+
+from .decision_extraction import (
+    SignalBundle,
+    ExtractionWeights,
+    run_extraction,
+)
+
+
+@dataclass
+class ArchaeologyResult:
+    commits_scanned: int = 0
+    commits_processed: int = 0
+    commits_skipped: int = 0
+    candidates_generated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
+
+
+def _extract_files_from_patch(patch_text: str) -> list[str]:
+    if not patch_text:
+        return []
+    return list(dict.fromkeys(_DIFF_HEADER_RE.findall(patch_text)))
+
+
+def _build_signal_bundle(
+    commit_sha: str, patch_text: str, pr_body: str | None
+) -> SignalBundle:
+    text_blocks = []
+    if pr_body:
+        text_blocks.append(pr_body)
+    if patch_text:
+        text_blocks.append(patch_text)
+    return SignalBundle(
+        source_type="archaeology",
+        source_id=commit_sha,
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=text_blocks,
+        files=_extract_files_from_patch(patch_text),
+    )
+
+
+def _is_processed(conn: sqlite3.Connection, commit_sha: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM archaeology_processed WHERE commit_sha = ?", (commit_sha,)
+    ).fetchone()
+    return row is not None
+
+
+def _mark_processed(
+    conn: sqlite3.Connection, commit_sha: str, candidate_count: int
+) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO archaeology_processed (commit_sha, candidate_count) VALUES (?, ?)",
+        (commit_sha, candidate_count),
+    )
+
+
+def _stream_commits(
+    repo_path: str,
+    since: str | None,
+    until: str | None,
+    limit: int,
+) -> Iterator[tuple[str, str, str]]:
+    # %x1e (record separator) before each commit disambiguates patch content
+    # from the next commit's header. Split on \x1e, then split each record
+    # on \x00 with maxsplit=2 to get (sha, subject, patch).
+    cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%s%x00"]
+    if since and _looks_like_date(since):
+        cmd.append(f"--since={since}")
+    elif since:
+        rev_range = f"{since}..{until}" if until and not _looks_like_date(until) else f"{since}..HEAD"
+        cmd.append(rev_range)
+    if until and _looks_like_date(until):
+        cmd.append(f"--until={until}")
+    if limit:
+        cmd.extend(["-n", str(limit)])
+
+    result = subprocess.run(
+        cmd,
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        errors="surrogateescape",
+    )
+    if result.returncode != 0:
+        return
+
+    records = result.stdout.split("\x1e")
+    for record in records:
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x00", maxsplit=2)
+        if len(parts) < 2:
+            continue
+        sha = parts[0].strip()
+        subject = parts[1].strip()
+        patch_text = parts[2] if len(parts) > 2 else ""
+        if len(sha) == 40:
+            yield sha, subject, patch_text
+
+
+def _looks_like_date(ref: str) -> bool:
+    return bool(re.match(r"^\d{4}-\d{2}-\d{2}", ref))
+
+
+def _get_github_token() -> str | None:
+    token = os.environ.get("EC_GITHUB_TOKEN")
+    if token:
+        return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _fetch_pr_body(
+    commit_sha: str, repo_path: str, token: str
+) -> str | None:
+    remote_url = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if remote_url.returncode != 0:
+        return None
+    url = remote_url.stdout.strip()
+    match = re.search(r"[:/]([^/]+/[^/.]+?)(?:\.git)?$", url)
+    if not match:
+        return None
+    owner_repo = match.group(1)
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{owner_repo}/commits/{commit_sha}/pulls",
+                "--jq", ".[0].body // empty",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def archaeologize(
+    conn: sqlite3.Connection,
+    repo_path: str,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 100,
+    pr_bodies: bool = False,
+    dry_run: bool = False,
+    batch_size: int = 10,
+    extraction_weights: ExtractionWeights | None = None,
+    progress_callback: callable | None = None,
+) -> ArchaeologyResult:
+    result = ArchaeologyResult()
+    token = None
+    if pr_bodies:
+        token = _get_github_token()
+        if not token:
+            result.warnings.append(
+                "No GitHub token found. Set EC_GITHUB_TOKEN or install gh CLI. "
+                "Proceeding without PR bodies."
+            )
+            pr_bodies = False
+
+    commits = list(_stream_commits(repo_path, since, until, limit))
+    result.commits_scanned = len(commits)
+
+    already_processed = sum(1 for sha, _, _ in commits if _is_processed(conn, sha))
+    to_process = result.commits_scanned - already_processed
+
+    if dry_run:
+        result.commits_skipped = already_processed
+        est_tokens_low = to_process * 2500
+        est_tokens_high = to_process * 3000
+        if progress_callback:
+            progress_callback(
+                f"Found {result.commits_scanned} commits, "
+                f"{already_processed} already processed, "
+                f"{to_process} to process.\n"
+                f"Estimated token cost: ~{est_tokens_low:,}-{est_tokens_high:,} tokens"
+            )
+        return result
+
+    batch: list[tuple[str, str, str]] = []
+    for sha, subject, patch_text in commits:
+        if _is_processed(conn, sha):
+            result.commits_skipped += 1
+            continue
+        batch.append((sha, subject, patch_text))
+        if len(batch) >= batch_size:
+            _process_batch(
+                conn, repo_path, batch, result,
+                pr_bodies=pr_bodies, token=token,
+                extraction_weights=extraction_weights,
+                progress_callback=progress_callback,
+            )
+            batch = []
+
+    if batch:
+        _process_batch(
+            conn, repo_path, batch, result,
+            pr_bodies=pr_bodies, token=token,
+            extraction_weights=extraction_weights,
+            progress_callback=progress_callback,
+        )
+
+    return result
+
+
+def _process_batch(
+    conn: sqlite3.Connection,
+    repo_path: str,
+    batch: list[tuple[str, str, str]],
+    result: ArchaeologyResult,
+    *,
+    pr_bodies: bool,
+    token: str | None,
+    extraction_weights: ExtractionWeights | None,
+    progress_callback: callable | None,
+) -> None:
+    for sha, subject, patch_text in batch:
+        pr_body = None
+        if pr_bodies and token:
+            pr_body = _fetch_pr_body(sha, repo_path, token)
+
+        bundle = _build_signal_bundle(sha, patch_text, pr_body)
+        try:
+            outcome = run_extraction(
+                conn,
+                session_id=None,
+                repo_path=repo_path,
+                bundles=[bundle],
+                extraction_weights=extraction_weights,
+            )
+            _mark_processed(conn, sha, outcome.candidates_inserted)
+            result.commits_processed += 1
+            result.candidates_generated += outcome.candidates_inserted
+            if outcome.warnings:
+                result.warnings.extend(outcome.warnings)
+        except Exception as exc:
+            result.warnings.append(f"commit {sha[:12]}: {exc}")
+
+    if progress_callback:
+        progress_callback(
+            f"Processed {result.commits_processed}/{result.commits_scanned - result.commits_skipped} commits, "
+            f"{result.candidates_generated} candidates"
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/test_archaeology.py -v`
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entirecontext/core/archaeology.py tests/test_archaeology.py
+git commit -m "feat(archaeology): core orchestration module with git log streaming and dedup"
+```
+
+---
+
+### Task 4: CLI Command + Config Section
+
+**Files:**
+- Create: `src/entirecontext/cli/archaeology_cmds.py`
+- Modify: `src/entirecontext/cli/__init__.py:9-29` (add import)
+- Modify: `src/entirecontext/cli/__init__.py:31-53` (add to `_MODULES`)
+- Modify: `src/entirecontext/core/config.py:96` (add `[decisions.archaeology]` defaults)
+- Test: `tests/test_archaeology_cli.py`
+
+**Interfaces:**
+- Consumes: `archaeologize()` from Task 3; `load_config()` from `core/config.py`
+- Produces: `ec archaeologize` CLI command with `--since`, `--until`, `--limit`, `--pr-bodies`, `--dry-run`, `--batch-size`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_archaeology_cli.py
+"""CLI tests for ec archaeologize."""
+
+import subprocess
+import pytest
+
+
+def test_help_output():
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--since" in result.stdout
+    assert "--until" in result.stdout
+    assert "--limit" in result.stdout
+    assert "--dry-run" in result.stdout
+    assert "--pr-bodies" in result.stdout
+    assert "--batch-size" in result.stdout
+
+
+def test_dry_run_on_fixture(git_repo):
+    for i in range(3):
+        (git_repo / f"file{i}.py").write_text(f"x = {i}")
+        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"feat: add file{i}"],
+            cwd=git_repo,
+            check=True,
+            env={
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@test.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@test.com",
+                "PATH": subprocess.check_output(
+                    ["bash", "-c", "echo $PATH"]
+                ).decode().strip(),
+            },
+        )
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=git_repo,
+    )
+    assert result.returncode == 0
+    assert "commits" in result.stdout.lower() or "commits" in result.stderr.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_archaeology_cli.py::test_help_output -v`
+Expected: FAIL — no `archaeologize` command
+
+- [ ] **Step 3: Add config defaults**
+
+In `src/entirecontext/core/config.py`, add inside the `"decisions"` dict in `DEFAULT_CONFIG`:
+
+```python
+        "archaeology": {
+            "enabled": True,
+            "batch_size": 10,
+            "pr_body_fetch": False,
+        },
+```
+
+- [ ] **Step 4: Create CLI module**
+
+```python
+# src/entirecontext/cli/archaeology_cmds.py
+"""CLI command: ec archaeologize."""
+
+from __future__ import annotations
+
+import signal
+import sys
+from typing import Optional
+
+import typer
+
+archaeology_app = typer.Typer(help="Retroactive decision extraction from git history")
+
+
+@archaeology_app.callback(invoke_without_command=True)
+def archaeologize(
+    since: Optional[str] = typer.Option(None, help="Git ref or date (e.g., v1.0.0, 2025-01-01)"),
+    until: Optional[str] = typer.Option(None, help="Git ref or date (default: HEAD)"),
+    limit: int = typer.Option(100, help="Max commits to process"),
+    pr_bodies: bool = typer.Option(False, "--pr-bodies", help="Fetch merged PR bodies from GitHub API"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show commit count and cost estimate only"),
+    batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Override config batch_size"),
+) -> None:
+    """Extract decisions from git commit history."""
+    from entirecontext.core.config import load_config
+    from entirecontext.db import check_and_migrate, get_db
+
+    repo_path = "."
+    config = load_config(repo_path)
+    arch_config = config.get("decisions", {}).get("archaeology", {})
+
+    if not arch_config.get("enabled", True):
+        typer.echo("Archaeology is disabled in config. Set [decisions.archaeology] enabled = true.")
+        raise typer.Exit(1)
+
+    effective_batch_size = batch_size or arch_config.get("batch_size", 10)
+
+    conn = get_db(repo_path)
+    check_and_migrate(conn)
+    interrupted = False
+
+    def _handle_interrupt(signum, frame):
+        nonlocal interrupted
+        interrupted = True
+
+    original_handler = signal.signal(signal.SIGINT, _handle_interrupt)
+
+    try:
+        from entirecontext.core.archaeology import archaeologize as do_archaeologize
+
+        def _progress(msg: str) -> None:
+            typer.echo(msg)
+
+        result = do_archaeologize(
+            conn,
+            repo_path,
+            since=since,
+            until=until,
+            limit=limit,
+            pr_bodies=pr_bodies,
+            dry_run=dry_run,
+            batch_size=effective_batch_size,
+            progress_callback=_progress,
+        )
+
+        if dry_run:
+            return
+
+        typer.echo(
+            f"\nDone. Scanned {result.commits_scanned}, "
+            f"processed {result.commits_processed}, "
+            f"skipped {result.commits_skipped}, "
+            f"candidates {result.candidates_generated}."
+        )
+        if result.warnings:
+            typer.echo(f"Warnings: {len(result.warnings)}")
+            for w in result.warnings[:5]:
+                typer.echo(f"  - {w}")
+        if interrupted:
+            typer.echo("Interrupted. Re-run same command to resume.")
+
+    finally:
+        signal.signal(signal.SIGINT, original_handler)
+        conn.close()
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="archaeologize")(archaeologize)
+```
+
+- [ ] **Step 5: Register in CLI `__init__.py`**
+
+In `src/entirecontext/cli/__init__.py`, add import:
+```python
+from . import archaeology_cmds  # noqa: E402
+```
+
+Add to `_MODULES` tuple:
+```python
+    archaeology_cmds,
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `uv run pytest tests/test_archaeology_cli.py -v`
+Expected: all tests PASS
+
+Run: `uv run ec archaeologize --help`
+Expected: help output with all options listed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/entirecontext/cli/archaeology_cmds.py src/entirecontext/cli/__init__.py \
+  src/entirecontext/core/config.py tests/test_archaeology_cli.py
+git commit -m "feat(cli): ec archaeologize command with --dry-run, --pr-bodies, --limit"
+```
+
+---
+
+### Task 5: Integration Test + Documentation
+
+**Files:**
+- Create: `tests/test_archaeology_integration.py`
+- Modify: `CHANGELOG.md` (v0.13.0 entry)
+- Modify: `ROADMAP.md:296-308` (mark Git Archaeology items done)
+- Modify: `CLAUDE.md` (update schema version, CLI list, data model tables)
+
+**Interfaces:**
+- Consumes: all previous tasks (schema, extraction seam, core module, CLI)
+- Produces: E2E test proving full pipeline, updated documentation
+
+- [ ] **Step 1: Write integration test**
+
+```python
+# tests/test_archaeology_integration.py
+"""Integration test: ec archaeologize end-to-end pipeline."""
+
+import subprocess
+import sqlite3
+import pytest
+from unittest.mock import patch
+from entirecontext.core.archaeology import archaeologize, _is_processed
+from entirecontext.db.migration import bootstrap_schema
+
+
+@pytest.fixture
+def arch_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, check=True)
+
+    for i in range(5):
+        f = repo / f"mod{i}.py"
+        f.write_text(f"def func_{i}():\n    return {i}\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"feat: add module {i} with func_{i}"],
+            cwd=repo,
+            check=True,
+        )
+    return repo
+
+
+@pytest.fixture
+def arch_db(tmp_path):
+    db_path = tmp_path / "ec.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    bootstrap_schema(conn)
+    return conn
+
+
+def test_full_pipeline(arch_repo, arch_db):
+    mock_response = (
+        '[{"title": "Use function pattern for module", '
+        '"rationale": "Simple function pattern chosen over class-based", '
+        '"scope": "module design", '
+        '"rejected_alternatives": [{"alternative": "class-based", "reason": "unnecessary complexity"}]}]'
+    )
+
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        result = archaeologize(
+            arch_db,
+            str(arch_repo),
+            limit=5,
+            batch_size=2,
+        )
+
+    assert result.commits_scanned == 5
+    assert result.commits_processed == 5
+    assert result.commits_skipped == 0
+    assert result.candidates_generated >= 1
+
+    rows = arch_db.execute(
+        "SELECT source_type, session_id FROM decision_candidates"
+    ).fetchall()
+    for row in rows:
+        assert row["source_type"] == "archaeology"
+        assert row["session_id"] is None
+
+
+def test_rerun_skips_all(arch_repo, arch_db):
+    mock_response = "[]"
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        archaeologize(arch_db, str(arch_repo), limit=5)
+        result2 = archaeologize(arch_db, str(arch_repo), limit=5)
+
+    assert result2.commits_skipped == 5
+    assert result2.commits_processed == 0
+
+
+def test_dry_run_no_writes(arch_repo, arch_db):
+    result = archaeologize(arch_db, str(arch_repo), limit=5, dry_run=True)
+    assert result.commits_scanned == 5
+    assert result.commits_processed == 0
+
+    processed = arch_db.execute("SELECT COUNT(*) FROM archaeology_processed").fetchone()[0]
+    assert processed == 0
+
+    candidates = arch_db.execute("SELECT COUNT(*) FROM decision_candidates").fetchone()[0]
+    assert candidates == 0
+
+
+def test_source_type_archaeology_on_candidates(arch_repo, arch_db):
+    mock_response = (
+        '[{"title": "Test decision", "rationale": "Test", "scope": "test", '
+        '"rejected_alternatives": []}]'
+    )
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        archaeologize(arch_db, str(arch_repo), limit=1)
+
+    row = arch_db.execute(
+        "SELECT source_type FROM decision_candidates LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row["source_type"] == "archaeology"
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `uv run pytest tests/test_archaeology_integration.py -v`
+Expected: all tests PASS
+
+- [ ] **Step 3: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+
+- **`ec archaeologize` command** — retroactive decision extraction from `git log --patch`. Streams commit history through the existing extraction pipeline to produce `source:archaeology` candidates. Supports `--since`, `--until`, `--limit` (default 100), `--pr-bodies` (GitHub API), `--dry-run` (cost estimate), `--batch-size`. Implicit resume via dedup. Addresses the 91% file-link gap and cold-start adoption barrier.
+- **`archaeology_processed` table (schema v16)** — tracks processed commits for dedup across runs.
+- **`source_type='archaeology'` in `decision_candidates`** — new source type for git-history-derived candidates.
+- **`[decisions.archaeology]` config section** — `enabled`, `batch_size`, `pr_body_fetch` settings.
+- **`run_extraction` bundles injection** — optional `bundles` parameter allows external callers to bypass `collect_signals` while sharing the full extraction pipeline.
+```
+
+- [ ] **Step 4: Update ROADMAP.md**
+
+Mark the Git Archaeology item as done:
+```markdown
+- [x] **`ec archaeologize` command** — ...
+```
+
+- [ ] **Step 5: Update CLAUDE.md**
+
+Update `Schema version: 15` → `Schema version: 16`
+
+Add `archaeology_processed` to Key tables list.
+
+Add `archaeology_cmds` to CLI module list.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: all tests PASS, no regressions
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_archaeology_integration.py CHANGELOG.md ROADMAP.md CLAUDE.md
+git commit -m "feat(archaeology): integration test + documentation for v0.13.0"
+```

--- a/docs/superpowers/specs/2026-07-11-v0.13.0-git-archaeology-design.md
+++ b/docs/superpowers/specs/2026-07-11-v0.13.0-git-archaeology-design.md
@@ -1,0 +1,248 @@
+# v0.13.0 Design — Git Archaeology + Intervene Graduation
+
+_Created 2026-07-11._
+
+## Overview
+
+v0.13.0 closes the 91% file-link gap via retroactive git archaeology, pushes intervene past the 10% applied_context_rate threshold, and carries forward experiment analysis results.
+
+Three pillars:
+1. **Git Archaeology** (`ec archaeologize`) — the sole implementation workstream
+2. **Intervene Graduation** — dogfooding discipline only, no code change
+3. **Experiment Analysis** — verdict already recorded (insufficient data, deprioritized)
+
+## Scope
+
+### In
+
+- `ec archaeologize` CLI command (top-level)
+- `core/archaeology.py` orchestration module
+- Schema v16 migration: `archaeology_processed` table + `source_type` CHECK expansion
+- `_VALID_SOURCE_TYPES` expansion to include `"archaeology"`
+- `[decisions.archaeology]` config section
+- `--since`, `--until`, `--limit`, `--pr-bodies`, `--dry-run`, `--batch-size` flags
+- Streaming progress output
+- Graceful interrupt (Ctrl+C → flush partial results)
+- Implicit resume via `archaeology_processed` dedup
+- Unit + integration tests
+- CHANGELOG, ROADMAP, README cold-start section updates
+
+### Out
+
+- Auto-promotion of inferred candidates (requires human review via `ec review`)
+- Non-GitHub PR body sources (GitLab, Bitbucket)
+- Changes to `run_extraction` core logic (extraction steps unchanged; only signature and entry seam added)
+- `ec review` source filter enhancement (defer to v0.13.1)
+- `--source archaeology` filter for `ec decision candidates list` (existing `--source-type` suffices)
+
+## Architecture
+
+### Module structure
+
+```
+src/entirecontext/
+  cli/archaeology_cmds.py     # ec archaeologize command
+  core/archaeology.py          # orchestration: git log → batch → extract → track
+  db/migrations/v016.py        # archaeology_processed table + source_type expansion
+```
+
+### Core functions (`core/archaeology.py`)
+
+- `archaeologize(conn, repo_path, *, since, until, limit, pr_bodies, dry_run, batch_size, extraction_weights)` — main orchestrator
+- `_stream_commits(repo_path, since, until, limit)` — `git log --patch --reverse` subprocess, yields `(sha, subject, patch_text)` per commit
+- `_build_signal_bundle(commit_sha, patch_text, pr_body)` — constructs `SignalBundle(source_type="archaeology", ...)`
+- `_extract_files_from_patch(patch_text)` — parses `diff --git a/... b/...` headers for file paths
+- `_extract_from_commit(conn, repo_path, commit_sha, patch_text, pr_body, *, extraction_weights)` — builds `SignalBundle`, calls `run_extraction(conn, session_id=None, repo_path, bundles=[bundle])`, returns `ExtractionOutcome`
+- `_is_processed(conn, commit_sha) → bool` — dedup check against `archaeology_processed`
+- `_mark_processed(conn, commit_sha, candidate_count)` — records processed commit
+- `_fetch_pr_body(commit_sha, token) → str | None` — GitHub API call for merged PR body
+- `_get_github_token() → str` — `EC_GITHUB_TOKEN` env → `gh auth token` subprocess → error
+
+### Data flow
+
+```
+ec archaeologize --since v1.0 --limit 100
+  → _stream_commits() yields (sha, subject, patch)
+  → batch N commits (default 10)
+  → for each commit in batch:
+      if _is_processed(sha): skip
+      else:
+        if --pr-bodies: pr_body = _fetch_pr_body(sha, token)
+        result = _extract_from_commit(conn, repo_path, sha, patch, pr_body, ...)
+        _mark_processed(conn, sha, result.candidates_inserted)
+  → print batch progress: "Batch 3/10: 27/100 commits, 4 candidates"
+  → on KeyboardInterrupt: flush current batch, print resume instruction
+```
+
+### Integration with extraction pipeline
+
+`run_extraction` receives a minimal seam: optional `bundles` parameter and `session_id: str | None`. This avoids forking the extraction pipeline into a parallel path (which would drift on future changes — see LESSONS.md: "공유 helper로 policy divergence 방지").
+
+Changes to `decision_extraction.py`:
+
+1. **`SignalBundle.session_id: str → str | None`** — archaeology has no session
+2. **`CandidateDraft.session_id: str → str | None`** — flows from SignalBundle
+3. **`run_extraction` signature change**:
+   ```python
+   def run_extraction(
+       conn,
+       session_id: str | None,         # was: str
+       repo_path: str,
+       *,
+       bundles: list[SignalBundle] | None = None,  # NEW
+       min_confidence: float = 0.35,
+       extraction_weights: ExtractionWeights | None = None,
+   ) -> ExtractionOutcome:
+   ```
+4. **Inside `run_extraction`**: if `bundles` is provided, skip `collect_signals` and use injected bundles directly. All downstream steps (assemble_prompt → redact → LLM → parse → dedup → persist) remain unchanged.
+5. **Session marking**: skip `_mark_session_extracted` when `session_id is None`.
+
+`core/archaeology.py` calls `run_extraction(conn, session_id=None, repo_path, bundles=[bundle])` per commit, keeping the extraction logic in one place.
+
+Key: `decision_candidates.session_id` is FK with `ON DELETE SET NULL`, so `NULL` is valid. Existing consumers (`list_candidates`, `confirm_candidate`) already handle `session_id` as optional filter.
+
+## Schema v16
+
+### New table: `archaeology_processed`
+
+```sql
+CREATE TABLE IF NOT EXISTS archaeology_processed (
+    commit_sha TEXT PRIMARY KEY,
+    candidate_count INTEGER NOT NULL DEFAULT 0,
+    processed_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+### Modified constraint: `decision_candidates.source_type`
+
+```sql
+-- v15: CHECK(source_type IN ('session','checkpoint','assessment'))
+-- v16: CHECK(source_type IN ('session','checkpoint','assessment','archaeology'))
+```
+
+Requires table rebuild (SQLite CHECK constraints cannot be altered in-place). The rebuild MUST:
+1. Drop FTS triggers (`fts_decision_candidates_ai`, `fts_decision_candidates_ad`, `fts_decision_candidates_au`)
+2. Drop `fts_decision_candidates` virtual table
+3. Rename → create new → copy → drop old → rename (standard SQLite rebuild)
+4. Recreate `fts_decision_candidates` virtual table
+5. Repopulate FTS from rebuilt table
+6. Recreate all 3 FTS triggers
+7. Recreate all indexes on `decision_candidates`
+
+### `_VALID_SOURCE_TYPES` expansion
+
+```python
+# decision_extraction.py line 57
+_VALID_SOURCE_TYPES = frozenset({"session", "checkpoint", "assessment", "archaeology"})
+```
+
+## Config
+
+Added to `DEFAULT_CONFIG` under `[decisions]`:
+
+```toml
+[decisions.archaeology]
+enabled = true
+batch_size = 10
+pr_body_fetch = false
+```
+
+`github_token` is NOT stored in config — sourced from `EC_GITHUB_TOKEN` env or `gh auth token` subprocess to prevent secret leakage.
+
+## CLI Interface
+
+```
+ec archaeologize [OPTIONS]
+
+Options:
+  --since TEXT       Git ref or date (e.g., v1.0.0, 2025-01-01)
+  --until TEXT       Git ref or date (default: HEAD)
+  --limit INT        Max commits to process (default: 100)
+  --pr-bodies        Fetch merged PR bodies from GitHub API
+  --dry-run          Show commit count and estimated cost, no DB writes
+  --batch-size INT   Override config batch_size
+```
+
+Registered as a top-level command in `cli/archaeology_cmds.py` with `register(app)`.
+
+## Deduplication Contract
+
+| Case | Behavior |
+|---|---|
+| `commit_sha` in `archaeology_processed` | Skip (previously processed) |
+| `commit_sha` not in `archaeology_processed` | Extract → record in `archaeology_processed` regardless of candidate count |
+| Re-run on same `--since..--until` range | All SHAs already tracked → entire range skipped |
+
+Resume is implicit — no state file or explicit resume flag needed.
+
+## `--pr-bodies` behavior
+
+- Always requires explicit `--pr-bodies` flag — never auto-fetches even when token is available
+- Token resolution: `EC_GITHUB_TOKEN` env → `gh auth token` subprocess → error with instructions
+- GitHub API: `GET /repos/{owner}/{repo}/commits/{sha}/pulls` → first merged PR → body text
+- Rate limit: respect `X-RateLimit-Remaining`; on exhaustion, warn and continue without PR bodies for remaining commits
+
+## `--dry-run` output
+
+```
+Scanning git log (--since v1.0.0 --until HEAD)...
+Found 247 commits, 12 already processed, 235 to process.
+Estimated token cost: ~590K-705K tokens (~$0.09-$0.42 at gpt-4o-mini rates)
+Run without --dry-run to start extraction.
+```
+
+## Graceful Interrupt
+
+- `KeyboardInterrupt` caught at batch boundary
+- Current batch results committed to DB (both `decision_candidates` and `archaeology_processed`)
+- Prints: `"Interrupted. Processed N/M commits, K candidates generated. Re-run same command to resume."`
+- Mid-LLM-call interrupts: partial extraction lost for that single commit (acceptable — re-run will re-process it since `_mark_processed` hasn't been called)
+
+## Testing
+
+### Unit tests (`tests/test_archaeology.py`)
+
+- `_stream_commits` — fixture repo, commit range parsing, empty range
+- `_is_processed` / `_mark_processed` — dedup logic
+- `_extract_files_from_patch` — patch header parsing (add, delete, rename, binary)
+- `_build_signal_bundle` — source_type="archaeology", files populated from patch
+- `--dry-run` — zero DB writes assertion
+- `_get_github_token` — env var priority, `gh` fallback, missing token error
+
+### Integration test (`tests/test_archaeology_integration.py`)
+
+- Fixture repo with 20 commits → `archaeologize()` → candidate count > 0
+- Re-run same range → all skipped (dedup)
+- `source_type="archaeology"` on all generated candidates
+- `session_id=None` on all generated candidates
+- Schema v15→v16 migration + rollback
+
+### Schema migration test
+
+- v15→v16 upgrade: `archaeology_processed` table created, `decision_candidates` CHECK expanded, FTS triggers recreated
+- Rollback: migration framework is forward-only (no `downgrade` functions in v013-v015). No rollback test — document manual rollback SQL in migration docstring instead.
+
+## Intervene Graduation (non-code)
+
+No code changes. Success criteria:
+- `applied_context_rate ≥ 10%` — current 8% (5/66 session-based). Requires 2+ sessions with `ec context apply`.
+- `lesson_reuse_rate` upward trend — current 2% (1/40). Record lesson-typed applications.
+
+Tracked via dogfooding checklist in CLAUDE.local.md.
+
+## Experiment Analysis (carry-forward, completed)
+
+Verdict recorded in ROADMAP: insufficient data for hypothesis testing. Experiment remains active but deprioritized. No code change.
+
+## Risks
+
+1. **Token cost on large repos** — mitigated by `--limit 100` default and `--dry-run` cost estimate
+2. **Low signal-to-noise in commit patches** — dependency bumps, formatting, tests produce low-confidence candidates. Existing confidence threshold (0.35) + human review gate prevent noise promotion.
+3. **GitHub API rate limits** — `--pr-bodies` includes rate-limit awareness; continues without PR bodies on exhaustion
+4. **`decision_candidates` rebuild risk** — v016 migration rebuilds the table. Must preserve all existing rows and indexes. Tested in migration test.
+5. **`session_id=NULL` candidates** — verified: `list_candidates` uses `session_id` as optional WHERE filter (skipped when None). `confirm_candidate` reads from `decision_candidates` by `id` only. `persist_candidate` passes `draft.session_id` directly to INSERT (NULL is valid FK). No JOIN-based consumers found that assume non-null. The `_mark_session_extracted` call in `run_extraction` is guarded by `session_id is not None` check.
+
+## Open Decisions
+
+1. `--pr-bodies` requires explicit flag (decided: yes)
+2. `ec review` queue display of archaeology candidates (deferred to v0.13.1 — existing `source_type` column suffices for filtering)

--- a/src/entirecontext/cli/__init__.py
+++ b/src/entirecontext/cli/__init__.py
@@ -6,6 +6,7 @@ import typer
 
 app = typer.Typer(name="ec", help="EntireContext — searchable agent memory anchored to git")
 
+from . import archaeology_cmds  # noqa: E402
 from . import ast_cmds  # noqa: E402
 from . import blame_cmds  # noqa: E402
 from . import checkpoint_cmds  # noqa: E402
@@ -29,6 +30,7 @@ from . import sync_cmds  # noqa: E402
 from . import compact_cmds  # noqa: E402
 
 _MODULES = (
+    archaeology_cmds,
     project_cmds,
     search_cmds,
     session_cmds,

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -43,11 +43,22 @@ def archaeologize(
         raise typer.Exit(1)
 
     effective_batch_size = batch_size or arch_config.get("batch_size", 10)
+    decisions_config = config.get("decisions", {})
+    min_confidence = float(decisions_config.get("candidate_min_confidence", arch_config.get("min_confidence", 0.35)))
 
     if dry_run:
-        from ..db import get_memory_db
+        from pathlib import Path
 
-        conn = get_memory_db()
+        db_path = Path(repo_path) / ".entirecontext" / "db" / "local.db"
+        if db_path.exists():
+            import sqlite3
+
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+        else:
+            from ..db import get_memory_db
+
+            conn = get_memory_db()
     else:
         conn = get_db(repo_path)
     try:
@@ -66,6 +77,7 @@ def archaeologize(
             pr_bodies=pr_bodies,
             dry_run=dry_run,
             batch_size=effective_batch_size,
+            min_confidence=min_confidence,
             progress_callback=_progress,
         )
     finally:

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -38,11 +38,16 @@ def archaeologize(
         )
         raise typer.Exit(1)
 
+    if limit <= 0:
+        console.print("[red]--limit must be a positive integer.[/red]")
+        raise typer.Exit(1)
+
     effective_batch_size = batch_size or arch_config.get("batch_size", 10)
 
     conn = get_db(repo_path)
     try:
-        check_and_migrate(conn)
+        if not dry_run:
+            check_and_migrate(conn)
 
         def _progress(msg: str) -> None:
             console.print(msg)

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -1,0 +1,80 @@
+"""CLI command: ec archaeologize."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def archaeologize(
+    since: Optional[str] = typer.Option(None, "--since", help="Git ref or date (e.g., v1.0.0, 2025-01-01)"),
+    until: Optional[str] = typer.Option(None, "--until", help="Git ref or date (default: HEAD)"),
+    limit: int = typer.Option(100, "--limit", help="Max commits to process"),
+    pr_bodies: bool = typer.Option(False, "--pr-bodies", help="Fetch merged PR bodies from GitHub API"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show commit count and cost estimate only"),
+    batch_size: Optional[int] = typer.Option(None, "--batch-size", help="Override config batch_size"),
+) -> None:
+    """Extract decisions from git commit history."""
+    from ..core.archaeology import archaeologize as do_archaeologize
+    from ..core.config import load_config
+    from ..core.project import find_git_root
+    from ..db import check_and_migrate, get_db
+
+    repo_path = find_git_root()
+    if not repo_path:
+        console.print("[red]Not in a git repository.[/red]")
+        raise typer.Exit(1)
+
+    config = load_config(repo_path)
+    arch_config = config.get("decisions", {}).get("archaeology", {})
+
+    if not arch_config.get("enabled", True):
+        console.print(
+            "[yellow]Archaeology is disabled in config. Set [decisions.archaeology] enabled = true.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    effective_batch_size = batch_size or arch_config.get("batch_size", 10)
+
+    conn = get_db(repo_path)
+    try:
+        check_and_migrate(conn)
+
+        def _progress(msg: str) -> None:
+            console.print(msg)
+
+        result = do_archaeologize(
+            conn,
+            repo_path,
+            since=since,
+            until=until,
+            limit=limit,
+            pr_bodies=pr_bodies,
+            dry_run=dry_run,
+            batch_size=effective_batch_size,
+            progress_callback=_progress,
+        )
+    finally:
+        conn.close()
+
+    if dry_run:
+        return
+
+    console.print(
+        f"\n[bold]Done.[/bold] Scanned {result.commits_scanned}, "
+        f"processed {result.commits_processed}, "
+        f"skipped {result.commits_skipped}, "
+        f"candidates {result.candidates_generated}."
+    )
+    if result.warnings:
+        console.print(f"[yellow]Warnings: {len(result.warnings)}[/yellow]")
+        for w in result.warnings[:5]:
+            console.print(f"  - {w}")
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="archaeologize")(archaeologize)

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -44,7 +44,12 @@ def archaeologize(
 
     effective_batch_size = batch_size or arch_config.get("batch_size", 10)
 
-    conn = get_db(repo_path)
+    if dry_run:
+        from ..db import get_memory_db
+
+        conn = get_memory_db()
+    else:
+        conn = get_db(repo_path)
     try:
         if not dry_run:
             check_and_migrate(conn)

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -66,6 +66,11 @@ def archaeologize(
     finally:
         conn.close()
 
+    if result.warnings:
+        console.print(f"[yellow]Warnings: {len(result.warnings)}[/yellow]")
+        for w in result.warnings[:5]:
+            console.print(f"  - {w}")
+
     if dry_run:
         return
 
@@ -75,10 +80,6 @@ def archaeologize(
         f"skipped {result.commits_skipped}, "
         f"candidates {result.candidates_generated}."
     )
-    if result.warnings:
-        console.print(f"[yellow]Warnings: {len(result.warnings)}[/yellow]")
-        for w in result.warnings[:5]:
-            console.print(f"  - {w}")
 
 
 def register(app: typer.Typer) -> None:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -1,0 +1,290 @@
+"""Retroactive decision extraction from git history."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Callable, Iterator
+
+from .decision_extraction import (
+    SignalBundle,
+    ExtractionWeights,
+    run_extraction,
+)
+
+
+@dataclass
+class ArchaeologyResult:
+    commits_scanned: int = 0
+    commits_processed: int = 0
+    commits_skipped: int = 0
+    candidates_generated: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
+
+
+def _extract_files_from_patch(patch_text: str) -> list[str]:
+    if not patch_text:
+        return []
+    return list(dict.fromkeys(_DIFF_HEADER_RE.findall(patch_text)))
+
+
+def _build_signal_bundle(commit_sha: str, patch_text: str, pr_body: str | None) -> SignalBundle:
+    text_blocks = []
+    if pr_body:
+        text_blocks.append(pr_body)
+    if patch_text:
+        text_blocks.append(patch_text)
+    return SignalBundle(
+        source_type="archaeology",
+        source_id=commit_sha,
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=text_blocks,
+        files=_extract_files_from_patch(patch_text),
+    )
+
+
+def _is_processed(conn: sqlite3.Connection, commit_sha: str) -> bool:
+    row = conn.execute("SELECT 1 FROM archaeology_processed WHERE commit_sha = ?", (commit_sha,)).fetchone()
+    return row is not None
+
+
+def _mark_processed(conn: sqlite3.Connection, commit_sha: str, candidate_count: int) -> None:
+    conn.execute(
+        "INSERT OR IGNORE INTO archaeology_processed (commit_sha, candidate_count) VALUES (?, ?)",
+        (commit_sha, candidate_count),
+    )
+
+
+def _looks_like_date(ref: str) -> bool:
+    return bool(re.match(r"^\d{4}-\d{2}-\d{2}", ref))
+
+
+def _stream_commits(
+    repo_path: str,
+    since: str | None,
+    until: str | None,
+    limit: int,
+) -> Iterator[tuple[str, str, str]]:
+    # %x1e (record separator) before each commit disambiguates patch content
+    # from the next commit's header. Split on \x1e, then split each record
+    # on \x00 with maxsplit=2 to get (sha, subject, patch).
+    cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%s%x00"]
+    if since and _looks_like_date(since):
+        cmd.append(f"--since={since}")
+    elif since:
+        rev_range = f"{since}..{until}" if until and not _looks_like_date(until) else f"{since}..HEAD"
+        cmd.append(rev_range)
+    if until and _looks_like_date(until):
+        cmd.append(f"--until={until}")
+    if limit:
+        cmd.extend(["-n", str(limit)])
+
+    result = subprocess.run(
+        cmd,
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        errors="surrogateescape",
+    )
+    if result.returncode != 0:
+        return
+
+    records = result.stdout.split("\x1e")
+    for record in records:
+        record = record.strip()
+        if not record:
+            continue
+        parts = record.split("\x00", maxsplit=2)
+        if len(parts) < 2:
+            continue
+        sha = parts[0].strip()
+        subject = parts[1].strip()
+        patch_text = parts[2] if len(parts) > 2 else ""
+        if len(sha) == 40:
+            yield sha, subject, patch_text
+
+
+def _get_github_token() -> str | None:
+    token = os.environ.get("EC_GITHUB_TOKEN")
+    if token:
+        return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
+    remote_url = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if remote_url.returncode != 0:
+        return None
+    url = remote_url.stdout.strip()
+    match = re.search(r"[:/]([^/]+/[^/.]+?)(?:\.git)?$", url)
+    if not match:
+        return None
+    owner_repo = match.group(1)
+
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner_repo}/commits/{commit_sha}/pulls",
+                "--jq",
+                ".[0].body // empty",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def archaeologize(
+    conn: sqlite3.Connection,
+    repo_path: str,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 100,
+    pr_bodies: bool = False,
+    dry_run: bool = False,
+    batch_size: int = 10,
+    extraction_weights: ExtractionWeights | None = None,
+    progress_callback: Callable[[str], None] | None = None,
+) -> ArchaeologyResult:
+    result = ArchaeologyResult()
+    token = None
+    if pr_bodies:
+        token = _get_github_token()
+        if not token:
+            result.warnings.append(
+                "No GitHub token found. Set EC_GITHUB_TOKEN or install gh CLI. Proceeding without PR bodies."
+            )
+            pr_bodies = False
+
+    commits = list(_stream_commits(repo_path, since, until, limit))
+    result.commits_scanned = len(commits)
+
+    already_processed = sum(1 for sha, _, _ in commits if _is_processed(conn, sha))
+    to_process = result.commits_scanned - already_processed
+
+    if dry_run:
+        result.commits_skipped = already_processed
+        est_tokens_low = to_process * 2500
+        est_tokens_high = to_process * 3000
+        if progress_callback:
+            progress_callback(
+                f"Found {result.commits_scanned} commits, "
+                f"{already_processed} already processed, "
+                f"{to_process} to process.\n"
+                f"Estimated token cost: ~{est_tokens_low:,}-{est_tokens_high:,} tokens"
+            )
+        return result
+
+    batch: list[tuple[str, str, str]] = []
+    try:
+        for sha, subject, patch_text in commits:
+            if _is_processed(conn, sha):
+                result.commits_skipped += 1
+                continue
+            batch.append((sha, subject, patch_text))
+            if len(batch) >= batch_size:
+                _process_batch(
+                    conn,
+                    repo_path,
+                    batch,
+                    result,
+                    pr_bodies=pr_bodies,
+                    token=token,
+                    extraction_weights=extraction_weights,
+                    progress_callback=progress_callback,
+                )
+                batch = []
+
+        if batch:
+            _process_batch(
+                conn,
+                repo_path,
+                batch,
+                result,
+                pr_bodies=pr_bodies,
+                token=token,
+                extraction_weights=extraction_weights,
+                progress_callback=progress_callback,
+            )
+    except KeyboardInterrupt:
+        # Commits already marked processed (via _mark_processed, autocommit)
+        # are durable. Do NOT re-run _process_batch here — the interrupt may
+        # have landed mid-batch, and re-processing would duplicate work
+        # already committed. A re-run of archaeologize resumes via dedup.
+        result.warnings.append(
+            f"Interrupted by user after {result.commits_processed} commits. Progress saved — re-run to resume."
+        )
+
+    return result
+
+
+def _process_batch(
+    conn: sqlite3.Connection,
+    repo_path: str,
+    batch: list[tuple[str, str, str]],
+    result: ArchaeologyResult,
+    *,
+    pr_bodies: bool,
+    token: str | None,
+    extraction_weights: ExtractionWeights | None,
+    progress_callback: Callable[[str], None] | None,
+) -> None:
+    for sha, subject, patch_text in batch:
+        pr_body = None
+        if pr_bodies and token:
+            pr_body = _fetch_pr_body(sha, repo_path, token)
+
+        bundle = _build_signal_bundle(sha, patch_text, pr_body)
+        try:
+            outcome = run_extraction(
+                conn,
+                session_id=None,
+                repo_path=repo_path,
+                bundles=[bundle],
+                extraction_weights=extraction_weights,
+            )
+            _mark_processed(conn, sha, outcome.candidates_inserted)
+            result.commits_processed += 1
+            result.candidates_generated += outcome.candidates_inserted
+            if outcome.warnings:
+                result.warnings.extend(outcome.warnings)
+        except Exception as exc:
+            result.warnings.append(f"commit {sha[:12]}: {exc}")
+
+    if progress_callback:
+        progress_callback(
+            f"Processed {result.commits_processed}/{result.commits_scanned - result.commits_skipped} commits, "
+            f"{result.candidates_generated} candidates"
+        )

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -34,8 +34,12 @@ def _extract_files_from_patch(patch_text: str) -> list[str]:
     return list(dict.fromkeys(_DIFF_HEADER_RE.findall(patch_text)))
 
 
-def _build_signal_bundle(commit_sha: str, patch_text: str, pr_body: str | None) -> SignalBundle:
+def _build_signal_bundle(
+    commit_sha: str, message: str, patch_text: str, pr_body: str | None
+) -> SignalBundle:
     text_blocks = []
+    if message:
+        text_blocks.append(message)
     if pr_body:
         text_blocks.append(pr_body)
     if patch_text:
@@ -73,10 +77,19 @@ def _stream_commits(
     until: str | None,
     limit: int,
 ) -> Iterator[tuple[str, str, str]]:
+    """Yield (sha, message, patch_text) for commits in the given range.
+
+    Note: `git log -n limit --reverse` selects the *most recent* `limit`
+    commits and then reverses their order for output — it does not walk
+    from the oldest commit forward. Re-running with the same `limit` can
+    never advance into older history; callers must increase `limit` (or
+    narrow `since`/`until`) to reach commits beyond the most recent window.
+    """
     # %x1e (record separator) before each commit disambiguates patch content
     # from the next commit's header. Split on \x1e, then split each record
-    # on \x00 with maxsplit=2 to get (sha, subject, patch).
-    cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%s%x00"]
+    # on \x00 with maxsplit=2 to get (sha, message, patch). %B (not %s) is
+    # used so the full commit body reaches the bundle, not just the subject.
+    cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%B%x00"]
     if since and _looks_like_date(since):
         cmd.append(f"--since={since}")
     elif since:
@@ -106,10 +119,10 @@ def _stream_commits(
         if len(parts) < 2:
             continue
         sha = parts[0].strip()
-        subject = parts[1].strip()
+        message = parts[1].strip()
         patch_text = parts[2] if len(parts) > 2 else ""
         if len(sha) == 40:
-            yield sha, subject, patch_text
+            yield sha, message, patch_text
 
 
 def _get_github_token() -> str | None:
@@ -145,6 +158,7 @@ def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
         return None
     owner_repo = match.group(1)
 
+    env = {**os.environ, "GH_TOKEN": token} if token else None
     try:
         result = subprocess.run(
             [
@@ -157,6 +171,7 @@ def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
             capture_output=True,
             text=True,
             timeout=10,
+            env=env,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
@@ -199,21 +214,31 @@ def archaeologize(
         est_tokens_low = to_process * 2500
         est_tokens_high = to_process * 3000
         if progress_callback:
-            progress_callback(
+            msg = (
                 f"Found {result.commits_scanned} commits, "
                 f"{already_processed} already processed, "
                 f"{to_process} to process.\n"
                 f"Estimated token cost: ~{est_tokens_low:,}-{est_tokens_high:,} tokens"
             )
+            # `git log -n limit --reverse` selects the most recent `limit`
+            # commits, not the oldest `limit` — re-runs at the same limit
+            # can never reach older history. Surface this when the scan
+            # looks capped by the limit rather than by actual history size.
+            if limit and result.commits_scanned >= limit:
+                msg += (
+                    f"\nNote: --limit {limit} may be capping results to the most "
+                    "recent commits; increase --limit to reach older history."
+                )
+            progress_callback(msg)
         return result
 
     batch: list[tuple[str, str, str]] = []
     try:
-        for sha, subject, patch_text in commits:
+        for sha, message, patch_text in commits:
             if _is_processed(conn, sha):
                 result.commits_skipped += 1
                 continue
-            batch.append((sha, subject, patch_text))
+            batch.append((sha, message, patch_text))
             if len(batch) >= batch_size:
                 _process_batch(
                     conn,
@@ -261,12 +286,12 @@ def _process_batch(
     extraction_weights: ExtractionWeights | None,
     progress_callback: Callable[[str], None] | None,
 ) -> None:
-    for sha, subject, patch_text in batch:
+    for sha, message, patch_text in batch:
         pr_body = None
         if pr_bodies and token:
             pr_body = _fetch_pr_body(sha, repo_path, token)
 
-        bundle = _build_signal_bundle(sha, patch_text, pr_body)
+        bundle = _build_signal_bundle(sha, message, patch_text, pr_body)
         try:
             outcome = run_extraction(
                 conn,

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -91,7 +91,7 @@ def _mark_processed(conn: sqlite3.Connection, commit_sha: str, candidate_count: 
 
 
 def _looks_like_date(ref: str) -> bool:
-    return bool(re.match(r"^\d{4}-\d{2}-\d{2}", ref))
+    return bool(re.match(r"^\d{4}-\d{2}-\d{2}$", ref))
 
 
 def _stream_commits(
@@ -160,7 +160,7 @@ def _stream_commits(
         sha = parts[0].strip()
         message = parts[1].strip()
         patch_text = parts[2] if len(parts) > 2 else ""
-        if len(sha) == 40:
+        if len(sha) in (40, 64):
             yield sha, message, patch_text
 
 
@@ -321,6 +321,9 @@ def archaeologize(
     return result
 
 
+_PR_BODY_FAIL_THRESHOLD = 3
+
+
 def _process_batch(
     conn: sqlite3.Connection,
     repo_path: str,
@@ -332,12 +335,19 @@ def _process_batch(
     extraction_weights: ExtractionWeights | None,
     progress_callback: Callable[[str], None] | None,
 ) -> None:
+    consecutive_pr_failures = 0
     for sha, message, patch_text in batch:
         pr_body = None
-        if pr_bodies and token:
+        if pr_bodies and token and consecutive_pr_failures < _PR_BODY_FAIL_THRESHOLD:
             pr_body = _fetch_pr_body(sha, repo_path, token)
             if pr_body is None:
-                result.warnings.append(f"commit {sha[:12]}: PR body fetch returned empty (rate limit, permissions, or no associated PR)")
+                consecutive_pr_failures += 1
+                if consecutive_pr_failures >= _PR_BODY_FAIL_THRESHOLD:
+                    result.warnings.append(
+                        f"PR body fetch failed {_PR_BODY_FAIL_THRESHOLD} times consecutively — disabling for remaining commits"
+                    )
+            else:
+                consecutive_pr_failures = 0
 
         bundle = _build_signal_bundle(sha, message, patch_text, pr_body)
         try:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -25,7 +25,7 @@ class ArchaeologyResult:
     warnings: list[str] = field(default_factory=list)
 
 
-_DIFF_HEADER_RE = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
+_DIFF_HEADER_RE = re.compile(r'^diff --git "?a/.+ "?b/(.+?)"?$', re.MULTILINE)
 
 
 def _extract_files_from_patch(patch_text: str) -> list[str]:
@@ -76,6 +76,7 @@ def _stream_commits(
     since: str | None,
     until: str | None,
     limit: int,
+    warnings: list[str] | None = None,
 ) -> Iterator[tuple[str, str, str]]:
     """Yield (sha, message, patch_text) for commits in the given range.
 
@@ -90,14 +91,25 @@ def _stream_commits(
     # on \x00 with maxsplit=2 to get (sha, message, patch). %B (not %s) is
     # used so the full commit body reaches the bundle, not just the subject.
     cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%B%x00"]
-    if since and _looks_like_date(since):
+
+    since_is_date = bool(since) and _looks_like_date(since)
+    until_is_date = bool(until) and _looks_like_date(until)
+    since_is_ref = bool(since) and not since_is_date
+    until_is_ref = bool(until) and not until_is_date
+
+    if since_is_ref and until_is_ref:
+        cmd.append(f"{since}..{until}")
+    elif since_is_ref:
+        cmd.append(f"{since}..HEAD")
+    elif until_is_ref:
+        cmd.append(until)
+
+    if since_is_date:
         cmd.append(f"--since={since}")
-    elif since:
-        rev_range = f"{since}..{until}" if until and not _looks_like_date(until) else f"{since}..HEAD"
-        cmd.append(rev_range)
-    if until and _looks_like_date(until):
+    if until_is_date:
         cmd.append(f"--until={until}")
-    if limit:
+
+    if limit is not None and limit > 0:
         cmd.extend(["-n", str(limit)])
 
     result = subprocess.run(
@@ -108,6 +120,9 @@ def _stream_commits(
         errors="surrogateescape",
     )
     if result.returncode != 0:
+        msg = f"git log failed (exit {result.returncode}): {result.stderr.strip()}"
+        if warnings is not None:
+            warnings.append(msg)
         return
 
     records = result.stdout.split("\x1e")
@@ -153,7 +168,9 @@ def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
     if remote_url.returncode != 0:
         return None
     url = remote_url.stdout.strip()
-    match = re.search(r"[:/]([^/]+/[^/.]+?)(?:\.git)?$", url)
+    if "github.com" not in url:
+        return None
+    match = re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
     if not match:
         return None
     owner_repo = match.group(1)
@@ -203,10 +220,15 @@ def archaeologize(
             )
             pr_bodies = False
 
-    commits = list(_stream_commits(repo_path, since, until, limit))
+    commits = list(_stream_commits(repo_path, since, until, limit, warnings=result.warnings))
     result.commits_scanned = len(commits)
 
-    already_processed = sum(1 for sha, _, _ in commits if _is_processed(conn, sha))
+    try:
+        already_processed = sum(1 for sha, _, _ in commits if _is_processed(conn, sha))
+    except sqlite3.OperationalError:
+        # archaeology_processed table doesn't exist yet (e.g. dry-run before
+        # migration has ever run) — nothing has been processed.
+        already_processed = 0
     to_process = result.commits_scanned - already_processed
 
     if dry_run:
@@ -300,9 +322,12 @@ def _process_batch(
                 bundles=[bundle],
                 extraction_weights=extraction_weights,
             )
-            _mark_processed(conn, sha, outcome.candidates_inserted)
-            result.commits_processed += 1
-            result.candidates_generated += outcome.candidates_inserted
+            if outcome.parsed_ok or outcome.candidates_inserted > 0:
+                _mark_processed(conn, sha, outcome.candidates_inserted)
+                result.commits_processed += 1
+                result.candidates_generated += outcome.candidates_inserted
+            else:
+                result.warnings.append(f"commit {sha[:12]}: extraction did not parse; will retry next run")
             if outcome.warnings:
                 result.warnings.extend(outcome.warnings)
         except Exception as exc:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -26,12 +26,35 @@ class ArchaeologyResult:
 
 
 _DIFF_HEADER_RE = re.compile(r'^diff --git "?a/.+ "?b/(.+?)"?$', re.MULTILINE)
+_GIT_OCTAL_RE = re.compile(r"\\([0-7]{3})")
+
+
+def _decode_git_quoted_path(path: str) -> str:
+    if "\\" not in path:
+        return path
+    decoded = _GIT_OCTAL_RE.sub(lambda m: chr(int(m.group(1), 8)), path)
+    try:
+        return decoded.encode("latin-1").decode("utf-8")
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return decoded
+
+
+def _is_github_remote(url: str) -> bool:
+    if url.startswith("git@"):
+        host = url.split("@", 1)[1].split(":", 1)[0]
+        return host == "github.com"
+    for prefix in ("https://", "http://", "ssh://"):
+        if url.startswith(prefix):
+            host = url[len(prefix):].split("/", 1)[0].split("@")[-1].split(":")[0]
+            return host == "github.com"
+    return False
 
 
 def _extract_files_from_patch(patch_text: str) -> list[str]:
     if not patch_text:
         return []
-    return list(dict.fromkeys(_DIFF_HEADER_RE.findall(patch_text)))
+    raw = _DIFF_HEADER_RE.findall(patch_text)
+    return list(dict.fromkeys(_decode_git_quoted_path(p) for p in raw))
 
 
 def _build_signal_bundle(
@@ -169,7 +192,7 @@ def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
     if remote_url.returncode != 0:
         return None
     url = remote_url.stdout.strip()
-    if "github.com" not in url:
+    if not _is_github_remote(url):
         return None
     match = re.search(r"[:/]([^/]+/[^/]+?)(?:\.git)?$", url)
     if not match:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -284,6 +284,7 @@ def archaeologize(
         return result
 
     batch: list[tuple[str, str, str]] = []
+    pr_fail_count = 0
     try:
         for sha, message, patch_text in commits:
             if _is_processed(conn, sha):
@@ -291,7 +292,7 @@ def archaeologize(
                 continue
             batch.append((sha, message, patch_text))
             if len(batch) >= batch_size:
-                _process_batch(
+                pr_fail_count = _process_batch(
                     conn,
                     repo_path,
                     batch,
@@ -301,6 +302,7 @@ def archaeologize(
                     min_confidence=min_confidence,
                     extraction_weights=extraction_weights,
                     progress_callback=progress_callback,
+                    consecutive_pr_failures=pr_fail_count,
                 )
                 batch = []
 
@@ -315,6 +317,7 @@ def archaeologize(
                 min_confidence=min_confidence,
                 extraction_weights=extraction_weights,
                 progress_callback=progress_callback,
+                consecutive_pr_failures=pr_fail_count,
             )
     except KeyboardInterrupt:
         # Commits already marked processed (via _mark_processed, autocommit)
@@ -342,8 +345,9 @@ def _process_batch(
     min_confidence: float,
     extraction_weights: ExtractionWeights | None,
     progress_callback: Callable[[str], None] | None,
-) -> None:
-    consecutive_pr_failures = 0
+    consecutive_pr_failures: int = 0,
+) -> int:
+    """Returns updated consecutive_pr_failures count."""
     for sha, message, patch_text in batch:
         pr_body = None
         if pr_bodies and token and consecutive_pr_failures < _PR_BODY_FAIL_THRESHOLD:
@@ -384,3 +388,4 @@ def _process_batch(
             f"Processed {result.commits_processed}/{result.commits_scanned - result.commits_skipped} commits, "
             f"{result.candidates_generated} candidates"
         )
+    return consecutive_pr_failures

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -312,6 +312,8 @@ def _process_batch(
         pr_body = None
         if pr_bodies and token:
             pr_body = _fetch_pr_body(sha, repo_path, token)
+            if pr_body is None:
+                result.warnings.append(f"commit {sha[:12]}: PR body fetch returned empty (rate limit, permissions, or no associated PR)")
 
         bundle = _build_signal_bundle(sha, message, patch_text, pr_body)
         try:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -92,16 +92,17 @@ def _stream_commits(
     # used so the full commit body reaches the bundle, not just the subject.
     cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%B%x00"]
 
-    since_is_date = bool(since) and _looks_like_date(since)
-    until_is_date = bool(until) and _looks_like_date(until)
-    since_is_ref = bool(since) and not since_is_date
-    until_is_ref = bool(until) and not until_is_date
+    since_is_date = since is not None and _looks_like_date(since)
+    until_is_date = until is not None and _looks_like_date(until)
+    since_is_ref = since is not None and not since_is_date
+    until_is_ref = until is not None and not until_is_date
 
     if since_is_ref and until_is_ref:
         cmd.append(f"{since}..{until}")
     elif since_is_ref:
         cmd.append(f"{since}..HEAD")
     elif until_is_ref:
+        assert until is not None  # narrowing for mypy
         cmd.append(until)
 
     if since_is_date:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -113,7 +113,11 @@ def _stream_commits(
     # from the next commit's header. Split on \x1e, then split each record
     # on \x00 with maxsplit=2 to get (sha, message, patch). %B (not %s) is
     # used so the full commit body reaches the bundle, not just the subject.
-    cmd = ["git", "log", "--patch", "--reverse", "--format=%x1e%H%x00%B%x00"]
+    cmd = [
+        "git", "log", "--patch", "--reverse",
+        "--no-color", "--src-prefix=a/", "--dst-prefix=b/",
+        "--format=%x1e%H%x00%B%x00",
+    ]
 
     since_is_date = since is not None and _looks_like_date(since)
     until_is_date = until is not None and _looks_like_date(until)
@@ -214,11 +218,11 @@ def _fetch_pr_body(commit_sha: str, repo_path: str, token: str) -> str | None:
             timeout=10,
             env=env,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
+        if result.returncode == 0:
+            return result.stdout.strip() or ""
+        return None
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-    return None
+        return None
 
 
 def archaeologize(
@@ -231,6 +235,7 @@ def archaeologize(
     pr_bodies: bool = False,
     dry_run: bool = False,
     batch_size: int = 10,
+    min_confidence: float = 0.35,
     extraction_weights: ExtractionWeights | None = None,
     progress_callback: Callable[[str], None] | None = None,
 ) -> ArchaeologyResult:
@@ -293,6 +298,7 @@ def archaeologize(
                     result,
                     pr_bodies=pr_bodies,
                     token=token,
+                    min_confidence=min_confidence,
                     extraction_weights=extraction_weights,
                     progress_callback=progress_callback,
                 )
@@ -306,6 +312,7 @@ def archaeologize(
                 result,
                 pr_bodies=pr_bodies,
                 token=token,
+                min_confidence=min_confidence,
                 extraction_weights=extraction_weights,
                 progress_callback=progress_callback,
             )
@@ -332,6 +339,7 @@ def _process_batch(
     *,
     pr_bodies: bool,
     token: str | None,
+    min_confidence: float,
     extraction_weights: ExtractionWeights | None,
     progress_callback: Callable[[str], None] | None,
 ) -> None:
@@ -339,8 +347,8 @@ def _process_batch(
     for sha, message, patch_text in batch:
         pr_body = None
         if pr_bodies and token and consecutive_pr_failures < _PR_BODY_FAIL_THRESHOLD:
-            pr_body = _fetch_pr_body(sha, repo_path, token)
-            if pr_body is None:
+            raw_pr = _fetch_pr_body(sha, repo_path, token)
+            if raw_pr is None:
                 consecutive_pr_failures += 1
                 if consecutive_pr_failures >= _PR_BODY_FAIL_THRESHOLD:
                     result.warnings.append(
@@ -348,6 +356,7 @@ def _process_batch(
                     )
             else:
                 consecutive_pr_failures = 0
+                pr_body = raw_pr or None
 
         bundle = _build_signal_bundle(sha, message, patch_text, pr_body)
         try:
@@ -356,6 +365,7 @@ def _process_batch(
                 session_id=None,
                 repo_path=repo_path,
                 bundles=[bundle],
+                min_confidence=min_confidence,
                 extraction_weights=extraction_weights,
             )
             if outcome.parsed_ok or outcome.candidates_inserted > 0:

--- a/src/entirecontext/core/config.py
+++ b/src/entirecontext/core/config.py
@@ -132,6 +132,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "contradicted_penalty": 0.15,
         },
         "auto_embed": True,
+        "archaeology": {
+            "enabled": True,
+            "batch_size": 10,
+            "pr_body_fetch": False,
+        },
         "injection": {
             "inject_on_user_prompt": True,
             "experiment_block": None,

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -54,12 +54,13 @@ _CODE_STOPWORDS_TITLE: frozenset[str] = frozenset(
 )
 
 
-_VALID_SOURCE_TYPES = frozenset({"session", "checkpoint", "assessment"})
+_VALID_SOURCE_TYPES = frozenset({"session", "checkpoint", "assessment", "archaeology"})
 
 _BASE_CONFIDENCE_WEIGHTS: dict[str, float] = {
     "assessment": 0.55,
     "checkpoint": 0.40,
     "session": 0.30,
+    "archaeology": 0.25,
 }
 
 _DEFAULT_EXTRACT_KEYWORDS: list[str] = [
@@ -85,7 +86,7 @@ _MAX_PROMPT_CHARS = 8000
 class SignalBundle:
     source_type: str
     source_id: str
-    session_id: str
+    session_id: str | None
     checkpoint_id: str | None
     assessment_id: str | None
     text_blocks: list[str]
@@ -101,7 +102,7 @@ class CandidateDraft:
     supporting_evidence: list[Any]
     source_type: str
     source_id: str
-    session_id: str
+    session_id: str | None
     checkpoint_id: str | None
     assessment_id: str | None
     files: list[str]
@@ -554,6 +555,19 @@ _SYSTEM_PROMPT_BY_SOURCE: dict[str, str] = {
         "Return [] if the assessment is a neutral observation. "
         "For each rejected alternative, provide the reason it was not chosen — "
         "only if the reason is explicit in the source text. "
+        'If no reason is stated, omit the "reason" key entirely (do not invent one).'
+    ),
+    "archaeology": (
+        "You are reviewing a git commit patch for architectural or technical decisions. "
+        "The patch shows what was changed and the commit message explains why. "
+        "Extract decisions where the developer chose one approach over another. "
+        "Return a JSON array: "
+        '[{"title": str, "rationale": str, "scope": str, '
+        '"rejected_alternatives": [{"alternative": str, "reason": str}]}]. '
+        "Return [] if the commit is a routine refactor, dependency bump, formatting, "
+        "or test-only change with no architectural choice. "
+        "For each rejected alternative, provide the reason it was not chosen — "
+        "only if the reason is explicit in the commit message or code comments. "
         'If no reason is stated, omit the "reason" key entirely (do not invent one).'
     ),
 }
@@ -1108,17 +1122,23 @@ class ExtractionOutcome:
 
 def run_extraction(
     conn,
-    session_id: str,
+    session_id: str | None,
     repo_path: str,
     *,
+    bundles: list[SignalBundle] | None = None,
     min_confidence: float = 0.35,
     extraction_weights: ExtractionWeights | None = None,
 ) -> ExtractionOutcome:
     outcome = ExtractionOutcome()
-    if is_session_extracted(conn, session_id):
+
+    if session_id is not None and is_session_extracted(conn, session_id):
         return outcome
 
-    bundles = collect_signals(conn, session_id, repo_path)
+    if bundles is None:
+        if session_id is None:
+            return outcome
+        bundles = collect_signals(conn, session_id, repo_path)
+
     outcome.bundles_collected = len(bundles)
     if not bundles:
         return outcome
@@ -1185,7 +1205,7 @@ def run_extraction(
             f"no_drafts: {outcome.bundles_collected} bundles collected but 0 drafts parsed"
         )
 
-    if outcome.parsed_ok:
+    if outcome.parsed_ok and session_id is not None:
         mark_session_extracted(conn, session_id)
         outcome.marked = True
 

--- a/src/entirecontext/db/migrations/__init__.py
+++ b/src/entirecontext/db/migrations/__init__.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 def get_migrations() -> dict[int, list]:
     migrations: dict[int, list] = {}
-    for version in range(2, 16):
+    for version in range(2, 17):
         # version is a hardcoded bounded integer from range(), not user input
         module = import_module(
             f".v{version:03d}", __name__

--- a/src/entirecontext/db/migrations/v016.py
+++ b/src/entirecontext/db/migrations/v016.py
@@ -1,0 +1,160 @@
+"""Migration to schema v16 — add archaeology_processed table, widen decision_candidates.source_type."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _create_archaeology_processed(conn: sqlite3.Connection) -> None:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'"
+    ).fetchone()
+    if row is not None:
+        return
+    conn.execute(
+        """
+        CREATE TABLE archaeology_processed (
+            commit_sha TEXT PRIMARY KEY,
+            candidate_count INTEGER NOT NULL DEFAULT 0,
+            processed_at TEXT DEFAULT (datetime('now'))
+        )
+        """
+    )
+
+
+_WIDENED_DDL = """
+CREATE TABLE decision_candidates_new (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    rationale TEXT,
+    scope TEXT,
+    rejected_alternatives TEXT,
+    supporting_evidence TEXT,
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment','archaeology')),
+    source_id TEXT NOT NULL,
+    session_id TEXT,
+    checkpoint_id TEXT,
+    assessment_id TEXT,
+    files TEXT,
+    confidence REAL NOT NULL DEFAULT 0.0,
+    confidence_breakdown TEXT,
+    review_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(review_status IN ('pending','confirmed','rejected')),
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    review_note TEXT,
+    promoted_decision_id TEXT,
+    dedup_key TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE SET NULL,
+    FOREIGN KEY (checkpoint_id) REFERENCES checkpoints(id) ON DELETE SET NULL,
+    FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON DELETE SET NULL,
+    FOREIGN KEY (promoted_decision_id) REFERENCES decisions(id) ON DELETE SET NULL
+)
+"""
+
+_COLUMNS = (
+    "id, title, rationale, scope, rejected_alternatives, supporting_evidence, "
+    "source_type, source_id, session_id, checkpoint_id, assessment_id, "
+    "files, confidence, confidence_breakdown, review_status, "
+    "reviewed_at, reviewed_by, review_note, promoted_decision_id, "
+    "dedup_key, created_at, updated_at"
+)
+
+
+def _rebuild_decision_candidates(conn: sqlite3.Connection) -> None:
+    existing = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='decision_candidates'"
+    ).fetchone()
+
+    if existing is None:
+        conn.execute(_WIDENED_DDL.replace("decision_candidates_new", "decision_candidates"))
+        _create_indexes(conn)
+        _create_fts(conn)
+        return
+
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_ai")
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_ad")
+    conn.execute("DROP TRIGGER IF EXISTS fts_decision_candidates_au")
+    conn.execute("DROP TABLE IF EXISTS fts_decision_candidates")
+
+    conn.execute(_WIDENED_DDL)
+    conn.execute(
+        f"INSERT INTO decision_candidates_new SELECT {_COLUMNS} FROM decision_candidates"
+    )
+    conn.execute("DROP TABLE decision_candidates")
+    conn.execute("ALTER TABLE decision_candidates_new RENAME TO decision_candidates")
+
+    _create_indexes(conn)
+    _create_fts(conn)
+
+
+def _create_indexes(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uniq_decision_candidates_source_dedup "
+        "ON decision_candidates(source_type, source_id, dedup_key)"
+    )
+
+
+def _create_fts(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS fts_decision_candidates USING fts5(
+            title, rationale,
+            content='decision_candidates',
+            content_rowid='rowid'
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO fts_decision_candidates(rowid, title, rationale) "
+        "SELECT rowid, title, COALESCE(rationale, '') FROM decision_candidates"
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ai AFTER INSERT ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, COALESCE(new.rationale, ''));
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_ad AFTER DELETE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, COALESCE(old.rationale, ''));
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS fts_decision_candidates_au AFTER UPDATE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, COALESCE(old.rationale, ''));
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, COALESCE(new.rationale, ''));
+        END
+        """
+    )
+
+
+MIGRATION_STEPS = [
+    _create_archaeology_processed,
+    _rebuild_decision_candidates,
+]

--- a/src/entirecontext/db/schema.py
+++ b/src/entirecontext/db/schema.py
@@ -1,6 +1,6 @@
 """Database schema definitions for EntireContext."""
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 # Minimum SQLite version required (for JSON functions)
 MIN_SQLITE_VERSION = "3.38.0"
@@ -427,7 +427,7 @@ CREATE TABLE IF NOT EXISTS decision_candidates (
     scope TEXT,
     rejected_alternatives TEXT,
     supporting_evidence TEXT,
-    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment')),
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment','archaeology')),
     source_id TEXT NOT NULL,
     session_id TEXT,
     checkpoint_id TEXT,
@@ -472,6 +472,13 @@ CREATE TABLE IF NOT EXISTS ranking_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_event_id ON ranking_snapshots(retrieval_event_id);
 CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_created_at ON ranking_snapshots(created_at DESC);
+""",
+    "archaeology_processed": """
+CREATE TABLE IF NOT EXISTS archaeology_processed (
+    commit_sha TEXT PRIMARY KEY,
+    candidate_count INTEGER NOT NULL DEFAULT 0,
+    processed_at TEXT DEFAULT (datetime('now'))
+);
 """,
 }
 

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -12,6 +12,8 @@ from entirecontext.core.archaeology import (
     _stream_commits,
     _get_github_token,
     _fetch_pr_body,
+    _is_github_remote,
+    _decode_git_quoted_path,
     archaeologize,
     ArchaeologyResult,
 )
@@ -63,12 +65,13 @@ class TestExtractFilesFromPatch:
     def test_quoted_non_ascii_path(self):
         # Git quotes both sides and octal-escapes non-ASCII bytes, e.g.
         # `diff --git "a/\355\225\234.py" "b/\355\225\234.py"`.
+        # \355\225\234 is UTF-8 for '한' (U+D55C).
         patch = (
             'diff --git "a/\\355\\225\\234.py" "b/\\355\\225\\234.py"\n'
             '--- "a/\\355\\225\\234.py"\n+++ "b/\\355\\225\\234.py"\n'
         )
         files = _extract_files_from_patch(patch)
-        assert files == ["\\355\\225\\234.py"]
+        assert files == ["한.py"]
 
     def test_quoted_path_with_spaces(self):
         patch = 'diff --git "a/my file.py" "b/my file.py"\n--- a/my file.py\n+++ b/my file.py\n'
@@ -319,6 +322,40 @@ class TestFetchPrBody:
         assert result == "body"
         gh_call_args = mock_run.call_args_list[1].args[0]
         assert "repos/owner/repo/commits/abc123/pulls" in gh_call_args
+
+
+class TestIsGithubRemote:
+    def test_ssh_github(self):
+        assert _is_github_remote("git@github.com:owner/repo.git") is True
+
+    def test_https_github(self):
+        assert _is_github_remote("https://github.com/owner/repo.git") is True
+
+    def test_ssh_gitlab(self):
+        assert _is_github_remote("git@gitlab.com:owner/repo.git") is False
+
+    def test_https_bitbucket(self):
+        assert _is_github_remote("https://bitbucket.org/owner/repo.git") is False
+
+    def test_notgithub_com(self):
+        assert _is_github_remote("git@notgithub.com:owner/repo.git") is False
+
+    def test_github_com_evil(self):
+        assert _is_github_remote("https://github.com.evil/owner/repo.git") is False
+
+    def test_subdomain_github(self):
+        assert _is_github_remote("https://api.github.com/owner/repo.git") is False
+
+
+class TestDecodeGitQuotedPath:
+    def test_no_escapes(self):
+        assert _decode_git_quoted_path("src/foo.py") == "src/foo.py"
+
+    def test_korean_octal(self):
+        assert _decode_git_quoted_path("\\355\\225\\234.py") == "한.py"
+
+    def test_mixed_ascii_and_octal(self):
+        assert _decode_git_quoted_path("src/\\355\\225\\234/bar.py") == "src/한/bar.py"
 
 
 class TestArchaeologize:

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -62,16 +62,30 @@ class TestExtractFilesFromPatch:
 
 class TestBuildSignalBundle:
     def test_basic(self):
-        bundle = _build_signal_bundle("abc123", "diff content", None)
+        bundle = _build_signal_bundle("abc123", "commit message", "diff content", None)
         assert bundle.source_type == "archaeology"
         assert bundle.source_id == "abc123"
         assert bundle.session_id is None
         assert "diff content" in bundle.text_blocks
 
     def test_with_pr_body(self):
-        bundle = _build_signal_bundle("abc123", "diff", "PR description")
+        bundle = _build_signal_bundle("abc123", "commit message", "diff", "PR description")
         assert "PR description" in bundle.text_blocks
         assert "diff" in bundle.text_blocks
+
+    def test_message_included_in_text_blocks(self):
+        bundle = _build_signal_bundle(
+            "abc123", "fix: handle edge case\n\nThis explains why.", "diff content", None
+        )
+        assert "fix: handle edge case\n\nThis explains why." in bundle.text_blocks
+
+    def test_message_precedes_pr_body_and_patch(self):
+        bundle = _build_signal_bundle("abc123", "the message", "the patch", "the pr body")
+        assert bundle.text_blocks == ["the message", "the pr body", "the patch"]
+
+    def test_empty_message_omitted(self):
+        bundle = _build_signal_bundle("abc123", "", "diff content", None)
+        assert bundle.text_blocks == ["diff content"]
 
 
 class TestDedup:
@@ -118,9 +132,9 @@ class TestStreamCommits:
             )
         commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=10))
         assert len(commits) >= 3
-        for sha, subject, patch_text in commits:
+        for sha, message, patch_text in commits:
             assert len(sha) == 40
-            assert isinstance(subject, str)
+            assert isinstance(message, str)
             assert isinstance(patch_text, str)
 
     def test_limit(self, git_repo):
@@ -145,6 +159,34 @@ class TestStreamCommits:
     def test_empty_range(self, git_repo):
         commits = list(_stream_commits(str(git_repo), since="HEAD", until="HEAD", limit=10))
         assert len(commits) == 0
+
+    def test_full_multiline_message_captured(self, git_repo):
+        (git_repo / "body.txt").write_text("content")
+        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+        subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "subject line",
+                "-m",
+                "This is the body explaining why the change was made.",
+            ],
+            cwd=git_repo,
+            check=True,
+            env={
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@test.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@test.com",
+                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
+            },
+        )
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=1))
+        assert len(commits) == 1
+        _, message, _ = commits[0]
+        assert "subject line" in message
+        assert "This is the body explaining why the change was made." in message
 
 
 class TestGetGithubToken:
@@ -193,6 +235,43 @@ class TestArchaeologize:
         assert result.commits_processed >= 2
         assert result.candidates_generated == result.commits_processed
         assert mock_extract.call_count == result.commits_processed
+
+    def test_commit_message_reaches_bundle(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 1, prefix="msgtest")
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=0),
+        ) as mock_extract:
+            archaeologize(ec_db, str(ec_repo))
+        assert mock_extract.call_count >= 1
+        bundles = mock_extract.call_args.kwargs["bundles"]
+        assert any("msgtest commit 0" in b.text_blocks[0] for b in bundles)
+
+    def test_dry_run_limit_note_when_scanned_meets_limit(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 3)
+        progress = []
+        archaeologize(
+            ec_db,
+            str(ec_repo),
+            limit=2,
+            dry_run=True,
+            progress_callback=progress.append,
+        )
+        assert progress
+        assert "increase --limit" in progress[0]
+
+    def test_dry_run_no_limit_note_when_under_limit(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 2)
+        progress = []
+        archaeologize(
+            ec_db,
+            str(ec_repo),
+            limit=100,
+            dry_run=True,
+            progress_callback=progress.append,
+        )
+        assert progress
+        assert "increase --limit" not in progress[0]
 
     def test_rerun_skips_already_processed(self, ec_db, ec_repo):
         _make_commits(ec_repo, 2)

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -1,0 +1,243 @@
+"""Unit tests for core/archaeology.py helper functions."""
+
+import sqlite3
+import subprocess
+import pytest
+from unittest.mock import patch, MagicMock
+from entirecontext.core.archaeology import (
+    _extract_files_from_patch,
+    _build_signal_bundle,
+    _is_processed,
+    _mark_processed,
+    _stream_commits,
+    _get_github_token,
+    archaeologize,
+    ArchaeologyResult,
+)
+from entirecontext.core.decision_extraction import ExtractionOutcome
+
+
+def _make_commits(git_repo, n, prefix="c"):
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
+    }
+    for i in range(n):
+        (git_repo / f"{prefix}{i}.txt").write_text(f"content {i}")
+        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"{prefix} commit {i}"],
+            cwd=git_repo,
+            check=True,
+            env=env,
+        )
+
+
+class TestExtractFilesFromPatch:
+    def test_basic_diff(self):
+        patch = "diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        assert _extract_files_from_patch(patch) == ["src/foo.py"]
+
+    def test_multiple_files(self):
+        patch = "diff --git a/a.py b/a.py\n+++ b/a.py\ndiff --git a/b.py b/b.py\n+++ b/b.py\n"
+        files = _extract_files_from_patch(patch)
+        assert "a.py" in files
+        assert "b.py" in files
+
+    def test_rename(self):
+        patch = "diff --git a/old.py b/new.py\nrename from old.py\nrename to new.py\n"
+        files = _extract_files_from_patch(patch)
+        assert "new.py" in files
+
+    def test_empty_patch(self):
+        assert _extract_files_from_patch("") == []
+
+    def test_binary_file(self):
+        patch = "diff --git a/img.png b/img.png\nBinary files differ\n"
+        assert _extract_files_from_patch(patch) == ["img.png"]
+
+
+class TestBuildSignalBundle:
+    def test_basic(self):
+        bundle = _build_signal_bundle("abc123", "diff content", None)
+        assert bundle.source_type == "archaeology"
+        assert bundle.source_id == "abc123"
+        assert bundle.session_id is None
+        assert "diff content" in bundle.text_blocks
+
+    def test_with_pr_body(self):
+        bundle = _build_signal_bundle("abc123", "diff", "PR description")
+        assert "PR description" in bundle.text_blocks
+        assert "diff" in bundle.text_blocks
+
+
+class TestDedup:
+    @pytest.fixture
+    def arch_db(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "CREATE TABLE archaeology_processed "
+            "(commit_sha TEXT PRIMARY KEY, candidate_count INTEGER NOT NULL DEFAULT 0, "
+            "processed_at TEXT DEFAULT (datetime('now')))"
+        )
+        return conn
+
+    def test_not_processed(self, arch_db):
+        assert _is_processed(arch_db, "abc123") is False
+
+    def test_mark_and_check(self, arch_db):
+        _mark_processed(arch_db, "abc123", 2)
+        assert _is_processed(arch_db, "abc123") is True
+
+    def test_mark_zero_candidates(self, arch_db):
+        _mark_processed(arch_db, "abc123", 0)
+        assert _is_processed(arch_db, "abc123") is True
+
+
+class TestStreamCommits:
+    def test_stream_from_fixture(self, git_repo):
+        for i in range(3):
+            (git_repo / f"file{i}.txt").write_text(f"content {i}")
+            subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"commit {i}"],
+                cwd=git_repo,
+                check=True,
+                env={
+                    "GIT_AUTHOR_NAME": "Test",
+                    "GIT_AUTHOR_EMAIL": "test@test.com",
+                    "GIT_COMMITTER_NAME": "Test",
+                    "GIT_COMMITTER_EMAIL": "test@test.com",
+                    "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
+                },
+            )
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=10))
+        assert len(commits) >= 3
+        for sha, subject, patch_text in commits:
+            assert len(sha) == 40
+            assert isinstance(subject, str)
+            assert isinstance(patch_text, str)
+
+    def test_limit(self, git_repo):
+        for i in range(5):
+            (git_repo / f"f{i}.txt").write_text(f"c{i}")
+            subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"c{i}"],
+                cwd=git_repo,
+                check=True,
+                env={
+                    "GIT_AUTHOR_NAME": "Test",
+                    "GIT_AUTHOR_EMAIL": "test@test.com",
+                    "GIT_COMMITTER_NAME": "Test",
+                    "GIT_COMMITTER_EMAIL": "test@test.com",
+                    "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
+                },
+            )
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=2))
+        assert len(commits) == 2
+
+    def test_empty_range(self, git_repo):
+        commits = list(_stream_commits(str(git_repo), since="HEAD", until="HEAD", limit=10))
+        assert len(commits) == 0
+
+
+class TestGetGithubToken:
+    def test_env_var_priority(self, monkeypatch):
+        monkeypatch.setenv("EC_GITHUB_TOKEN", "env-token-123")
+        assert _get_github_token() == "env-token-123"
+
+    def test_gh_cli_fallback(self, monkeypatch):
+        monkeypatch.delenv("EC_GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="gh-token-456\n")
+            assert _get_github_token() == "gh-token-456"
+
+    def test_no_token_returns_none(self, monkeypatch):
+        monkeypatch.delenv("EC_GITHUB_TOKEN", raising=False)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert _get_github_token() is None
+
+
+class TestArchaeologize:
+    def test_dry_run_does_not_process(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 3)
+        progress = []
+        with patch("entirecontext.core.archaeology.run_extraction") as mock_extract:
+            result = archaeologize(
+                ec_db,
+                str(ec_repo),
+                dry_run=True,
+                progress_callback=progress.append,
+            )
+        mock_extract.assert_not_called()
+        assert isinstance(result, ArchaeologyResult)
+        assert result.commits_processed == 0
+        assert result.commits_scanned >= 3
+        assert progress
+        assert "Estimated token cost" in progress[0]
+
+    def test_processes_and_marks(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 2)
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=1),
+        ) as mock_extract:
+            result = archaeologize(ec_db, str(ec_repo))
+        assert result.commits_processed >= 2
+        assert result.candidates_generated == result.commits_processed
+        assert mock_extract.call_count == result.commits_processed
+
+    def test_rerun_skips_already_processed(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 2)
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=1),
+        ):
+            first = archaeologize(ec_db, str(ec_repo))
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=1),
+        ) as mock_extract:
+            second = archaeologize(ec_db, str(ec_repo))
+        assert second.commits_processed == 0
+        assert second.commits_skipped == first.commits_processed
+        mock_extract.assert_not_called()
+
+    def test_interrupt_processes_each_commit_exactly_once(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 3)
+        calls = {"n": 0}
+
+        def side_effect(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise KeyboardInterrupt()
+            return ExtractionOutcome(candidates_inserted=1)
+
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            side_effect=side_effect,
+        ):
+            result = archaeologize(ec_db, str(ec_repo), batch_size=1)
+
+        assert result.commits_processed == 1
+        assert any("Interrupted" in w for w in result.warnings)
+
+        # Re-run should process each remaining commit exactly once — no
+        # double-processing of the commit that was mid-flight at interrupt.
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=1),
+        ) as mock_extract:
+            second = archaeologize(ec_db, str(ec_repo), batch_size=1)
+
+        assert mock_extract.call_count == second.commits_processed
+        # Exactly one commit was processed before the interrupt; the rest
+        # (scanned minus that one) must be processed on the second run.
+        assert second.commits_processed == second.commits_scanned - 1

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -11,6 +11,7 @@ from entirecontext.core.archaeology import (
     _mark_processed,
     _stream_commits,
     _get_github_token,
+    _fetch_pr_body,
     archaeologize,
     ArchaeologyResult,
 )
@@ -58,6 +59,20 @@ class TestExtractFilesFromPatch:
     def test_binary_file(self):
         patch = "diff --git a/img.png b/img.png\nBinary files differ\n"
         assert _extract_files_from_patch(patch) == ["img.png"]
+
+    def test_quoted_non_ascii_path(self):
+        # Git quotes both sides and octal-escapes non-ASCII bytes, e.g.
+        # `diff --git "a/\355\225\234.py" "b/\355\225\234.py"`.
+        patch = (
+            'diff --git "a/\\355\\225\\234.py" "b/\\355\\225\\234.py"\n'
+            '--- "a/\\355\\225\\234.py"\n+++ "b/\\355\\225\\234.py"\n'
+        )
+        files = _extract_files_from_patch(patch)
+        assert files == ["\\355\\225\\234.py"]
+
+    def test_quoted_path_with_spaces(self):
+        patch = 'diff --git "a/my file.py" "b/my file.py"\n--- a/my file.py\n+++ b/my file.py\n'
+        assert _extract_files_from_patch(patch) == ["my file.py"]
 
 
 class TestBuildSignalBundle:
@@ -188,6 +203,63 @@ class TestStreamCommits:
         assert "subject line" in message
         assert "This is the body explaining why the change was made." in message
 
+    def test_until_ref_without_since_is_honored(self, git_repo):
+        """--until as a ref with no --since must scope commits reachable from
+        that ref, not be silently dropped (PR #190 finding #2)."""
+        _make_commits(git_repo, 3)
+        tag_result = subprocess.run(
+            ["git", "rev-parse", "HEAD~1"], cwd=git_repo, capture_output=True, text=True, check=True
+        )
+        until_sha = tag_result.stdout.strip()
+        commits = list(_stream_commits(str(git_repo), since=None, until=until_sha, limit=100))
+        shas = [sha for sha, _, _ in commits]
+        assert until_sha in shas
+        # The most recent commit (HEAD) must not be reachable from HEAD~1.
+        head_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=git_repo, capture_output=True, text=True, check=True
+        )
+        assert head_result.stdout.strip() not in shas
+
+    def test_since_ref_without_until_defaults_to_head(self, git_repo):
+        _make_commits(git_repo, 3)
+        since_result = subprocess.run(
+            ["git", "rev-parse", "HEAD~1"], cwd=git_repo, capture_output=True, text=True, check=True
+        )
+        commits = list(_stream_commits(str(git_repo), since=since_result.stdout.strip(), until=None, limit=100))
+        # HEAD~1..HEAD contains exactly the last commit.
+        assert len(commits) == 1
+
+    def test_both_refs_since_until(self, git_repo):
+        _make_commits(git_repo, 4)
+        log = subprocess.run(
+            ["git", "log", "--format=%H"], cwd=git_repo, capture_output=True, text=True, check=True
+        )
+        shas_newest_first = log.stdout.strip().splitlines()
+        since_sha = shas_newest_first[3]  # oldest commit
+        until_sha = shas_newest_first[1]
+        commits = list(_stream_commits(str(git_repo), since=since_sha, until=until_sha, limit=100))
+        result_shas = {sha for sha, _, _ in commits}
+        assert result_shas == {shas_newest_first[2], shas_newest_first[1]}
+
+    def test_limit_zero_scans_full_history_not_zero_commits(self, git_repo):
+        """--limit 0 must not be treated as falsy (PR #190 finding #4):
+        it should fall through to scanning all history, not silently
+        produce zero results due to `-n 0`."""
+        _make_commits(git_repo, 3)
+        all_commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=100))
+        commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=0))
+        assert len(commits) == len(all_commits)
+        assert len(commits) > 0
+
+    def test_bad_ref_reports_warning_not_silent_empty(self, git_repo):
+        warnings: list[str] = []
+        commits = list(
+            _stream_commits(str(git_repo), since="not-a-real-ref", until=None, limit=10, warnings=warnings)
+        )
+        assert commits == []
+        assert warnings
+        assert "git log failed" in warnings[0]
+
 
 class TestGetGithubToken:
     def test_env_var_priority(self, monkeypatch):
@@ -207,7 +279,69 @@ class TestGetGithubToken:
             assert _get_github_token() is None
 
 
+class TestFetchPrBody:
+    def _mock_remote(self, url):
+        return MagicMock(returncode=0, stdout=f"{url}\n")
+
+    def test_non_github_origin_returns_none(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._mock_remote("git@gitlab.com:owner/repo.git")
+            result = _fetch_pr_body("abc123", "/tmp/fake", "token")
+        assert result is None
+        # Must not attempt a `gh api` call for a non-GitHub remote.
+        assert mock_run.call_count == 1
+
+    def test_bitbucket_origin_returns_none(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._mock_remote("https://bitbucket.org/owner/repo.git")
+            result = _fetch_pr_body("abc123", "/tmp/fake", "token")
+        assert result is None
+        assert mock_run.call_count == 1
+
+    def test_dotted_repo_name_extracted(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._mock_remote("git@github.com:owner/api.server.git"),
+                MagicMock(returncode=0, stdout="PR body text\n"),
+            ]
+            result = _fetch_pr_body("abc123", "/tmp/fake", "token")
+        assert result == "PR body text"
+        gh_call_args = mock_run.call_args_list[1].args[0]
+        assert "repos/owner/api.server/commits/abc123/pulls" in gh_call_args
+
+    def test_github_https_url_extracted(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._mock_remote("https://github.com/owner/repo.git"),
+                MagicMock(returncode=0, stdout="body\n"),
+            ]
+            result = _fetch_pr_body("abc123", "/tmp/fake", "token")
+        assert result == "body"
+        gh_call_args = mock_run.call_args_list[1].args[0]
+        assert "repos/owner/repo/commits/abc123/pulls" in gh_call_args
+
+
 class TestArchaeologize:
+    def test_dry_run_without_migrated_db_defaults_to_zero_processed(self, git_repo):
+        """PR #190 finding #5: dry-run against a connection whose DB has
+        never been migrated (no archaeology_processed table) must not
+        raise — it should treat 'already processed' as 0."""
+        _make_commits(git_repo, 2)
+        conn = sqlite3.connect(":memory:")
+        progress = []
+        with patch("entirecontext.core.archaeology.run_extraction") as mock_extract:
+            result = archaeologize(
+                conn,
+                str(git_repo),
+                dry_run=True,
+                progress_callback=progress.append,
+            )
+        mock_extract.assert_not_called()
+        assert result.commits_skipped == 0
+        assert result.commits_scanned >= 2
+        assert progress
+        assert "0 already processed" in progress[0]
+
     def test_dry_run_does_not_process(self, ec_db, ec_repo):
         _make_commits(ec_repo, 3)
         progress = []
@@ -235,6 +369,60 @@ class TestArchaeologize:
         assert result.commits_processed >= 2
         assert result.candidates_generated == result.commits_processed
         assert mock_extract.call_count == result.commits_processed
+
+    def test_failed_extraction_not_marked_processed(self, ec_db, ec_repo):
+        """PR #190 finding #1: a commit whose extraction failed to parse
+        (parsed_ok=False, 0 candidates) must not be marked processed, so a
+        transient LLM/parse failure doesn't become a permanent gap."""
+        _make_commits(ec_repo, 2)
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=0, parsed_ok=False, warnings=["parse:archaeology:boom"]),
+        ):
+            result = archaeologize(ec_db, str(ec_repo))
+
+        assert result.commits_processed == 0
+        assert any("will retry next run" in w for w in result.warnings)
+
+        processed = ec_db.execute("SELECT COUNT(*) FROM archaeology_processed").fetchone()[0]
+        assert processed == 0
+
+    def test_failed_extraction_retried_on_next_run(self, ec_db, ec_repo):
+        _make_commits(ec_repo, 1)
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=0, parsed_ok=False),
+        ):
+            first = archaeologize(ec_db, str(ec_repo))
+        assert first.commits_processed == 0
+        scanned = first.commits_scanned
+
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=1, parsed_ok=True),
+        ) as mock_extract:
+            second = archaeologize(ec_db, str(ec_repo))
+
+        # Retried, not skipped as already-processed: every commit scanned
+        # the first time is reprocessed (none were marked processed).
+        assert second.commits_skipped == 0
+        assert second.commits_processed == scanned
+        assert mock_extract.call_count == scanned
+
+    def test_parsed_ok_zero_candidates_still_marked_processed(self, ec_db, ec_repo):
+        """A clean parse that legitimately found zero decisions (e.g. `[]`
+        from the LLM) is a real result, not a failure — it should still be
+        marked processed so it isn't retried forever."""
+        _make_commits(ec_repo, 1)
+        with patch(
+            "entirecontext.core.archaeology.run_extraction",
+            return_value=ExtractionOutcome(candidates_inserted=0, parsed_ok=True),
+        ):
+            result = archaeologize(ec_db, str(ec_repo))
+
+        assert result.commits_processed == result.commits_scanned
+        processed = ec_db.execute("SELECT COUNT(*) FROM archaeology_processed").fetchone()[0]
+        assert processed == result.commits_scanned
 
     def test_commit_message_reaches_bundle(self, ec_db, ec_repo):
         _make_commits(ec_repo, 1, prefix="msgtest")

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -4,10 +4,12 @@ import subprocess
 
 
 def test_help_output():
+    env = {**__import__("os").environ, "NO_COLOR": "1"}
     result = subprocess.run(
         ["uv", "run", "ec", "archaeologize", "--help"],
         capture_output=True,
         text=True,
+        env=env,
     )
     assert result.returncode == 0
     assert "--since" in result.stdout

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -44,3 +44,60 @@ def test_dry_run_on_fixture(git_repo):
     )
     assert result.returncode == 0
     assert "commits" in result.stdout.lower() or "commits" in result.stderr.lower()
+
+
+def test_dry_run_does_not_create_db(git_repo):
+    """PR #190 finding #5: --dry-run must not trigger a DB migration —
+    no `.entirecontext/db` schema should be created as a side effect of
+    a read-only preview."""
+    for i in range(2):
+        (git_repo / f"file{i}.py").write_text(f"x = {i}")
+        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"feat: add file{i}"],
+            cwd=git_repo,
+            check=True,
+            env={
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@test.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@test.com",
+                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
+            },
+        )
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=git_repo,
+    )
+    assert result.returncode == 0
+
+    db_path = git_repo / ".entirecontext" / "db" / "local.db"
+    if db_path.exists():
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        conn.close()
+        assert tables == [], f"dry-run should not migrate the schema, found tables: {tables}"
+
+
+def test_limit_zero_is_rejected(git_repo):
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--limit", "0"],
+        capture_output=True,
+        text=True,
+        cwd=git_repo,
+    )
+    assert result.returncode != 0
+
+
+def test_limit_negative_is_rejected(git_repo):
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--limit", "-1"],
+        capture_output=True,
+        text=True,
+        cwd=git_repo,
+    )
+    assert result.returncode != 0

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -1,23 +1,29 @@
 """CLI tests for ec archaeologize."""
 
+import re
 import subprocess
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def test_help_output():
-    env = {**__import__("os").environ, "NO_COLOR": "1"}
     result = subprocess.run(
         ["uv", "run", "ec", "archaeologize", "--help"],
         capture_output=True,
         text=True,
-        env=env,
     )
     assert result.returncode == 0
-    assert "--since" in result.stdout
-    assert "--until" in result.stdout
-    assert "--limit" in result.stdout
-    assert "--dry-run" in result.stdout
-    assert "--pr-bodies" in result.stdout
-    assert "--batch-size" in result.stdout
+    out = _strip_ansi(result.stdout)
+    assert "--since" in out
+    assert "--until" in out
+    assert "--limit" in out
+    assert "--dry-run" in out
+    assert "--pr-bodies" in out
+    assert "--batch-size" in out
 
 
 def test_dry_run_on_fixture(git_repo):

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -1,0 +1,46 @@
+"""CLI tests for ec archaeologize."""
+
+import subprocess
+
+
+def test_help_output():
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--since" in result.stdout
+    assert "--until" in result.stdout
+    assert "--limit" in result.stdout
+    assert "--dry-run" in result.stdout
+    assert "--pr-bodies" in result.stdout
+    assert "--batch-size" in result.stdout
+
+
+def test_dry_run_on_fixture(git_repo):
+    for i in range(3):
+        (git_repo / f"file{i}.py").write_text(f"x = {i}")
+        subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"feat: add file{i}"],
+            cwd=git_repo,
+            check=True,
+            env={
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@test.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@test.com",
+                "PATH": subprocess.check_output(
+                    ["bash", "-c", "echo $PATH"]
+                ).decode().strip(),
+            },
+        )
+    result = subprocess.run(
+        ["uv", "run", "ec", "archaeologize", "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=git_repo,
+    )
+    assert result.returncode == 0
+    assert "commits" in result.stdout.lower() or "commits" in result.stderr.lower()

--- a/tests/test_archaeology_integration.py
+++ b/tests/test_archaeology_integration.py
@@ -1,0 +1,97 @@
+"""Integration test: ec archaeologize end-to-end pipeline."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from entirecontext.core.archaeology import archaeologize
+
+
+@pytest.fixture
+def arch_repo(ec_repo):
+    """ec_repo with 5 additional commits, each adding a module."""
+    for i in range(5):
+        f = ec_repo / f"mod{i}.py"
+        f.write_text(f"def func_{i}():\n    return {i}\n")
+        subprocess.run(["git", "-C", str(ec_repo), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(ec_repo), "commit", "-m", f"feat: add module {i} with func_{i}"],
+            check=True,
+            capture_output=True,
+        )
+    return ec_repo
+
+
+def test_full_pipeline(arch_repo, ec_db):
+    mock_response = (
+        '[{"title": "Use function pattern for module", '
+        '"rationale": "Simple function pattern chosen over class-based", '
+        '"scope": "module design", '
+        '"rejected_alternatives": [{"alternative": "class-based", "reason": "unnecessary complexity"}]}]'
+    )
+
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        result = archaeologize(
+            ec_db,
+            str(arch_repo),
+            limit=5,
+            batch_size=2,
+        )
+
+    assert result.commits_scanned == 5
+    assert result.commits_processed == 5
+    assert result.commits_skipped == 0
+    assert result.candidates_generated >= 1
+
+    rows = ec_db.execute("SELECT source_type, session_id FROM decision_candidates").fetchall()
+    assert rows
+    for row in rows:
+        assert row["source_type"] == "archaeology"
+        assert row["session_id"] is None
+
+
+def test_rerun_skips_all(arch_repo, ec_db):
+    mock_response = "[]"
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        archaeologize(ec_db, str(arch_repo), limit=5)
+        result2 = archaeologize(ec_db, str(arch_repo), limit=5)
+
+    assert result2.commits_skipped == 5
+    assert result2.commits_processed == 0
+
+
+def test_dry_run_no_writes(arch_repo, ec_db):
+    result = archaeologize(ec_db, str(arch_repo), limit=5, dry_run=True)
+    assert result.commits_scanned == 5
+    assert result.commits_processed == 0
+
+    processed = ec_db.execute("SELECT COUNT(*) FROM archaeology_processed").fetchone()[0]
+    assert processed == 0
+
+    candidates = ec_db.execute("SELECT COUNT(*) FROM decision_candidates").fetchone()[0]
+    assert candidates == 0
+
+
+def test_source_type_archaeology_on_candidates(arch_repo, ec_db):
+    mock_response = (
+        '[{"title": "Test decision", "rationale": "Test", "scope": "test", '
+        '"rejected_alternatives": []}]'
+    )
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        archaeologize(ec_db, str(arch_repo), limit=1)
+
+    row = ec_db.execute("SELECT source_type FROM decision_candidates LIMIT 1").fetchone()
+    assert row is not None
+    assert row["source_type"] == "archaeology"

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -241,6 +241,9 @@ class TestMigration:
         )
         conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
         conn.execute("CREATE TABLE turns (id TEXT PRIMARY KEY)")
+        # FK targets for decision_candidates, created later in the migration chain (v013, widened in v016).
+        conn.execute("CREATE TABLE IF NOT EXISTS checkpoints (id TEXT PRIMARY KEY)")
+        conn.execute("CREATE TABLE IF NOT EXISTS assessments (id TEXT PRIMARY KEY)")
         conn.commit()
 
         check_and_migrate(conn)
@@ -272,6 +275,10 @@ class TestMigration:
             )
             """
         )
+        # FK targets for decision_candidates, created later in the migration chain (v013, widened in v016).
+        conn.execute("CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY)")
+        conn.execute("CREATE TABLE IF NOT EXISTS checkpoints (id TEXT PRIMARY KEY)")
+        conn.execute("CREATE TABLE IF NOT EXISTS assessments (id TEXT PRIMARY KEY)")
         conn.commit()
 
         check_and_migrate(conn)
@@ -514,7 +521,7 @@ class TestMigration:
         ver = conn.execute(
             "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
         ).fetchone()[0]
-        assert ver == 15
+        assert ver == SCHEMA_VERSION
 
         # FK works: can insert with NULL retrieval_event_id
         conn.execute(

--- a/tests/test_extraction_archaeology_seam.py
+++ b/tests/test_extraction_archaeology_seam.py
@@ -1,0 +1,113 @@
+"""Tests for run_extraction archaeology seam (injected bundles, session_id=None)."""
+
+import json
+from unittest.mock import patch
+from entirecontext.core.decision_extraction import (
+    SignalBundle,
+    run_extraction,
+    _VALID_SOURCE_TYPES,
+    _BASE_CONFIDENCE_WEIGHTS,
+    _SYSTEM_PROMPT_BY_SOURCE,
+)
+
+
+def test_archaeology_in_valid_source_types():
+    assert "archaeology" in _VALID_SOURCE_TYPES
+
+
+def test_archaeology_in_base_confidence_weights():
+    assert "archaeology" in _BASE_CONFIDENCE_WEIGHTS
+
+
+def test_archaeology_in_system_prompt():
+    assert "archaeology" in _SYSTEM_PROMPT_BY_SOURCE
+
+
+def test_signal_bundle_accepts_none_session_id():
+    bundle = SignalBundle(
+        source_type="archaeology",
+        source_id="abc123",
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=["diff --git a/foo.py b/foo.py"],
+        files=["foo.py"],
+    )
+    assert bundle.session_id is None
+    assert bundle.source_type == "archaeology"
+
+
+def test_run_extraction_with_injected_bundles(ec_db):
+    bundle = SignalBundle(
+        source_type="archaeology",
+        source_id="abc123",
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=["No decision content here."],
+        files=[],
+    )
+
+    mock_response = "[]"
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        outcome = run_extraction(
+            ec_db,
+            session_id=None,
+            repo_path="/tmp/fake",
+            bundles=[bundle],
+        )
+    assert outcome.bundles_collected == 1
+    assert outcome.marked is False  # no session to mark
+
+
+def test_run_extraction_with_injected_bundles_persists_candidate_with_null_session(ec_db):
+    """Confirms the persist path (not just plumbing) works with session_id=None.
+
+    A "[]" mock response never reaches persist_candidate, so this test uses a
+    real decision JSON payload to exercise the INSERT with a NULL session_id.
+    """
+    bundle = SignalBundle(
+        source_type="archaeology",
+        source_id="commit-abc123",
+        session_id=None,
+        checkpoint_id=None,
+        assessment_id=None,
+        text_blocks=["diff --git a/foo.py b/foo.py\nSwitched from X to Y because Z."],
+        files=["foo.py"],
+    )
+
+    mock_response = json.dumps(
+        [
+            {
+                "title": "Switch from X to Y",
+                "rationale": "Z requires it",
+                "scope": "foo.py",
+                "rejected_alternatives": [{"alternative": "X", "reason": "insufficient"}],
+            }
+        ]
+    )
+    with patch(
+        "entirecontext.core.decision_extraction.call_extraction_llm",
+        return_value=mock_response,
+    ):
+        outcome = run_extraction(
+            ec_db,
+            session_id=None,
+            repo_path="/tmp/fake",
+            bundles=[bundle],
+            min_confidence=0.0,
+        )
+
+    assert outcome.candidates_inserted == 1
+    assert outcome.marked is False
+
+    row = ec_db.execute(
+        "SELECT session_id, source_type FROM decision_candidates WHERE source_id = ?",
+        ("commit-abc123",),
+    ).fetchone()
+    assert row is not None
+    assert row["session_id"] is None
+    assert row["source_type"] == "archaeology"

--- a/tests/test_migration_v016.py
+++ b/tests/test_migration_v016.py
@@ -1,0 +1,181 @@
+"""Tests for schema v15 → v16 migration."""
+
+import sqlite3
+
+import pytest
+
+from entirecontext.db.connection import get_memory_db
+from entirecontext.db.migration import apply_migrations
+
+# Narrow (v15) decision_candidates CHECK constraint — does NOT accept 'archaeology'.
+_V15_DECISION_CANDIDATES_DDL = """
+CREATE TABLE decision_candidates (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    rationale TEXT,
+    scope TEXT,
+    rejected_alternatives TEXT,
+    supporting_evidence TEXT,
+    source_type TEXT NOT NULL CHECK(source_type IN ('session','checkpoint','assessment')),
+    source_id TEXT NOT NULL,
+    session_id TEXT,
+    checkpoint_id TEXT,
+    assessment_id TEXT,
+    files TEXT,
+    confidence REAL NOT NULL DEFAULT 0.0,
+    confidence_breakdown TEXT,
+    review_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(review_status IN ('pending','confirmed','rejected')),
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    review_note TEXT,
+    promoted_decision_id TEXT,
+    dedup_key TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+)
+"""
+
+
+@pytest.fixture
+def v15_db():
+    """A genuine schema-v15 database: narrow decision_candidates CHECK, no archaeology_processed."""
+    conn = get_memory_db()
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)"
+    )
+    conn.execute("INSERT INTO schema_version (version, description) VALUES (15, 'v15')")
+
+    # FK targets referenced by decision_candidates (foreign_keys=ON requires them to exist).
+    conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE checkpoints (id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE assessments (id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TABLE decisions (id TEXT PRIMARY KEY)")
+
+    conn.execute(_V15_DECISION_CANDIDATES_DDL)
+    conn.execute(
+        "CREATE INDEX idx_decision_candidates_review ON decision_candidates(review_status)"
+    )
+    conn.execute(
+        "CREATE INDEX idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
+    )
+    conn.execute(
+        "CREATE INDEX idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
+    )
+    conn.execute("CREATE INDEX idx_decision_candidates_dedup ON decision_candidates(dedup_key)")
+    conn.execute("CREATE INDEX idx_decision_candidates_session ON decision_candidates(session_id)")
+    conn.execute(
+        "CREATE UNIQUE INDEX uniq_decision_candidates_source_dedup "
+        "ON decision_candidates(source_type, source_id, dedup_key)"
+    )
+
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE fts_decision_candidates USING fts5(
+            title, rationale,
+            content='decision_candidates',
+            content_rowid='rowid'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER fts_decision_candidates_ai AFTER INSERT ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, new.rationale);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER fts_decision_candidates_ad AFTER DELETE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, old.rationale);
+        END
+        """
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER fts_decision_candidates_au AFTER UPDATE ON decision_candidates BEGIN
+          INSERT INTO fts_decision_candidates(fts_decision_candidates, rowid, title, rationale)
+          VALUES ('delete', old.rowid, old.title, old.rationale);
+          INSERT INTO fts_decision_candidates(rowid, title, rationale)
+          VALUES (new.rowid, new.title, new.rationale);
+        END
+        """
+    )
+
+    yield conn
+    conn.close()
+
+
+def test_archaeology_processed_table_exists(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    row = v15_db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_source_type_accepts_archaeology(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key) "
+        "VALUES ('test1', 'Test', 'archaeology', 'abc123', 0.5, 'dk1')"
+    )
+    row = v15_db.execute(
+        "SELECT source_type FROM decision_candidates WHERE id = 'test1'"
+    ).fetchone()
+    assert row["source_type"] == "archaeology"
+
+
+def test_source_type_rejects_invalid(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    with pytest.raises(sqlite3.IntegrityError):
+        v15_db.execute(
+            "INSERT INTO decision_candidates "
+            "(id, title, source_type, source_id, confidence, dedup_key) "
+            "VALUES ('test2', 'Test', 'bogus', 'abc123', 0.5, 'dk2')"
+        )
+
+
+def test_existing_candidates_preserved(v15_db):
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key, rationale) "
+        "VALUES ('pre1', 'Existing', 'session', 's1', 0.7, 'dk0', 'reason')"
+    )
+    apply_migrations(v15_db, 15, 16)
+    row = v15_db.execute(
+        "SELECT title, source_type, rationale FROM decision_candidates WHERE id = 'pre1'"
+    ).fetchone()
+    assert row["title"] == "Existing"
+    assert row["source_type"] == "session"
+    assert row["rationale"] == "reason"
+
+
+def test_fts_triggers_work_after_migration(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO decision_candidates "
+        "(id, title, source_type, source_id, confidence, dedup_key, rationale) "
+        "VALUES ('fts1', 'Archaeology FTS Test', 'archaeology', 'abc', 0.5, 'dk3', 'test rationale')"
+    )
+    rows = v15_db.execute(
+        "SELECT * FROM fts_decision_candidates WHERE fts_decision_candidates MATCH 'Archaeology'"
+    ).fetchall()
+    assert len(rows) >= 1
+
+
+def test_archaeology_processed_schema(v15_db):
+    apply_migrations(v15_db, 15, 16)
+    v15_db.execute(
+        "INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc123', 3)"
+    )
+    row = v15_db.execute(
+        "SELECT commit_sha, candidate_count, processed_at FROM archaeology_processed WHERE commit_sha = 'abc123'"
+    ).fetchone()
+    assert row["commit_sha"] == "abc123"
+    assert row["candidate_count"] == 3
+    assert row["processed_at"] is not None


### PR DESCRIPTION
## Summary

- **`ec archaeologize` command** — streams `git log --patch` through the existing extraction pipeline to produce `source:archaeology` decision candidates from commit history. Supports `--since`, `--until`, `--limit` (default 100), `--pr-bodies` (GitHub API), `--dry-run` (cost estimate), `--batch-size`. Implicit resume via dedup.
- **Schema v16 migration** — `archaeology_processed` table for commit-level dedup + `decision_candidates.source_type` CHECK expansion to accept `'archaeology'`. FTS triggers properly rebuilt.
- **`run_extraction` bundles seam** — optional `bundles` parameter and `session_id: str | None` allow external callers to inject pre-built `SignalBundle` objects while sharing the full extraction pipeline. Single entry point, no pipeline fork.
- **`[decisions.archaeology]` config section** — `enabled`, `batch_size`, `pr_body_fetch` settings.
- Addresses the **91% file-link gap** (122 decisions, only 11 with file links) and eliminates the **cold-start adoption barrier**.

## Key design decisions

- `run_extraction` receives a minimal seam (not a parallel extraction path) to avoid pipeline drift — per LESSONS.md: "공유 helper로 policy divergence 방지"
- Commit message (`%B` full body) prepended to bundle text for LLM context
- `archaeology_processed` table tracks all processed commits (including zero-candidate ones) for idempotent re-runs
- `--pr-bodies` requires explicit flag; token passed via `GH_TOKEN` env to `gh api`
- `--limit N + --reverse` selects most-recent-N (documented as known limitation)

## Test plan

- [ ] Schema v16 migration tests (6): table creation, CHECK expansion, data preservation, FTS triggers, rejected values
- [ ] Extraction seam tests (6): type registration, bundle construction, injected bundles, NULL session_id persistence
- [ ] Core archaeology tests (20+): helpers, dry-run, processing, dedup resume, interrupt recovery, commit message in bundle
- [ ] Integration tests (4): full pipeline, re-run dedup, dry-run no-writes, source_type assertion
- [ ] CLI tests (2): help output, dry-run
- [ ] Full suite: 1946 passed, 1 skipped (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qKsBWxCBxsK1oLCKUYA1v