### PR TITLE
fix(blame): bound decision-link lookup complexity

### DIFF
--- a/.release-loop/archive/2026-07-20-v0.15.0-self-archaeology-blame-progress.md
+++ b/.release-loop/archive/2026-07-20-v0.15.0-self-archaeology-blame-progress.md
@@ -1,0 +1,21 @@
+# Release Loop Progress
+Phase: done
+Feature: v0.15.0 Self-Archaeology + Decision-Annotated Blame
+Branch: feature/self-archaeology-blame
+Base: c925e49
+BaseBranch: main
+Spec: docs/specs/2026-07-19-self-archaeology-blame-design.md
+Plan: docs/superpowers/plans/2026-07-19-v0.15.0-self-archaeology-blame-plan.md
+PR: #197
+Tasks: 5/5 complete
+DeliverableType: code
+MinorFindings: (none)
+ReviewRounds: 4
+ReviewComments: 9 fixed, 1 accepted residual
+Unit 1: complete (commits 94d48d4..de72884, review clean round 2)
+Unit 2: complete (commit dc056ff, review clean round 1)
+Unit 3: complete (commit 3f5fe2b, review clean round 1)
+Unit 4: complete (commit 4c80e47, review clean round 1)
+Unit 5: complete (334/334 non-merge commits archaeologized; 138 decisions commit-linked; file-link coverage 56.0%; blame evidence recorded)
+Merged: PR #197 as 11fb9ad2effa1328e9417f54f6277df297e6dbe4
+Retro: docs/retros/2026-07-20-v0.15.0-self-archaeology-blame-retro.md

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -2,9 +2,9 @@
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
 phase: design
-phase_status: in-progress
+phase_status: waiting-user
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:26:43Z
+updated: 2026-07-21T04:27:36Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -29,3 +29,4 @@ blocked_reason: null
 - 2026-07-21T04:10:21Z init: selected `ROADMAP.md:351` P2 carry-forward; isolated branch created from `412288f`; prior completed v0.15.0 ledger archived.
 - 2026-07-21T04:18:29Z design: clean baseline verified with `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → 2093 passed, 1 skipped, 1 warning.
 - 2026-07-21T04:26:43Z design: independent review found 2 Important query-plan/measurement gaps; both corrected; final re-review verdict `clean`; placeholder, consistency, scope, and empirical-evidence checks passed.
+- 2026-07-21T04:27:36Z design: draft spec committed; `git show --quiet --format=%H HEAD` → `1f861c016f7cd904a5582a2bdcd1b6747c9e282b`; waiting for the required user approval gate.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -4,12 +4,12 @@ feature: Bound abbreviated-SHA blame lookup complexity
 phase: plan
 phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:31:29Z
+updated: 2026-07-21T04:36:35Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
 spec: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
-plan: null
+plan: docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
 retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: null
@@ -31,3 +31,4 @@ blocked_reason: null
 - 2026-07-21T04:26:43Z design: independent review found 2 Important query-plan/measurement gaps; both corrected; final re-review verdict `clean`; placeholder, consistency, scope, and empirical-evidence checks passed.
 - 2026-07-21T04:27:36Z design: draft spec committed; `git show --quiet --format=%H HEAD` → `1f861c016f7cd904a5582a2bdcd1b6747c9e282b`; waiting for the required user approval gate.
 - 2026-07-21T04:31:29Z design→plan: user approved the committed spec through the blocking Design gate; spec status changed to `approved`; Plan phase started.
+- 2026-07-21T04:36:35Z plan: all five retained assumptions rechecked as `match`; S1–S4 map to U1; stateless fallback present; placeholder/type/caller/scope checks passed; deepening skipped because no trigger scored.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -1,17 +1,17 @@
 ---
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
-phase: design
-phase_status: waiting-user
+phase: plan
+phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:27:36Z
+updated: 2026-07-21T04:31:29Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
 spec: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
 plan: null
 retro: null
-design_approved: null
+design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: null
 current_unit: null
 ci_attempts: 0
@@ -30,3 +30,4 @@ blocked_reason: null
 - 2026-07-21T04:18:29Z design: clean baseline verified with `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → 2093 passed, 1 skipped, 1 warning.
 - 2026-07-21T04:26:43Z design: independent review found 2 Important query-plan/measurement gaps; both corrected; final re-review verdict `clean`; placeholder, consistency, scope, and empirical-evidence checks passed.
 - 2026-07-21T04:27:36Z design: draft spec committed; `git show --quiet --format=%H HEAD` → `1f861c016f7cd904a5582a2bdcd1b6747c9e282b`; waiting for the required user approval gate.
+- 2026-07-21T04:31:29Z design→plan: user approved the committed spec through the blocking Design gate; spec status changed to `approved`; Plan phase started.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -4,7 +4,7 @@ feature: Bound abbreviated-SHA blame lookup complexity
 phase: implement
 phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:38:52Z
+updated: 2026-07-21T06:59:28Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -13,9 +13,9 @@ plan: docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
 retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: null
-current_unit: U1
+current_unit: null
 ci_attempts: 0
-review_rounds: 0
+review_rounds: 3
 feedback_rounds: 0
 comments_fixed: 0
 comments_deferred: 0
@@ -34,3 +34,7 @@ blocked_reason: null
 - 2026-07-21T04:36:35Z plan: all five retained assumptions rechecked as `match`; S1–S4 map to U1; stateless fallback present; placeholder/type/caller/scope checks passed; deepening skipped because no trigger scored.
 - 2026-07-21T04:37:08Z plan: draft committed; `git show --quiet --format=%H HEAD` → `6a5198beb90b92dc91f5719491ff8202eafdd4ec`; waiting for the required plan approval gate.
 - 2026-07-21T04:38:52Z plan→implement: user approved the committed plan through the blocking Plan gate; plan status changed to `approved`; U1 started with test-first execution.
+- 2026-07-21T04:43:56Z implement/U1: RED reproduced SQLite expression-depth failure in both new 1,200-SHA tests; GREEN passed 2 focused tests, 30 blame core/CLI tests, Ruff, mypy, and the full suite (`2095 passed, 1 skipped, 1 warning`); implementation committed as `6876ebe`.
+- 2026-07-21T04:51:01Z implement/U1 review round 1: Spec FAIL / Quality FAIL on uppercase full-SHA regression; added a RED→GREEN regression and bounded dual-case indexed exact lookup in `33eb341`; revalidated 31 blame tests, Ruff, mypy, `EXPLAIN QUERY PLAN`, and full suite (`2096 passed, 1 skipped, 1 warning`).
+- 2026-07-21T06:58:17Z implement/U1 review round 2: Spec FAIL / Quality FAIL on mixed-case full-SHA regression; user chose complete unchanged behavior over the narrower shorter-only candidate detail; added a RED→GREEN regression and same-width non-lowercase candidate fallback in `8bdb0da`; revalidated 32 blame tests, Ruff, mypy, exact-query index use, and full suite (`2097 passed, 1 skipped, 1 warning`).
+- 2026-07-21T06:59:28Z implement/U1 review round 3: Spec PASS / Quality PASS with no findings; mixed SHA-1/SHA-256 boundary check passed; no observable-behavior deviation artifact required. Unit 1: complete (commits `a3da957..8bdb0da`, review clean).

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -1,10 +1,10 @@
 ---
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
-phase: plan
-phase_status: waiting-user
+phase: implement
+phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:37:08Z
+updated: 2026-07-21T04:38:52Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -13,7 +13,7 @@ plan: docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
 retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: null
-current_unit: null
+current_unit: U1
 ci_attempts: 0
 review_rounds: 0
 feedback_rounds: 0
@@ -33,3 +33,4 @@ blocked_reason: null
 - 2026-07-21T04:31:29Z design→plan: user approved the committed spec through the blocking Design gate; spec status changed to `approved`; Plan phase started.
 - 2026-07-21T04:36:35Z plan: all five retained assumptions rechecked as `match`; S1–S4 map to U1; stateless fallback present; placeholder/type/caller/scope checks passed; deepening skipped because no trigger scored.
 - 2026-07-21T04:37:08Z plan: draft committed; `git show --quiet --format=%H HEAD` → `6a5198beb90b92dc91f5719491ff8202eafdd4ec`; waiting for the required plan approval gate.
+- 2026-07-21T04:38:52Z plan→implement: user approved the committed plan through the blocking Plan gate; plan status changed to `approved`; U1 started with test-first execution.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -2,9 +2,9 @@
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
 phase: ship
-phase_status: in-progress
+phase_status: waiting-user
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T07:25:47Z
+updated: 2026-07-21T07:28:42Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -14,7 +14,7 @@ retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: {by: user, at: 2026-07-21T07:05:26Z, conditions: "push and PR approved; merge requires final approval"}
 current_unit: null
-ci_attempts: 1
+ci_attempts: 2
 review_rounds: 3
 feedback_rounds: 1
 comments_fixed: 1
@@ -45,3 +45,4 @@ blocked_reason: null
 - 2026-07-21T07:09:44Z ship: pushed `fix/blame-sha-lookup-complexity` and opened PR #199 with ROADMAP/spec/plan traceability and fresh verification evidence.
 - 2026-07-21T07:14:03Z ship/CI attempt 1: all checks passed; complete feedback fetch found one open P2 thread (`PRRT_kwDORPUqAs6SfR1i`, comment `3620137548`) showing unrelated abbreviated links can trigger unbounded `git rev-parse` calls; feedback round 1 started with a test-first fix.
 - 2026-07-21T07:25:47Z ship/feedback round 1: RED proved 1,000 unrelated links caused 1,000 extra Git calls; `2c1e6ab` added blamed-prefix filtering; independent review then found case-variant cache misses, and `609e93a` normalized cache keys with a 64-variant regression; 34 blame tests, Ruff, mypy, full suite (`2099 passed, 1 skipped`), and clean re-review passed; thread `PRRT_kwDORPUqAs6SfR1i` was replied to and re-fetched as resolved.
+- 2026-07-21T07:28:42Z ship/CI attempt 2: all checks passed on `d5b1e6a`; complete feedback re-fetch found one resolved thread, zero open actionable comments, and `mergeStateStatus=CLEAN`; waiting for the required merge approval after the final ledger-only push is rechecked.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -4,7 +4,7 @@ feature: Bound abbreviated-SHA blame lookup complexity
 phase: ship
 phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T07:08:25Z
+updated: 2026-07-21T07:09:44Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -19,7 +19,7 @@ review_rounds: 3
 feedback_rounds: 0
 comments_fixed: 0
 comments_deferred: 0
-pr: null
+pr: 199
 merged: false
 blocked_reason: null
 ---
@@ -42,3 +42,4 @@ blocked_reason: null
 - 2026-07-21T07:01:48Z review→ship: phase-gate verified the reviewed HEAD and `git diff --check main...HEAD` passed; waiting at the required first-hand Ship approval gate before outward operations.
 - 2026-07-21T07:05:26Z ship: user approved push and PR creation; capability preflight found `gh 2.96.0`, authenticated ADMIN access, and reachable `origin`; unrelated local-base commits were removed by rebasing `8d2332a` onto `origin/main`, producing clean-scope HEAD `76b09da` with 11 feature-only commits.
 - 2026-07-21T07:08:25Z ship: fresh post-rebase verification gate — `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → `2097 passed, 1 skipped, 1 pre-existing warning`.
+- 2026-07-21T07:09:44Z ship: pushed `fix/blame-sha-lookup-complexity` and opened PR #199 with ROADMAP/spec/plan traceability and fresh verification evidence.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -1,21 +1,31 @@
-# Release Loop Progress
-Phase: done
-Feature: v0.15.0 Self-Archaeology + Decision-Annotated Blame
-Branch: feature/self-archaeology-blame
-Base: c925e49
-BaseBranch: main
-Spec: docs/specs/2026-07-19-self-archaeology-blame-design.md
-Plan: docs/superpowers/plans/2026-07-19-v0.15.0-self-archaeology-blame-plan.md
-PR: #197
-Tasks: 5/5 complete
-DeliverableType: code
-MinorFindings: (none)
-ReviewRounds: 4
-ReviewComments: 9 fixed, 1 accepted residual
-Unit 1: complete (commits 94d48d4..de72884, review clean round 2)
-Unit 2: complete (commit dc056ff, review clean round 1)
-Unit 3: complete (commit 3f5fe2b, review clean round 1)
-Unit 4: complete (commit 4c80e47, review clean round 1)
-Unit 5: complete (334/334 non-merge commits archaeologized; 138 decisions commit-linked; file-link coverage 56.0%; blame evidence recorded)
-Merged: PR #197 as 11fb9ad2effa1328e9417f54f6277df297e6dbe4
-Retro: docs/retros/2026-07-20-v0.15.0-self-archaeology-blame-retro.md
+---
+schema: release-loop/v1
+feature: Bound abbreviated-SHA blame lookup complexity
+phase: design
+phase_status: in-progress
+started: 2026-07-21T04:10:21Z
+updated: 2026-07-21T04:26:43Z
+branch: fix/blame-sha-lookup-complexity
+base_branch: main
+flags: []
+spec: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
+plan: null
+retro: null
+design_approved: null
+ship_approved: null
+current_unit: null
+ci_attempts: 0
+review_rounds: 0
+feedback_rounds: 0
+comments_fixed: 0
+comments_deferred: 0
+pr: null
+merged: false
+blocked_reason: null
+---
+
+## Log
+
+- 2026-07-21T04:10:21Z init: selected `ROADMAP.md:351` P2 carry-forward; isolated branch created from `412288f`; prior completed v0.15.0 ledger archived.
+- 2026-07-21T04:18:29Z design: clean baseline verified with `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → 2093 passed, 1 skipped, 1 warning.
+- 2026-07-21T04:26:43Z design: independent review found 2 Important query-plan/measurement gaps; both corrected; final re-review verdict `clean`; placeholder, consistency, scope, and empirical-evidence checks passed.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -2,9 +2,9 @@
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
 phase: plan
-phase_status: in-progress
+phase_status: waiting-user
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T04:36:35Z
+updated: 2026-07-21T04:37:08Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -32,3 +32,4 @@ blocked_reason: null
 - 2026-07-21T04:27:36Z design: draft spec committed; `git show --quiet --format=%H HEAD` → `1f861c016f7cd904a5582a2bdcd1b6747c9e282b`; waiting for the required user approval gate.
 - 2026-07-21T04:31:29Z design→plan: user approved the committed spec through the blocking Design gate; spec status changed to `approved`; Plan phase started.
 - 2026-07-21T04:36:35Z plan: all five retained assumptions rechecked as `match`; S1–S4 map to U1; stateless fallback present; placeholder/type/caller/scope checks passed; deepening skipped because no trigger scored.
+- 2026-07-21T04:37:08Z plan: draft committed; `git show --quiet --format=%H HEAD` → `6a5198beb90b92dc91f5719491ff8202eafdd4ec`; waiting for the required plan approval gate.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -1,10 +1,10 @@
 ---
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
-phase: implement
-phase_status: in-progress
+phase: ship
+phase_status: waiting-user
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T06:59:28Z
+updated: 2026-07-21T07:01:48Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -38,3 +38,5 @@ blocked_reason: null
 - 2026-07-21T04:51:01Z implement/U1 review round 1: Spec FAIL / Quality FAIL on uppercase full-SHA regression; added a RED→GREEN regression and bounded dual-case indexed exact lookup in `33eb341`; revalidated 31 blame tests, Ruff, mypy, `EXPLAIN QUERY PLAN`, and full suite (`2096 passed, 1 skipped, 1 warning`).
 - 2026-07-21T06:58:17Z implement/U1 review round 2: Spec FAIL / Quality FAIL on mixed-case full-SHA regression; user chose complete unchanged behavior over the narrower shorter-only candidate detail; added a RED→GREEN regression and same-width non-lowercase candidate fallback in `8bdb0da`; revalidated 32 blame tests, Ruff, mypy, exact-query index use, and full suite (`2097 passed, 1 skipped, 1 warning`).
 - 2026-07-21T06:59:28Z implement/U1 review round 3: Spec PASS / Quality PASS with no findings; mixed SHA-1/SHA-256 boundary check passed; no observable-behavior deviation artifact required. Unit 1: complete (commits `a3da957..8bdb0da`, review clean).
+- 2026-07-21T07:01:48Z implement→review: final branch review at `eff84ec` returned Spec PASS / Quality PASS with no findings; S1–S4, 32 blame tests, Ruff, mypy, query bounds, and index use were verified.
+- 2026-07-21T07:01:48Z review→ship: phase-gate verified the reviewed HEAD and `git diff --check main...HEAD` passed; waiting at the required first-hand Ship approval gate before outward operations.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -2,9 +2,9 @@
 schema: release-loop/v1
 feature: Bound abbreviated-SHA blame lookup complexity
 phase: ship
-phase_status: waiting-user
+phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T07:01:48Z
+updated: 2026-07-21T07:05:26Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -12,7 +12,7 @@ spec: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
 plan: docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
 retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
-ship_approved: null
+ship_approved: {by: user, at: 2026-07-21T07:05:26Z, conditions: "push and PR approved; merge requires final approval"}
 current_unit: null
 ci_attempts: 0
 review_rounds: 3
@@ -40,3 +40,4 @@ blocked_reason: null
 - 2026-07-21T06:59:28Z implement/U1 review round 3: Spec PASS / Quality PASS with no findings; mixed SHA-1/SHA-256 boundary check passed; no observable-behavior deviation artifact required. Unit 1: complete (commits `a3da957..8bdb0da`, review clean).
 - 2026-07-21T07:01:48Z implement→review: final branch review at `eff84ec` returned Spec PASS / Quality PASS with no findings; S1–S4, 32 blame tests, Ruff, mypy, query bounds, and index use were verified.
 - 2026-07-21T07:01:48Z review→ship: phase-gate verified the reviewed HEAD and `git diff --check main...HEAD` passed; waiting at the required first-hand Ship approval gate before outward operations.
+- 2026-07-21T07:05:26Z ship: user approved push and PR creation; capability preflight found `gh 2.96.0`, authenticated ADMIN access, and reachable `origin`; unrelated local-base commits were removed by rebasing `8d2332a` onto `origin/main`, producing clean-scope HEAD `76b09da` with 11 feature-only commits.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -4,7 +4,7 @@ feature: Bound abbreviated-SHA blame lookup complexity
 phase: ship
 phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T07:09:44Z
+updated: 2026-07-21T07:25:47Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -14,10 +14,10 @@ retro: null
 design_approved: {by: user, at: 2026-07-21T04:31:29Z}
 ship_approved: {by: user, at: 2026-07-21T07:05:26Z, conditions: "push and PR approved; merge requires final approval"}
 current_unit: null
-ci_attempts: 0
+ci_attempts: 1
 review_rounds: 3
-feedback_rounds: 0
-comments_fixed: 0
+feedback_rounds: 1
+comments_fixed: 1
 comments_deferred: 0
 pr: 199
 merged: false
@@ -43,3 +43,5 @@ blocked_reason: null
 - 2026-07-21T07:05:26Z ship: user approved push and PR creation; capability preflight found `gh 2.96.0`, authenticated ADMIN access, and reachable `origin`; unrelated local-base commits were removed by rebasing `8d2332a` onto `origin/main`, producing clean-scope HEAD `76b09da` with 11 feature-only commits.
 - 2026-07-21T07:08:25Z ship: fresh post-rebase verification gate — `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → `2097 passed, 1 skipped, 1 pre-existing warning`.
 - 2026-07-21T07:09:44Z ship: pushed `fix/blame-sha-lookup-complexity` and opened PR #199 with ROADMAP/spec/plan traceability and fresh verification evidence.
+- 2026-07-21T07:14:03Z ship/CI attempt 1: all checks passed; complete feedback fetch found one open P2 thread (`PRRT_kwDORPUqAs6SfR1i`, comment `3620137548`) showing unrelated abbreviated links can trigger unbounded `git rev-parse` calls; feedback round 1 started with a test-first fix.
+- 2026-07-21T07:25:47Z ship/feedback round 1: RED proved 1,000 unrelated links caused 1,000 extra Git calls; `2c1e6ab` added blamed-prefix filtering; independent review then found case-variant cache misses, and `609e93a` normalized cache keys with a 64-variant regression; 34 blame tests, Ruff, mypy, full suite (`2099 passed, 1 skipped`), and clean re-review passed; thread `PRRT_kwDORPUqAs6SfR1i` was replied to and re-fetched as resolved.

--- a/.release-loop/progress.md
+++ b/.release-loop/progress.md
@@ -4,7 +4,7 @@ feature: Bound abbreviated-SHA blame lookup complexity
 phase: ship
 phase_status: in-progress
 started: 2026-07-21T04:10:21Z
-updated: 2026-07-21T07:05:26Z
+updated: 2026-07-21T07:08:25Z
 branch: fix/blame-sha-lookup-complexity
 base_branch: main
 flags: []
@@ -41,3 +41,4 @@ blocked_reason: null
 - 2026-07-21T07:01:48Z implement→review: final branch review at `eff84ec` returned Spec PASS / Quality PASS with no findings; S1–S4, 32 blame tests, Ruff, mypy, query bounds, and index use were verified.
 - 2026-07-21T07:01:48Z review→ship: phase-gate verified the reviewed HEAD and `git diff --check main...HEAD` passed; waiting at the required first-hand Ship approval gate before outward operations.
 - 2026-07-21T07:05:26Z ship: user approved push and PR creation; capability preflight found `gh 2.96.0`, authenticated ADMIN access, and reachable `origin`; unrelated local-base commits were removed by rebasing `8d2332a` onto `origin/main`, producing clean-scope HEAD `76b09da` with 11 feature-only commits.
+- 2026-07-21T07:08:25Z ship: fresh post-rebase verification gate — `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` → `2097 passed, 1 skipped, 1 pre-existing warning`.

--- a/docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
+++ b/docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
@@ -1,0 +1,97 @@
+---
+schema: plan/v1
+title: Bound abbreviated-SHA blame lookup complexity
+type: fix
+status: draft
+date: 2026-07-21
+execution: code
+origin: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
+---
+
+# Bound Abbreviated-SHA Blame Lookup Complexity Plan
+
+## Goal
+
+Prevent `ec blame --decisions` from exceeding SQLite expression limits when a file spans many distinct commits. Preserve every existing annotation and CLI behavior while replacing the combined exact-plus-prefix expression with bounded indexed exact lookups and one abbreviated-candidate scan per Git object-ID width.
+
+The plan intentionally contains one implementation unit. Source, regression tests, and verification form one atomic behavior change, while the plan remains warranted for traceability to the approved spec and its query-shape decision.
+
+## Architecture Notes
+
+- Keep `annotate_file()` as the public core entry point and preserve its return shape.
+- Add `_SHA_QUERY_BATCH_SIZE = 400` in `src/entirecontext/core/blame_decisions.py`; the value is fixed, internal, and not configurable.
+- Add an internal `_query_decision_links(conn, blamed_shas)` helper that returns the same selected decision metadata rows consumed by the existing resolution loop.
+- Query exact stored SHAs with `commit_sha IN (...)` in slices of at most 400 so `idx_decision_commits_commit_sha` remains usable.
+- Query stored SHAs with lengths from 4 up to, but not including, each blamed full-SHA width. Run this abbreviated-candidate query once for normal SHA-1 or SHA-256 blame output and at most twice for synthetic mixed-width input.
+- Pass all candidate rows through the existing `_resolve_blamed_sha()` check and canonical `(resolved_sha, decision_id)` deduplication. Candidate selection alone never annotates a line.
+- Rejected: batching the current combined `OR` query. `EXPLAIN QUERY PLAN` shows that its prefix arm scans `decision_commits`, so chunking would repeat the scan for every batch.
+- Known Pattern: `src/entirecontext/core/archaeology.py::archaeologize()` accumulates bounded batches and flushes the final partial batch. Use the same explicit slice/flush clarity; do not introduce a repository-wide batching abstraction for one caller.
+- No applicable `docs/solutions/` entry or `CONCEPTS.md` vocabulary exists for this change.
+
+## Assumption Recheck
+
+All live assumptions retained by the approved origin spec were rerun from the isolated worktree. No contradiction or unavailable evidence was found.
+
+| Approved claim | Fresh command evidence | Outcome |
+|---|---|---|
+| The current lookup adds one prefix `OR` predicate per distinct blamed SHA. | `sed -n '128,143p' src/entirecontext/core/blame_decisions.py` at `2026-07-21T04:32:19Z` still shows one unbounded `prefix_conditions` expression. | match |
+| SQLite expression depth can be constrained to 1,000 in a deterministic regression. | `PYTHONPATH=src .venv/bin/python -c "import sqlite3; from entirecontext.db import get_memory_db; c=get_memory_db(); print(c.getlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH)); c.setlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH,1000); print(c.getlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH))"` at `2026-07-21T04:32:19Z` printed `10000` then `1000`. | match |
+| Existing tests lock abbreviated-link normalization, canonical deduplication, line ranges, and uncommitted ranges. | `rg -n 'test_(abbreviated|uppercase|equivalent|happy_two|line_range|uncommitted)' tests/test_blame_decisions.py` at `2026-07-21T04:32:19Z` found the same six focused tests. | match |
+| Split exact and abbreviated paths receive different query plans. | `PYTHONPATH=src .venv/bin/python -c "from entirecontext.db import get_memory_db,init_schema;c=get_memory_db();init_schema(c);print([tuple(r) for r in c.execute('EXPLAIN QUERY PLAN SELECT dc.commit_sha FROM decision_commits dc JOIN decisions d ON d.id=dc.decision_id WHERE dc.commit_sha IN (?,?,?)',('a'*40,'b'*40,'c'*40))]);print([tuple(r) for r in c.execute('EXPLAIN QUERY PLAN SELECT dc.commit_sha FROM decision_commits dc JOIN decisions d ON d.id=dc.decision_id WHERE length(dc.commit_sha)>=4 AND length(dc.commit_sha)<?',(40,))])"` at `2026-07-21T04:32:19Z` reported `SEARCH dc USING INDEX idx_decision_commits_commit_sha` for exact `IN` and `SCAN dc` for the abbreviated-length filter. | match |
+| The pre-change repository suite is green in the isolated worktree. | `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` completed at `2026-07-21T04:35:09Z` with 2,093 passed, 1 skipped, and 1 warning. | match |
+
+## File Structure
+
+- Modify `src/entirecontext/core/blame_decisions.py` — bounded candidate-query helper, fixed batch constant, and unchanged annotation-resolution integration.
+- Modify `tests/test_blame_decisions.py` — high-diversity regression data, lowered SQLite limit proof, exact/abbreviated annotation assertions, and bounded query-count evidence.
+
+## Scenario Coverage Map
+
+| Scenario | Ordered unit chain | Scenario evidence |
+|---|---|---|
+| S1: Annotate a file with high commit diversity | U1 | `test_high_distinct_sha_count_survives_expression_depth_limit` exercises 1,200 blamed SHAs with depth 1,000. Covers S1. |
+| S2: Resolve abbreviated commit links at scale | U1 | The same integration fixture includes full and abbreviated links and asserts canonical annotations. Covers S2. |
+| S3: Preserve partial-history states | U1 | Existing linked, unlinked, and uncommitted-range tests plus the focused module run remain green. Covers S3. |
+| S4: Keep normal blame behavior unchanged | U1 | Existing `tests/test_blame_decisions.py` and `tests/test_blame_cmds.py` pass without CLI or output changes. Covers S4. |
+
+## Implementation Units
+
+## U1: Split and bound decision-link candidate lookup
+Execution note: test-first
+Files:
+  Modify: `src/entirecontext/core/blame_decisions.py`
+  Test: `tests/test_blame_decisions.py`
+Interfaces:
+  Consumes: `annotate_file(conn: sqlite3.Connection, repo_path: str, file: str, start_line: int | None = None, end_line: int | None = None) -> dict[str, Any]`; `decision_commits.commit_sha`; `decisions` annotation metadata; Git blame porcelain full SHAs.
+  Produces: unchanged `annotate_file()` return contract; internal `_query_decision_links(conn: sqlite3.Connection, blamed_shas: list[str]) -> list[sqlite3.Row]`; internal `_SHA_QUERY_BATCH_SIZE = 400`.
+Test scenarios:
+  happy: 1,200 distinct SHA-1 blamed commits include exact and abbreviated stored links; both resolve to canonical full-SHA annotations. Covers S1 and S2.
+  edge: candidate SQL executes exactly three exact batches and one abbreviated-candidate query; each exact batch has at most 400 SHAs; existing equivalent-link deduplication and mixed linked/unlinked/uncommitted ranges remain unchanged. Covers S3.
+  error: set `SQLITE_LIMIT_EXPR_DEPTH` to 1,000 before the 1,200-SHA call and prove no `sqlite3.OperationalError` escapes.
+  integration: call `annotate_file()` with mocked porcelain output and the real `ec_db` SQLite fixture, then run the existing CLI/core suites. Covers S1, S2, S3, and S4.
+Steps:
+  1. Add `tests/test_blame_decisions.py::TestAnnotateFile::test_high_distinct_sha_count_survives_expression_depth_limit` and `test_high_distinct_sha_query_count_is_bounded`; use deterministic synthetic 40-character SHAs, a real migrated `ec_db`, `Connection.setlimit()`, and query tracing or a counting connection proxy.
+  2. Run `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k 'high_distinct_sha_count or query_count_is_bounded'`; confirm the current code fails with expression depth 1,000 and does not satisfy the required three-exact-plus-one-abbreviated query shape.
+  3. Add `_SHA_QUERY_BATCH_SIZE`, `_query_decision_links()`, indexed exact batches, and one abbreviated-candidate query per blamed SHA width; replace only the current combined-query block in `annotate_file()`.
+  4. Run the two new tests, the complete blame core/CLI suites, Ruff, mypy, and the full repository suite; confirm no regressions and retain the observed counts in `.release-loop/progress.md`.
+  5. Commit: `fix(blame): Bound decision-link lookup complexity` using the repository Lore trailers and the fresh verification evidence.
+Acceptance: `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k 'high_distinct_sha_count or query_count_is_bounded'`; `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py tests/test_blame_cmds.py`; `PATH="$PWD/.venv/bin:$PATH" uv run ruff check src/entirecontext/core/blame_decisions.py tests/test_blame_decisions.py`; `PATH="$PWD/.venv/bin:$PATH" uv run mypy src/entirecontext/core/blame_decisions.py`; `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q`.
+
+## Mutation/Failure-State Matrix
+
+No stateful ceremony in the deliverable; no mutation/failure-state matrix required.
+
+## Deferred to Follow-Up Work
+
+- General batching for other unbounded `IN (...)` queries remains outside this fix because no failure evidence was established for those callers.
+- Index or schema changes for abbreviated-link prefix search remain outside this fix because one verified candidate scan is sufficient for the accepted P2 scope.
+
+## Open Unknowns
+
+### Planning-Time
+
+None.
+
+### Implementation-Time
+
+- Choose query tracing or a small counting connection proxy for the bounded-query assertion. The test must observe three exact queries and one abbreviated-candidate query without changing production interfaces.

--- a/docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
+++ b/docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md
@@ -2,7 +2,7 @@
 schema: plan/v1
 title: Bound abbreviated-SHA blame lookup complexity
 type: fix
-status: draft
+status: approved
 date: 2026-07-21
 execution: code
 origin: docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md

--- a/docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
+++ b/docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
@@ -1,6 +1,6 @@
 ---
 title: Bounded Abbreviated-SHA Blame Lookup
-status: draft
+status: approved
 date: 2026-07-21
 schema: spec/v1
 ---

--- a/docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
+++ b/docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md
@@ -1,0 +1,141 @@
+---
+title: Bounded Abbreviated-SHA Blame Lookup
+status: draft
+date: 2026-07-21
+schema: spec/v1
+---
+
+# Bounded Abbreviated-SHA Blame Lookup Design
+
+_Created 2026-07-21._
+
+## Overview
+
+Make `ec blame <file> --decisions` reliable for files spanning more distinct commits than SQLite permits in one expression tree. Preserve the existing annotations, unlinked ranges, uncommitted ranges, CLI interface, and decision-link semantics while bounding each database lookup.
+
+## User Scenarios
+
+### S1: Annotate a file with high commit diversity
+
+A developer runs `ec blame path/to/generated-history.py --decisions` on a file whose blamed lines span at least 1,200 distinct commits. The command completes without a SQLite expression-depth error and renders all recorded decision annotations.
+
+### S2: Resolve abbreviated commit links at scale
+
+A repository contains `decision_commits` rows with abbreviated commit SHAs. When those links resolve to commits blamed in a high-diversity file, `ec blame --decisions` emits the same canonical full-SHA annotations and deduplication as it does for a small file.
+
+### S3: Preserve partial-history states
+
+A file contains linked commits, commits without recorded decisions, and uncommitted lines. The command continues to render the three states separately after lookup bounding is introduced.
+
+### S4: Keep normal blame behavior unchanged
+
+A developer runs `ec blame --decisions` on an ordinary file. Its output and exit behavior remain unchanged; no new flag, configuration, or operational step is required.
+
+## Scope
+
+### In
+
+- Bound the exact and abbreviated-SHA candidate lookup performed by `annotate_file()`.
+- Preserve parameterized SQL and the existing canonical SHA resolution and annotation deduplication pipeline.
+- Add an adversarial regression using at least 1,200 distinct blamed SHAs with SQLite expression depth lowered to 1,000.
+- Retain existing CLI rendering and error behavior.
+
+### Out
+
+- Changes to the `ec blame` CLI interface or output format.
+- Changes to `decision_commits`, decision schema, or migrations.
+- New dependencies, configuration knobs, or user-tunable batch sizes.
+- Performance redesign of `git blame` itself.
+- General retrieval batching outside decision-annotated blame.
+
+## Assumptions and Preconditions
+
+| Claim | Command | Observed at | Observed result | Evidence source |
+|---|---|---|---|---|
+| The current lookup adds one prefix `OR` predicate per distinct blamed SHA. | `sed -n '128,143p' src/entirecontext/core/blame_decisions.py` | `2026-07-21T04:17:00Z` | One unbounded `prefix_conditions` expression is executed with all blamed SHAs. | Working tree source at `412288f` |
+| SQLite expression depth can be constrained to the common 1,000 boundary in a deterministic regression. | `PYTHONPATH=src .venv/bin/python -c "import sqlite3; from entirecontext.db import get_memory_db; c=get_memory_db(); print(c.getlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH)); c.setlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH,1000); print(c.getlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH))"` | `2026-07-21T04:17:00Z` | The local limit is 10,000 and can be lowered to 1,000 for the test connection. | Python `sqlite3.Connection` runtime |
+| Existing tests already lock abbreviated-link normalization, canonical deduplication, line ranges, and uncommitted ranges. | `rg -n 'test_(abbreviated|uppercase|equivalent|happy_two|line_range|uncommitted)' tests/test_blame_decisions.py` | `2026-07-21T04:17:00Z` | Six focused behavior tests exist in `tests/test_blame_decisions.py`. | Working tree tests at `412288f` |
+| Separating exact and abbreviated candidates gives the two paths different query plans. | `PYTHONPATH=src .venv/bin/python -c "from entirecontext.db import get_memory_db,init_schema;c=get_memory_db();init_schema(c);print([tuple(r) for r in c.execute('EXPLAIN QUERY PLAN SELECT dc.commit_sha FROM decision_commits dc JOIN decisions d ON d.id=dc.decision_id WHERE dc.commit_sha IN (?,?,?)',('a'*40,'b'*40,'c'*40))]);print([tuple(r) for r in c.execute('EXPLAIN QUERY PLAN SELECT dc.commit_sha FROM decision_commits dc JOIN decisions d ON d.id=dc.decision_id WHERE length(dc.commit_sha)>=4 AND length(dc.commit_sha)<?',(40,))])"` | `2026-07-21T04:24:40Z` | Exact `IN` uses `idx_decision_commits_commit_sha`; the abbreviated-length filter scans stored commit links once. | In-memory migrated schema and SQLite query planner |
+| The pre-change suite is green when the worktree uses the repository virtual environment. | `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` | `2026-07-21T04:18:29Z` | 2,093 passed, 1 skipped, 1 warning. | Fresh worktree baseline |
+
+## Approaches Considered
+
+**Approach A: Split exact batches from abbreviated candidates**
+- How: query exact commit links in conservative indexed batches, then load potentially abbreviated links once based on the blamed repository's full SHA width; combine both result sets before the existing resolution and deduplication pass.
+- Pro: removes the unbounded prefix expression, preserves indexed exact lookup, scans abbreviated candidates once rather than once per batch, and avoids a per-SHA query loop.
+- Con: the abbreviated-candidate query still scales with stored commit-link count because prefix matching is not indexable by the existing schema.
+
+**Approach B: Batch the current combined OR query**
+- How: split blamed SHAs into batches and execute the current exact-plus-prefix `OR` query for each batch.
+- Pro: smallest source diff and bounded expression depth.
+- Con: the prefix `OR` makes SQLite scan `decision_commits`; batching repeats that corpus scan for every batch.
+
+**Approach C: Temporary-table join**
+- How: insert blamed SHAs into a temporary table and join it to decision links for exact and prefix matching.
+- Pro: keeps one set-based database operation and scales to very large SHA sets.
+- Con: adds temporary schema lifecycle and transaction behavior to a currently read-only lookup path.
+
+**Recommendation:** Approach A. It removes the accepted P2 failure without repeating a non-indexable prefix scan per batch. Exact batches must contain no more than 400 blamed SHAs, remaining below the legacy 999-variable boundary. Potentially abbreviated links are selected once per blamed full-SHA width and resolved through the existing Git-backed canonicalization path.
+
+## Architecture
+
+`src/entirecontext/core/blame_decisions.py` remains the only production module changed. `annotate_file()` continues to parse porcelain blame output into a deduplicated SHA-to-lines map. The candidate-query stage has two bounded parts:
+
+1. Exact links use `decision_commits.commit_sha IN (...)` in fixed batches of at most 400 so the existing commit-SHA index remains usable.
+2. Potentially abbreviated links are selected once for each full-SHA width present in blame output by requiring stored SHAs to be shorter than that width. Those candidates pass through `_resolve_blamed_sha()` before they can annotate a line.
+
+The combined candidate rows then enter the existing annotation construction path. A real repository uses one Git object format, so the normal path performs one abbreviated-candidate query; mixed-width synthetic input remains bounded to the two parser-supported widths.
+
+Candidate aggregation may return the same stored decision link through both exact and potentially abbreviated paths for mixed-width synthetic input. The existing canonical `(resolved_sha, decision_id)` deduplication remains authoritative, so result semantics do not depend on candidate path.
+
+The design introduces no public module, schema, migration, background work, or cross-repository integration.
+
+## Interface
+
+No public interface changes. These commands retain their current arguments, rendering, and exit behavior:
+
+```console
+ec blame <file> --decisions
+ec blame <file> -L <start>,<end> --decisions
+```
+
+`--summary` remains mutually exclusive with `--decisions`.
+
+## Data Model
+
+No data-model change. The existing `decision_commits(commit_sha)` index supports exact batches. Abbreviated-link selection remains a scan of candidate stored links, but it runs once per blamed full-SHA width rather than once per exact batch.
+
+## Integration
+
+The bounded lookup stays inside the existing `ec blame --decisions` call path. It does not affect archaeology, decision creation, commit-link normalization, MCP tools, or attribution-only blame output.
+
+## Testing
+
+Measurement infrastructure already exists: the real SQLite fixture, `sqlite3.Connection.setlimit()`, and `subprocess` monkeypatching used by `tests/test_blame_decisions.py`. No separate measurement implementation is required.
+
+TDD begins with a failing regression that lowers `SQLITE_LIMIT_EXPR_DEPTH` to 1,000, supplies porcelain output with at least 1,200 distinct full SHAs, includes exact and abbreviated decision links, and asserts successful complete annotation. The same fixture records candidate-query execution and proves three exact batches plus one abbreviated-candidate query, with no exact batch exceeding 400 SHAs. Existing tests then prove normalization, deduplication, line ranges, unlinked ranges, uncommitted ranges, and CLI rendering remain unchanged.
+
+## Risks
+
+- **Candidate duplication:** a stored full link can appear in the exact result while a malformed or mixed-width record also enters abbreviated candidates. Mitigation: retain canonical result deduplication after all rows are aggregated.
+- **Hidden variable-limit failure:** an exact batch can exceed older SQLite parameter limits. Mitigation: cap exact batches at 400 bound parameters.
+- **N+1 regression:** querying once per SHA would avoid the expression limit but scale poorly. Mitigation: require bounded set-based batches, not per-SHA queries.
+- **Abbreviated-link corpus scan:** the existing schema cannot index prefix resolution from stored shorter SHAs to blamed full SHAs. Mitigation: perform the candidate scan once per full-SHA width, then retain Git verification so unrelated rows cannot annotate output.
+- **Test passes only on the local SQLite build:** the local build allows expression depth 10,000. Mitigation: lower the test connection limit to 1,000 explicitly before exercising 1,200 SHAs.
+
+## Success Criteria
+
+1. A 1,200-distinct-SHA blame lookup completes with `SQLITE_LIMIT_EXPR_DEPTH` set to 1,000 and returns the expected exact and abbreviated-link annotations.
+   - **Measured by**: `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k high_distinct_sha_count`
+2. The 1,200-SHA fixture performs exactly three exact candidate queries and one abbreviated-candidate query, with no exact batch exceeding 400 SHAs.
+   - **Measured by**: `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k query_count_is_bounded`
+3. All existing decision-annotated blame behaviors remain green.
+   - **Measured by**: `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py tests/test_blame_cmds.py`
+4. The changed production module passes configured lint and type checking.
+   - **Measured by**: `PATH="$PWD/.venv/bin:$PATH" uv run ruff check src/entirecontext/core/blame_decisions.py tests/test_blame_decisions.py && PATH="$PWD/.venv/bin:$PATH" uv run mypy src/entirecontext/core/blame_decisions.py`
+5. The repository regression suite remains green.
+   - **Measured by**: `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q`
+
+## Open Decisions
+
+None. Planning owns test/implementation sequencing but may not change the public behavior, the split exact/abbreviated lookup shape, the 400-SHA maximum exact batch size, or the adversarial 1,200-SHA/1,000-depth proof without returning to design.

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -100,8 +100,10 @@ def _query_decision_links(
         placeholders = ",".join("?" * len(batch))
         rows.extend(
             conn.execute(  # noqa: S608
-                f"{select} WHERE dc.commit_sha IN ({placeholders})",
-                batch,
+                f"""{select}
+                WHERE dc.commit_sha IN ({placeholders})
+                   OR dc.commit_sha IN ({placeholders})""",
+                [*batch, *(sha.upper() for sha in batch)],
             ).fetchall()
         )
 

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -174,11 +174,14 @@ def annotate_file(
         annotation_keys: set[tuple[str, str]] = set()
         for row in rows:
             stored_sha = row["commit_sha"]
-            if stored_sha.lower() not in blamed_sha_candidates:
+            normalized_stored_sha = stored_sha.lower()
+            if normalized_stored_sha not in blamed_sha_candidates:
                 continue
-            if stored_sha not in resolved_links:
-                resolved_links[stored_sha] = _resolve_blamed_sha(repo_path, stored_sha, blamed_sha_set)
-            resolved_sha = resolved_links[stored_sha]
+            if normalized_stored_sha not in resolved_links:
+                resolved_links[normalized_stored_sha] = _resolve_blamed_sha(
+                    repo_path, stored_sha, blamed_sha_set
+                )
+            resolved_sha = resolved_links[normalized_stored_sha]
             if resolved_sha is None:
                 continue
             annotated_shas.add(resolved_sha)

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -100,10 +100,8 @@ def _query_decision_links(
         placeholders = ",".join("?" * len(batch))
         rows.extend(
             conn.execute(  # noqa: S608
-                f"""{select}
-                WHERE dc.commit_sha IN ({placeholders})
-                   OR dc.commit_sha IN ({placeholders})""",
-                [*batch, *(sha.upper() for sha in batch)],
+                f"{select} WHERE dc.commit_sha IN ({placeholders})",
+                batch,
             ).fetchall()
         )
 
@@ -112,8 +110,10 @@ def _query_decision_links(
             conn.execute(
                 f"""{select}
                 WHERE length(dc.commit_sha) >= 4
-                  AND length(dc.commit_sha) < ?""",
-                (sha_width,),
+                  AND (length(dc.commit_sha) < ?
+                       OR (length(dc.commit_sha) = ?
+                           AND dc.commit_sha != lower(dc.commit_sha)))""",
+                (sha_width, sha_width),
             ).fetchall()
         )
 

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -165,10 +165,17 @@ def annotate_file(
     if shas:
         rows = _query_decision_links(conn, shas)
         blamed_sha_set = set(shas)
+        blamed_sha_candidates = blamed_sha_set | {
+            sha[:prefix_length]
+            for sha in blamed_sha_set
+            for prefix_length in range(4, len(sha))
+        }
         resolved_links: dict[str, str | None] = {}
         annotation_keys: set[tuple[str, str]] = set()
         for row in rows:
             stored_sha = row["commit_sha"]
+            if stored_sha.lower() not in blamed_sha_candidates:
+                continue
             if stored_sha not in resolved_links:
                 resolved_links[stored_sha] = _resolve_blamed_sha(repo_path, stored_sha, blamed_sha_set)
             resolved_sha = resolved_links[stored_sha]

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -11,6 +11,7 @@ from typing import Any
 
 _ZERO_SHAS = {"0" * 40, "0" * 64}
 _HEADER_RE = re.compile(r"^([0-9a-f]{40}|[0-9a-f]{64}) (\d+) (\d+)(?: (\d+))?$")
+_SHA_QUERY_BATCH_SIZE = 400
 
 
 @dataclass
@@ -86,6 +87,37 @@ def _resolve_blamed_sha(repo_path: str, stored_sha: str, blamed_shas: set[str]) 
     return resolved_sha if resolved_sha in blamed_shas else None
 
 
+def _query_decision_links(
+    conn: sqlite3.Connection, blamed_shas: list[str]
+) -> list[sqlite3.Row]:
+    rows: list[sqlite3.Row] = []
+    select = """SELECT dc.commit_sha, d.id, d.title, d.rationale,
+        d.rejected_alternatives, d.staleness_status
+        FROM decision_commits dc JOIN decisions d ON d.id = dc.decision_id"""
+
+    for batch_start in range(0, len(blamed_shas), _SHA_QUERY_BATCH_SIZE):
+        batch = blamed_shas[batch_start : batch_start + _SHA_QUERY_BATCH_SIZE]
+        placeholders = ",".join("?" * len(batch))
+        rows.extend(
+            conn.execute(  # noqa: S608
+                f"{select} WHERE dc.commit_sha IN ({placeholders})",
+                batch,
+            ).fetchall()
+        )
+
+    for sha_width in sorted({len(sha) for sha in blamed_shas}):
+        rows.extend(
+            conn.execute(
+                f"""{select}
+                WHERE length(dc.commit_sha) >= 4
+                  AND length(dc.commit_sha) < ?""",
+                (sha_width,),
+            ).fetchall()
+        )
+
+    return rows
+
+
 def annotate_file(
     conn: sqlite3.Connection,
     repo_path: str,
@@ -129,15 +161,7 @@ def annotate_file(
     annotated_shas: set[str] = set()
 
     if shas:
-        placeholders = ",".join("?" * len(shas))
-        prefix_conditions = " OR ".join("? LIKE dc.commit_sha || '%'" for _ in shas)
-        rows = conn.execute(
-            f"""SELECT dc.commit_sha, d.id, d.title, d.rationale, d.rejected_alternatives, d.staleness_status
-            FROM decision_commits dc JOIN decisions d ON d.id = dc.decision_id
-            WHERE dc.commit_sha IN ({placeholders})
-               OR (length(dc.commit_sha) >= 4 AND ({prefix_conditions}))""",  # noqa: S608
-            [*shas, *shas],
-        ).fetchall()
+        rows = _query_decision_links(conn, shas)
         blamed_sha_set = set(shas)
         resolved_links: dict[str, str | None] = {}
         annotation_keys: set[tuple[str, str]] = set()

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -161,6 +161,17 @@ class TestAnnotateFile:
         assert result["annotations"][0].commit_sha == full_sha
         assert result["annotations"][0].decision_id == decision["id"]
 
+    def test_uppercase_full_commit_link_is_normalized(self, ec_repo, ec_db):
+        full_sha = _commit(ec_repo, "uppercase-full.py", "line1\n", "commit with uppercase full link")
+        decision = create_decision(ec_db, title="Uppercase full SHA decision")
+        link_decision_to_commit(ec_db, decision["id"], full_sha.upper())
+
+        result = annotate_file(ec_db, str(ec_repo), "uppercase-full.py")
+
+        assert result["annotated_sha_count"] == 1
+        assert result["annotations"][0].commit_sha == full_sha
+        assert result["annotations"][0].decision_id == decision["id"]
+
     def test_equivalent_full_and_abbreviated_links_are_deduplicated(self, ec_repo, ec_db):
         full_sha = _commit(ec_repo, "duplicate.py", "line1\n", "commit with duplicate links")
         decision = create_decision(ec_db, title="One decision, two link forms")

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -89,6 +89,38 @@ class TestAnnotateFile:
             assert match is not None
             assert len(match.group(1).split(",")) <= 400
 
+    def test_unrelated_abbreviated_links_do_not_invoke_git_resolution(
+        self, ec_repo, ec_db, monkeypatch
+    ):
+        full_sha = "abcdef0123" * 4
+        relevant_abbreviation = full_sha[:8]
+        decision = create_decision(ec_db, title="Relevant abbreviated SHA decision")
+        commit_links = [relevant_abbreviation, *(f"b{index:07x}" for index in range(1000))]
+        ec_db.executemany(
+            "INSERT INTO decision_commits (decision_id, commit_sha) VALUES (?, ?)",
+            ((decision["id"], commit_sha) for commit_sha in commit_links),
+        )
+        ec_db.commit()
+        blame_output = f"{full_sha} 1 1 1\n\tline1\n"
+        resolved_arguments = []
+
+        def fake_run(command, **kwargs):
+            if command[:3] == ["git", "blame", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, blame_output, "")
+            if command[:3] == ["git", "rev-parse", "--verify"]:
+                resolved_arguments.append(command[3])
+                if command[3] == f"{relevant_abbreviation}^{{commit}}":
+                    return subprocess.CompletedProcess(command, 0, f"{full_sha}\n", "")
+                return subprocess.CompletedProcess(command, 1, "", "unknown revision")
+            raise AssertionError(f"Unexpected subprocess command: {command}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = annotate_file(ec_db, str(ec_repo), "abbreviated-candidates.py")
+
+        assert result["annotated_sha_count"] == 1
+        assert resolved_arguments == [f"{relevant_abbreviation}^{{commit}}"]
+
     def test_non_utf8_file_is_parsed_without_decode_error(self, ec_repo, ec_db):
         (ec_repo / "binary.dat").write_bytes(b"\xff\n")
         subprocess.run(["git", "add", "binary.dat"], cwd=ec_repo, check=True, capture_output=True)

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import sqlite3
 import subprocess
+from itertools import product
 
 from entirecontext.core.blame_decisions import annotate_file
 from entirecontext.core.decisions import create_decision, link_decision_to_commit
@@ -117,6 +118,40 @@ class TestAnnotateFile:
         monkeypatch.setattr(subprocess, "run", fake_run)
 
         result = annotate_file(ec_db, str(ec_repo), "abbreviated-candidates.py")
+
+        assert result["annotated_sha_count"] == 1
+        assert resolved_arguments == [f"{relevant_abbreviation}^{{commit}}"]
+
+    def test_case_variant_abbreviations_share_git_resolution(self, ec_repo, ec_db, monkeypatch):
+        full_sha = "abcdef0123" * 4
+        relevant_abbreviation = full_sha[:8]
+        case_variants = [
+            "".join(characters)
+            for characters in product(
+                *((character.lower(), character.upper()) if character.isalpha() else (character,)
+                  for character in relevant_abbreviation)
+            )
+        ]
+        decision = create_decision(ec_db, title="Case-variant abbreviated SHA decision")
+        ec_db.executemany(
+            "INSERT INTO decision_commits (decision_id, commit_sha) VALUES (?, ?)",
+            ((decision["id"], commit_sha) for commit_sha in case_variants),
+        )
+        ec_db.commit()
+        blame_output = f"{full_sha} 1 1 1\n\tline1\n"
+        resolved_arguments = []
+
+        def fake_run(command, **kwargs):
+            if command[:3] == ["git", "blame", "--porcelain"]:
+                return subprocess.CompletedProcess(command, 0, blame_output, "")
+            if command[:3] == ["git", "rev-parse", "--verify"]:
+                resolved_arguments.append(command[3])
+                return subprocess.CompletedProcess(command, 0, f"{full_sha}\n", "")
+            raise AssertionError(f"Unexpected subprocess command: {command}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = annotate_file(ec_db, str(ec_repo), "case-variant-abbreviations.py")
 
         assert result["annotated_sha_count"] == 1
         assert resolved_arguments == [f"{relevant_abbreviation}^{{commit}}"]

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import sqlite3
 import subprocess
 
 from entirecontext.core.blame_decisions import annotate_file
@@ -16,7 +18,77 @@ def _commit(git_repo, filename: str, content: str, message: str) -> str:
     return result.stdout.strip()
 
 
+def _annotate_high_distinct_sha_file(ec_repo, ec_db, monkeypatch, traced_statements=None):
+    shas = [f"{index:08x}{index:032x}" for index in range(1, 1201)]
+    exact_decision = create_decision(ec_db, title="Exact SHA decision")
+    abbreviated_decision = create_decision(ec_db, title="Abbreviated SHA decision")
+    link_decision_to_commit(ec_db, exact_decision["id"], shas[0])
+    link_decision_to_commit(ec_db, abbreviated_decision["id"], shas[-1][:8])
+    blame_output = "".join(
+        f"{sha} {line_number} {line_number} 1\n\tline {line_number}\n"
+        for line_number, sha in enumerate(shas, start=1)
+    )
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "blame", "--porcelain"]:
+            return subprocess.CompletedProcess(command, 0, blame_output, "")
+        if command[:3] == ["git", "rev-parse", "--verify"]:
+            assert command[3] == f"{shas[-1][:8]}^{{commit}}"
+            return subprocess.CompletedProcess(command, 0, f"{shas[-1]}\n", "")
+        raise AssertionError(f"Unexpected subprocess command: {command}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    previous_limit = ec_db.setlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH, 1000)
+    if traced_statements is not None:
+        ec_db.set_trace_callback(traced_statements.append)
+    try:
+        result = annotate_file(ec_db, str(ec_repo), "large-history.py")
+    finally:
+        ec_db.set_trace_callback(None)
+        ec_db.setlimit(sqlite3.SQLITE_LIMIT_EXPR_DEPTH, previous_limit)
+
+    return result, shas, exact_decision, abbreviated_decision
+
+
 class TestAnnotateFile:
+    def test_high_distinct_sha_count_survives_expression_depth_limit(
+        self, ec_repo, ec_db, monkeypatch
+    ):
+        result, shas, exact_decision, abbreviated_decision = _annotate_high_distinct_sha_file(
+            ec_repo, ec_db, monkeypatch
+        )
+
+        assert result["total_sha_count"] == 1200
+        assert result["annotated_sha_count"] == 2
+        assert {(annotation.commit_sha, annotation.decision_id) for annotation in result["annotations"]} == {
+            (shas[0], exact_decision["id"]),
+            (shas[-1], abbreviated_decision["id"]),
+        }
+
+    def test_high_distinct_sha_query_count_is_bounded(self, ec_repo, ec_db, monkeypatch):
+        traced_statements = []
+
+        _annotate_high_distinct_sha_file(ec_repo, ec_db, monkeypatch, traced_statements)
+
+        candidate_queries = [
+            statement
+            for statement in traced_statements
+            if "FROM decision_commits dc JOIN decisions d" in statement
+        ]
+        exact_queries = [
+            statement for statement in candidate_queries if "WHERE dc.commit_sha IN (" in statement
+        ]
+        abbreviated_queries = [
+            statement for statement in candidate_queries if "length(dc.commit_sha) >= 4" in statement
+        ]
+
+        assert len(exact_queries) == 3
+        assert len(abbreviated_queries) == 1
+        for statement in exact_queries:
+            match = re.search(r"WHERE dc\.commit_sha IN \((.*?)\)", statement, re.DOTALL)
+            assert match is not None
+            assert len(match.group(1).split(",")) <= 400
+
     def test_non_utf8_file_is_parsed_without_decode_error(self, ec_repo, ec_db):
         (ec_repo / "binary.dat").write_bytes(b"\xff\n")
         subprocess.run(["git", "add", "binary.dat"], cwd=ec_repo, check=True, capture_output=True)

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -172,6 +172,25 @@ class TestAnnotateFile:
         assert result["annotations"][0].commit_sha == full_sha
         assert result["annotations"][0].decision_id == decision["id"]
 
+    def test_mixed_case_full_commit_link_is_normalized(self, ec_repo, ec_db, monkeypatch):
+        full_sha = "abcdef0123" * 4
+        mixed_case_sha = "AbCdEf0123" * 4
+        decision = create_decision(ec_db, title="Mixed-case full SHA decision")
+        link_decision_to_commit(ec_db, decision["id"], mixed_case_sha)
+        blame_output = f"{full_sha} 1 1 1\n\tline1\n"
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, blame_output, ""),
+        )
+
+        result = annotate_file(ec_db, str(ec_repo), "mixed-case-full.py")
+
+        assert result["annotated_sha_count"] == 1
+        assert result["annotations"][0].commit_sha == full_sha
+        assert result["annotations"][0].decision_id == decision["id"]
+
     def test_equivalent_full_and_abbreviated_links_are_deduplicated(self, ec_repo, ec_db):
         full_sha = _commit(ec_repo, "duplicate.py", "line1\n", "commit with duplicate links")
         decision = create_decision(ec_db, title="One decision, two link forms")


### PR DESCRIPTION
## Purpose

Complete the ROADMAP P2 carry-forward to keep `ec blame --decisions` reliable when a file contains more distinct commits than SQLite's expression-depth limit.

## Key changes

- split decision-link lookup into indexed exact-SHA batches of at most 400
- replace the per-SHA prefix expression with one bounded candidate scan per object-ID width
- preserve abbreviated and arbitrary-case full-SHA normalization plus canonical annotation deduplication
- add deterministic 1,200-SHA expression-depth and query-count regressions

## Test evidence

- `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py tests/test_blame_cmds.py` -> 32 passed
- `uv run ruff check src/entirecontext/core/blame_decisions.py tests/test_blame_decisions.py` -> passed
- `uv run mypy src/entirecontext/core/blame_decisions.py` -> passed
- `PYTHONPATH=src .venv/bin/pytest -q` -> 2097 passed, 1 skipped, 1 pre-existing warning
- independent U1 and final branch reviews -> Spec PASS, Quality PASS, no open findings

## Traceability

- Roadmap: `ROADMAP.md` P2, "Bound abbreviated-SHA blame lookup complexity"
- Spec: `docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md`
- Plan: `docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md`
