### PR TITLE
docs(roadmap): register MD024 duplicate-heading debt

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -388,6 +388,8 @@ Structural debt outside the "decision memory depth" wedge. The three items previ
 
 All PR #205 carry-forwards are registered under v0.16.0 above.
 
+- [ ] **`distill_lessons` emits duplicate Markdown headings** — `src/entirecontext/core/futures.py:176` builds every `LESSONS.md` heading from `impact_summary` alone, so repeated summaries (`Auto-assessed checkpoint`, identical `chore(deps)` bumps) collide. `markdownlint-cli2` reports MD024 at 6 locations in the current file. Not enforced today: the repository has no `.markdownlint*` config and no markdownlint CI step. Fix requires either adding a unique discriminator (assessment ID) to the heading or documenting an MD024 exemption for generated docs, then regenerating. Surfaced by CodeRabbit review on PR #206. _Priority: Low — cosmetic, unenforced._
+
 ## Later
 
 - [ ] **Sharpen product messaging around decision memory**


### PR DESCRIPTION
## Purpose

Register the one CodeRabbit finding deferred in #206, per the AGENTS.md carry-forward rule that deferrals must be registered in `ROADMAP.md` or marked explicit won't-fix.

## Context

CodeRabbit flagged MD024 duplicate headings in `LESSONS.md` during review of #206 ([discussion](https://github.com/teslamint/entirecontext/pull/206#discussion_r3757905676)). The finding is accurate, but it was deferred there for two reasons:

1. **Not enforced.** No `.markdownlint*` config exists in the repository and no markdownlint step runs in `.github/workflows/`. CI runs ruff, mypy, and pytest only.
2. **Root cause is the generator.** `distill_lessons` (`src/entirecontext/core/futures.py:176`) builds every heading from `impact_summary` alone. Making headings unique changes the output format for all 45 entries — a generator behaviour change outside the scope of #206, which existed to complete the trailing-space fix in 49c5659.

## Change

One entry added to the Hardening Backlog recording the location, the measured impact, the reason it is unenforced, and the two possible fixes.

## Test evidence

Docs-only change to `ROADMAP.md`. No test gate run — no source, config, or CI file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)