### PR TITLE
chore(lint): pin ruff lint select explicitly

### DIFF
--- a/docs/adr/0006-ruff-explicit-lint-select.md
+++ b/docs/adr/0006-ruff-explicit-lint-select.md
@@ -1,0 +1,56 @@
+# 0006. Pin ruff lint select explicitly
+
+**Status:** accepted
+**Date:** 2026-08-11
+**EC Decision:** `55b72138-555e-474c-8764-853999001544`
+
+## Context
+
+`pyproject.toml` configured `[tool.ruff]` with `target-version` and `line-length` only. It set no `select`, so the enforced rule set was whatever ruff shipped as its default in the installed version.
+
+Dependabot PR #202 bumped ruff from 0.15.21 to 0.16.0 and the `lint` job failed. Measured on identical code:
+
+| ruff version | errors |
+|---|---|
+| 0.15.20 | 0 |
+| 0.16.0 | 589 |
+
+No source file changed between those two runs. Ruff 0.16.0 widened its default rule set, so the bump proposed a lint-policy change while presenting as a version bump. The 589 findings break down as 275 autofixable and 314 requiring a human decision.
+
+Three of the largest new rules conflict with product contracts rather than style:
+
+- **BLE001** (110) — broad `except` clauses. Hook handlers must never crash the host session; the hook protocol is a 0/2 return code, not an exception.
+- **PLW1510** (77) — `subprocess.run` without `check=`. Several test fixtures and git helpers deliberately omit it and inspect the result instead.
+- **S110** (36) — `try`/`except`/`pass`, used for the same defensive reason as BLE001.
+
+Silencing these would mean either weakening the defensive behaviour or adding 223 `noqa` comments.
+
+## Decision
+
+Pin the rule set explicitly:
+
+```toml
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+```
+
+This reproduces the previously enforced set. Both 0.15.20 and 0.16.0 report zero errors against it, so the ruff bump becomes a plain dependency update.
+
+Adding rules is now a separate, deliberate change with its own review, not a side effect of a dependabot bump.
+
+## Consequences
+
+**Easier**
+
+- Ruff version bumps stop carrying hidden policy changes. CI failures after a bump indicate a real regression.
+- The enforced rule set is readable in `pyproject.toml` rather than implied by a version number.
+- Rule adoption can be staged one family at a time, each with its own diff and review.
+
+**Harder**
+
+- New ruff rules no longer arrive automatically. Adopting them requires an explicit config change, so useful rules can be missed if nobody revisits the list.
+- The pinned list needs periodic review. Treat a ruff major release as a prompt to compare `select` against the new defaults and decide deliberately.
+
+**Unchanged**
+
+- `uv run ruff check .` remains the CI command. `target-version` and `line-length` are untouched.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ source-include = ["LICENSE", "CHANGELOG.md"]
 target-version = "py312"
 line-length = 120
 
+# Pinned explicitly so the enforced rule set does not change when ruff ships a
+# new default. Adding rules is a deliberate decision, not a side effect of a
+# version bump. See docs/adr/0006-ruff-explicit-lint-select.md.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true


### PR DESCRIPTION
## Purpose

Unblock the ruff 0.16.0 bump (#202) by making the repository's lint policy explicit, so a version bump stops carrying a rule-set change with it.

## What #202 actually proposed

`pyproject.toml` had `[tool.ruff]` with `target-version` and `line-length` only — no `select`. The enforced rule set was therefore whatever ruff shipped as its default in the installed version.

Measured on identical code, no source file changed between the two runs:

| ruff version | errors |
|---|---|
| 0.15.20 | 0 |
| 0.16.0 | 589 |

Ruff 0.16.0 widened its default rule set. #202's `lint` failure is not a code regression — it is a lint-policy change presenting as a dependency bump.

## Why not adopt the new rules here

589 findings split into 275 autofixable and 314 needing a human decision. The three largest new rules collide with product contracts rather than style:

| rule | count | conflict |
|---|---|---|
| BLE001 | 110 | Hook handlers must never crash the host session — the protocol is a 0/2 return code, not an exception |
| PLW1510 | 77 | Test fixtures and git helpers deliberately omit `check=` and inspect the result instead |
| S110 | 36 | Same defensive intent as BLE001 |

Silencing those means either weakening the defensive behaviour or adding 223 `noqa` comments. Adopting rules stays available as a separate, deliberate change with its own review.

## Change

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```

Plus ADR 0006 recording the decision, the rejected alternative, and the periodic-review consequence.

## Test evidence

The acceptance criterion is that both ruff versions agree on the pinned config:

```
uv run ruff check .        (0.15.20)  ->  All checks passed!
uvx ruff@0.16.0 check .    (0.16.0)   ->  All checks passed!
```

No test suite run: this changes lint configuration only. `pytest` does not read `[tool.ruff.lint]`, and no source, CI, or runtime file is touched. CI runs the full suite on this PR regardless.

## Note on an unrelated pre-existing state

`uv run ruff format --check .` reports 44 files would be reformatted. This is pre-existing — the same count appears with `pyproject.toml` stashed — and CI does not run `ruff format --check` (`.github/workflows/ci.yml:31` runs `ruff check .` only). Left untouched as out of scope.

## Follow-up

After this merges, `@dependabot rebase` on #202 and merge it as a plain dependency update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
