### PR TITLE
docs(retro): land blame SHA lookup retro and cost-domain concepts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 CLAUDE.md and AGENTS.md are independently maintained. CLAUDE.md carries compact project reference and review principles; AGENTS.md carries workflow policies.
 
+Durable solved-problem guidance is indexed under `docs/solutions/`; shared domain vocabulary is defined in `CONCEPTS.md`.
+
 After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
 
 ## Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Time-travel searchable agent memory anchored to git state. Python 3.12+, uv, SQL
 
 After `uv sync` that touches `mcp/` or `core/decisions.py`, restart Claude Code — the stdio MCP server does not auto-reload.
 
-Durable guidance from solved problems lives under `docs/solutions/`; check the relevant category before repeating a diagnosis.
+Durable guidance from solved problems lives under `docs/solutions/`; check the relevant category before repeating a diagnosis. Shared domain vocabulary lives in `CONCEPTS.md`.
 
 ## Test
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,9 @@
+# Concepts
+
+## Lookup pipelines
+
+**Cost domain** — An independently scaling resource dimension within a pipeline. Bounding one cost domain does not establish a bound on another.
+
+**Lookup pipeline** — A sequence that retrieves candidates, filters them, resolves external identities, and assembles results. Each transition can introduce a separate multiplicative cost.
+
+**Cache identity** — The canonical representation used to decide whether two lookups can reuse one result. It must match the lookup's equivalence rules.

--- a/docs/retros/2026-07-21-blame-sha-lookup-complexity-retro.md
+++ b/docs/retros/2026-07-21-blame-sha-lookup-complexity-retro.md
@@ -1,0 +1,96 @@
+# Retro: Bound Abbreviated-SHA Blame Lookup Complexity
+
+- Date: 2026-07-21
+- Source: PR #199
+- Spec: `docs/specs/2026-07-21-blame-sha-lookup-complexity-design.md`
+- Plan: `docs/plans/2026-07-21-001-fix-blame-sha-lookup-complexity-plan.md`
+
+## Release data
+
+| Metric | Value |
+|---|---|
+| **Changed non-test lines** | 388 (355 added + 33 removed) |
+| Commits | 18 branch commits, squash-merged as `5a24ebf` |
+| Review rounds | 5 (3 unit rounds + 1 branch review + 1 PR feedback round) |
+| Comments (fixed / deferred) | 1 / 0 |
+| CI failures | 0 across 3 green runs |
+| Duration (first spec commit → merge) | 0.13 days (3h 12m 54s) |
+| Units planned / completed | 1 / 1 |
+
+## Success criteria: measured vs declared
+
+| # | Declared criterion | Measurement (command / rubric) | Measured result | Verdict |
+|---|---|---|---|---|
+| 1 | A 1,200-distinct-SHA blame lookup completes with `SQLITE_LIMIT_EXPR_DEPTH` set to 1,000 and returns the expected exact and abbreviated-link annotations. | `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k high_distinct_sha_count` | Fresh retro run: 1 passed, 19 deselected. | **Met** |
+| 2 | The 1,200-SHA fixture performs exactly three exact candidate queries and one abbreviated-candidate query, with no exact batch exceeding 400 SHAs. | `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py -k query_count_is_bounded` | Fresh retro run: 1 passed, 19 deselected. | **Met** |
+| 3 | All existing decision-annotated blame behaviors remain green. | `PYTHONPATH=src .venv/bin/pytest -q tests/test_blame_decisions.py tests/test_blame_cmds.py` | Fresh retro run: 34 passed. | **Met** |
+| 4 | The changed production module passes configured lint and type checking. | `PATH="$PWD/.venv/bin:$PATH" uv run ruff check src/entirecontext/core/blame_decisions.py tests/test_blame_decisions.py && PATH="$PWD/.venv/bin:$PATH" uv run mypy src/entirecontext/core/blame_decisions.py` | Fresh retro run: Ruff reported `All checks passed!`; mypy reported `Success: no issues found in 1 source file`. | **Met** |
+| 5 | The repository regression suite remains green. | `PATH="$PWD/.venv/bin:$PATH" UV_CACHE_DIR=/tmp/uv-cache PYTHONPATH=src .venv/bin/pytest -q` | Fresh retro run: 2,099 passed, 1 skipped, 1 pre-existing fixture warning in 138.74s. | **Met** |
+
+## Carry-forward from previous retro
+
+| Item | Status | Evidence |
+|---|---|---|
+| Bound abbreviated-SHA blame lookup complexity | Done | PR #199, merge `5a24ebf`, and all five fresh success measurements above; `ROADMAP.md` marks the item complete. (T3) |
+| Post-squash archaeology convergence | Not started | `ROADMAP.md` retains the item as unchecked; no explicit repository-content export authorization was supplied. (T3) |
+| TQL `--until` for local semantic search | Not started | `src/entirecontext/cli/search_cmds.py:90-103` passes `since` but not `until` to `semantic_search`. (T3) |
+| TQL `--until` for global cross-repo search | Not started | `src/entirecontext/core/cross_repo.py:180-241` accepts and forwards `since` but has no `until` parameter. (T3) |
+| Maturity 75 dogfooding with `ec context apply` | In progress | `ROADMAP.md` retains this as an ongoing measurement item. (T3) |
+| Consolidate PR fetch-result and processing-state branches in archaeology | Not started | `src/entirecontext/core/archaeology.py:447-496` still carries separate skip, token, batch, and final-batch transitions. (T3) |
+| General Git C-style escaped paths | Not started | `src/entirecontext/core/archaeology.py:35-45` still decodes octal escapes only. (T3) |
+
+- Previous doc shape: pre-schema, exempt
+
+## Interview Transcript
+
+- Independence level: same-model fresh-context
+- Rounds used: 2 (max 5)
+
+| ID | Round | Phase | Probe | Answer | Evidence | Verdict (verbatim) |
+|---|---|---|---|---|---|---|
+| T1 | 1 | 5 | What specifically prevented the original SQLite failure from recurring without merely moving unbounded work into Git subprocesses? | Exact SQL lookup is capped at 400 SHAs per batch and abbreviated candidates are scanned once per SHA width. Blamed-prefix filtering prevents unrelated candidates from reaching Git, while lowercase cache keys collapse case variants. | `src/entirecontext/core/blame_decisions.py:90-120,165-183`; `tests/test_blame_decisions.py:55-157`; `.release-loop/progress.md` feedback round 1; merge `5a24ebf`. | accepted |
+| T2 | 1 | 5 | What took meaningfully longer than the original minimum implementation, and what should a future plan test earlier? | Review exposed uppercase and mixed-case full-SHA behavior, unrelated abbreviated candidates, and case-variant cache misses after the initial batching implementation. Future Git/SQLite boundary plans should jointly test SQL expression/query counts, candidate cardinality, subprocess calls, and cache-key normalization. | `.release-loop/progress.md` unit review rounds 1–3 and feedback round 1; merged tests in `5a24ebf`; `review_rounds=3`, `feedback_rounds=1`, `comments_fixed=1`. | accepted |
+| T3 | 2 | 4 | Did this cycle close the previous P2 carry-forward and silently drop any of the other six prior items? | It closed only `Bound abbreviated-SHA blame lookup complexity`. The other six items remain explicitly tracked with supported statuses, and PR #199 introduced no deferred item because its sole actionable comment was fixed before merge. | `ROADMAP.md:350-357`; prior retro carry-forward table; PR #199 / `5a24ebf`; fresh success measurements; `src/entirecontext/cli/search_cmds.py:90-103`; `src/entirecontext/core/cross_repo.py:180-241`; `src/entirecontext/core/archaeology.py:35-45,381-507`; `.release-loop/progress.md`. | accepted |
+| T4 | 1 | 5 | Which claim is reusable beyond this feature, and what is the concrete rule? | A bound in one cost domain does not bound downstream work. Lookup pipelines should assert bounds at database expressions and queries, candidate rows, subprocess calls, and cache identities, with key normalization matching lookup equivalence. | The initial SQL-focused implementation passed before PR feedback exposed 1,000 Git calls; `tests/test_blame_decisions.py:69-157`; `.release-loop/progress.md` records the causal sequence. | accepted |
+
+## Findings
+
+### What worked well
+
+- **What happened**: PR #199 replaced the expression-depth failure with three exact indexed queries plus one candidate scan for 1,200 SHAs, then bounded Git resolution for 1,000 unrelated links and 64 case variants.
+  **Why**: review followed the candidate set across SQL, Python filtering, Git subprocesses, and cache identity instead of stopping after the database test passed.
+  **How to apply**: keep a regression assertion at every multiplicative boundary in lookup pipelines.
+  **Cites**: T1; Phase 2–3 data
+
+- **What happened**: all five declared success criteria passed in fresh post-merge runs, including 2,099 repository tests.
+  **Why**: each criterion named an executable measurement before implementation, and the retro reran those exact commands rather than citing PR claims.
+  **How to apply**: retain command-shaped criteria for storage-engine limits and query-shape guarantees.
+  **Cites**: Phase 2–3 data
+
+### What to improve
+
+- **What happened**: the first green implementation bounded SQLite expressions but still allowed 1,000 unrelated candidates to trigger 1,000 `git rev-parse` calls; a later review also found case variants bypassed the cache.
+  **Why**: the original success criteria measured SQL query shape but not downstream candidate cardinality, subprocess count, or cache-key equivalence.
+  **How to apply**: define one complexity budget spanning database expressions, candidate rows, external calls, and normalized cache identities before implementation.
+  **Cites**: T1; T2; T4
+
+### Process observations
+
+- **What happened**: the minimum batching change was followed by three unit review rounds and one PR feedback round covering uppercase full SHAs, mixed-case full SHAs, unrelated abbreviated candidates, and case-variant cache misses.
+  **Why**: representation and cost-boundary cases were broader than the initial SQL failure mode.
+  **How to apply**: add a boundary-matrix test pass before the first implementation review for code that joins Git identifiers with SQLite records.
+  **Cites**: T2; Phase 2 release data
+
+## Carry-forward items registered
+
+| Item | Type | Priority | Tracked at |
+|---|---|---|---|
+| None this cycle | — | — | The six unresolved prior items remain in `ROADMAP.md`; PR #199 deferred zero comments. |
+
+## Lessons
+
+- **“A bound in one cost domain does not bound the pipeline.”** Assert limits at database expressions and queries, candidate rows, subprocess calls, and cache identities, and normalize keys at the same equivalence boundary used for matching.
+
+## Compounding
+
+- compound invocation: `Documentation complete — docs/solutions/performance-issues/bound-cost-across-lookup-pipeline-domains.md`

--- a/docs/solutions/performance-issues/bound-cost-across-lookup-pipeline-domains.md
+++ b/docs/solutions/performance-issues/bound-cost-across-lookup-pipeline-domains.md
@@ -1,0 +1,55 @@
+---
+module: blame-decisions
+date: 2026-07-21
+problem_type: performance_issue
+component: sha-lookup-pipeline
+severity: medium
+symptoms:
+  - "A 1,200-SHA lookup exceeded SQLite's expression-depth limit"
+  - "Unrelated abbreviated links caused unnecessary Git subprocess calls"
+  - "Case variants bypassed the resolution cache"
+root_cause: a bound at the SQL expression layer did not bound downstream candidate and subprocess work
+resolution_type: code_fix
+applies_when:
+  - "A lookup pipeline crosses database, in-process filtering, and subprocess boundaries"
+  - "Equivalent identifiers can differ by case, abbreviation, or representation"
+related_components:
+  - sqlite-candidate-query
+  - git-sha-resolution
+tags:
+  - complexity-budgets
+  - database-queries
+  - candidate-filtering
+  - subprocess-bounds
+  - cache-normalization
+---
+
+# Bound cost across lookup pipeline domains
+
+## Problem
+
+`ec blame --decisions` built one SQL expression containing an exact match and one abbreviated-SHA prefix predicate per blamed SHA. A file spanning 1,200 distinct SHAs exceeded SQLite's expression-depth limit of 1,000.
+
+## Symptoms
+
+- The 1,200-SHA lookup raised a SQLite expression-depth error.
+- The first SQL-only fix still let 1,000 unrelated abbreviated links trigger 1,000 unnecessary `git rev-parse` calls.
+- Sixty-four case variants of the same abbreviation bypassed the resolution cache and repeated equivalent work.
+
+## What Didn't Work
+
+Batching the original combined exact-plus-prefix query bounded expression depth but repeated the non-indexable `decision_commits` scan for every batch. The initial split-query implementation fixed SQLite complexity but did not bound downstream Git work: it passed every abbreviated candidate to Git and cached by the unnormalized stored SHA.
+
+## Solution
+
+Set the exact batch size to 400 and split candidate retrieval into indexed exact `IN` queries plus one abbreviated-candidate scan per blamed SHA width. For 1,200 SHA-1 values, this produces exactly three exact queries and one abbreviated query—the 3+1 SQL shape.
+
+Before Git resolution, build the normalized set of blamed full SHAs and all valid prefixes, discard unrelated candidates, and cache resolutions by lowercase SHA. Keep Git verification and canonical `(resolved_sha, decision_id)` deduplication authoritative.
+
+## Why This Works
+
+Each exact query stays below SQLite expression and variable limits while preserving index use. The abbreviated corpus is scanned once rather than once per exact batch. Prefix filtering prevents the 1,000 unrelated links from reaching Git, and lowercase cache identities collapse all 64 case variants to one resolution. Exact and abbreviated annotations retain the existing public behavior.
+
+## Prevention
+
+For lookup pipelines, define and test one end-to-end complexity budget across every multiplicative boundary: database expression size, query count, candidate rows, external-process calls, and cache identities. Normalize cache keys at the same equivalence boundary used for matching.


### PR DESCRIPTION
## Purpose

Recover unmerged documentation from the stale local branch `docs/blame-sha-lookup-retro` (last commit 2026-07-21), rebased onto current main. Found during a branch audit; the work had no PR and would have been lost with the branch.

## What was missing from main

| File | Status |
|---|---|
| `docs/retros/2026-07-21-blame-sha-lookup-complexity-retro.md` | absent |
| `docs/solutions/performance-issues/bound-cost-across-lookup-pipeline-domains.md` | absent (new category directory) |
| `CONCEPTS.md` | absent |
| `AGENTS.md` / `CLAUDE.md` pointers to `CONCEPTS.md` | absent |

## What was dropped from the original branch

Two hunks were deliberately not carried over:

1. **`ROADMAP.md`** — the branch marked the "Bound abbreviated-SHA blame lookup complexity" carry-forward as complete. Main already does this, with a more precise reference (`5a24ebf`, PR #199). Applying the branch version would have regressed the wording.
2. **`.release-loop/progress.md`** — a live working file. Main archived the equivalent content at `.release-loop/archive/2026-07-21-blame-sha-lookup-complexity-progress.md`.

## Accuracy check

The solutions document is verified against current main, not just against the state it was written on:

- Claim: "Set the exact batch size to 400."
- Code: `src/entirecontext/core/blame_decisions.py:14` — `_SHA_QUERY_BATCH_SIZE = 400`

Its description of the 3+1 SQL shape, prefix filtering before Git resolution, and lowercase cache identity matches main's own ROADMAP text for the completed item.

## Test evidence

Docs-only change. No source, config, or CI file is touched, so no test gate was run locally. CI runs the full suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)