### PR TITLE
chore(ci): enforce ruff format, excluding Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Lint
         run: uv run ruff check .
 
+      - name: Format
+        run: uv run ruff format --check .
+
   type-check:
     runs-on: ubuntu-latest
     steps:

--- a/docs/adr/0007-ruff-format-enforced.md
+++ b/docs/adr/0007-ruff-format-enforced.md
@@ -1,0 +1,50 @@
+# 0007. Enforce ruff format in CI, excluding Markdown
+
+**Status:** accepted
+**Date:** 2026-08-12
+**EC Decision:** `22452eb2-160d-45a7-bb24-4f87eaacd234`
+
+## Context
+
+CI ran `uv run ruff check .` but never `ruff format --check`. Formatting was therefore advisory: 44 Python files had drifted from `ruff format` output without anyone noticing, because nothing measured it.
+
+This is the same failure shape as ADR 0006. There, the enforced lint rule set was implicit in the ruff version; here, formatting was enforced nowhere at all. In both cases the gap only surfaced when something external forced a look.
+
+Ruff 0.16 introduced a second consideration: it formats Python code blocks inside Markdown. With Markdown in scope, the drift is 58 files rather than 44. The extra 14 are all under `docs/superpowers/` — plans and specifications that record what was proposed at a point in time. Reformatting a snippet inside a historical plan changes the record of what was written, for no benefit to shipped code.
+
+## Decision
+
+Enforce formatting in CI, and exclude Markdown from formatting only:
+
+```toml
+[tool.ruff.format]
+exclude = ["docs/**/*.md"]
+```
+
+```yaml
+- name: Format
+  run: uv run ruff format --check .
+```
+
+The exclusion is scoped to `[tool.ruff.format]`, so lint coverage is unchanged. Reformatting the 44 Python files is a separate mechanical commit in the same PR.
+
+## Consequences
+
+**Easier**
+
+- Format drift cannot accumulate silently. The next drift is one file in one PR, not 44 across an unknown span.
+- Review diffs stop carrying incidental reformatting noise from editors with different settings.
+
+**Harder**
+
+- The reformat commit touches 44 files and will conflict with any long-running branch that edits the same lines. At the time of this decision, the two live worktrees (`feat/roadmap-completion`, `docs/blame-sha-lookup-retro`) had zero overlap with the reformatted set, but future large branches will need a rebase.
+- Markdown code blocks are now unformatted by policy. If a future document wants formatted snippets, it must be written that way by hand or moved outside `docs/`.
+
+**Unchanged**
+
+- `[tool.ruff.lint] select` from ADR 0006, `target-version`, and `line-length`.
+- Lint scope. The exclusion applies to the formatter only.
+
+## Related
+
+- [0006](0006-ruff-explicit-lint-select.md) — the lint-side counterpart. Together these make both halves of the ruff configuration explicit rather than inherited.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,13 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]
 
+# Markdown under docs/ is excluded from formatting only. Ruff 0.16 formats Python
+# code blocks inside Markdown, which would rewrite the snippets in historical
+# plans and specs — those record what was proposed at the time, not shipped code.
+# Lint scope is unaffected. See docs/adr/0007-ruff-format-enforced.md.
+[tool.ruff.format]
+exclude = ["docs/**/*.md"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/scripts/experiments/analyze_blocks.py
+++ b/scripts/experiments/analyze_blocks.py
@@ -73,9 +73,7 @@ def sessions_in_block(conn: sqlite3.Connection, start: str, end: str | None) -> 
     return [dict(r) for r in rows]
 
 
-def manual_retrieval_count(
-    conn: sqlite3.Connection, session_ids: list[str], start: str, end: str | None
-) -> int:
+def manual_retrieval_count(conn: sqlite3.Connection, session_ids: list[str], start: str, end: str | None) -> int:
     """Count manual retrieval events (non-proactive) in given sessions within a time window."""
     if not session_ids:
         return 0
@@ -127,7 +125,9 @@ def analyze(conn: sqlite3.Connection, blocks: list[dict]) -> dict:
                 "pair": (on_b["block_id"], off_b["block_id"]),
                 "on_sessions": on_b["qualifying_sessions"],
                 "off_sessions": off_b["qualifying_sessions"],
-                "avg_turns_delta": round(on_turns - off_turns, 3) if on_turns is not None and off_turns is not None else None,
+                "avg_turns_delta": round(on_turns - off_turns, 3)
+                if on_turns is not None and off_turns is not None
+                else None,
                 "manual_retrieval_delta": on_b["manual_retrieval_events"] - off_b["manual_retrieval_events"],
             }
         )
@@ -171,7 +171,9 @@ def main() -> None:
     if result["pair_deltas"]:
         print("\nPer-pair deltas (ON - OFF):")
         for pd in result["pair_deltas"]:
-            print(f"  Pair {pd['pair']}: avg_turns_delta={pd['avg_turns_delta']}, manual_retrieval_delta={pd['manual_retrieval_delta']}")
+            print(
+                f"  Pair {pd['pair']}: avg_turns_delta={pd['avg_turns_delta']}, manual_retrieval_delta={pd['manual_retrieval_delta']}"
+            )
     if result["pairs"] < 4:
         print("WARNING: <4 block pairs. Directional signal only; do not claim significance.")
     comp = result["compensation_check"]

--- a/scripts/experiments/flip_block.py
+++ b/scripts/experiments/flip_block.py
@@ -59,9 +59,7 @@ def update_config_toml(config_path: Path, block_value: str) -> None:
     """Set experiment_block in the config TOML file."""
     if not config_path.exists():
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(
-            f"[decisions.injection]\nexperiment_block = \"{block_value}\"\n"
-        )
+        config_path.write_text(f'[decisions.injection]\nexperiment_block = "{block_value}"\n')
         return
 
     content = config_path.read_text()
@@ -134,7 +132,7 @@ def flip(
     update_config_toml(config_path, block_value)
 
     print(f"FLIPPED to block {new_block['block_id']} (injection={'ON' if new_injection else 'OFF'})")
-    print(f"Config updated: experiment_block = \"{block_value}\"")
+    print(f'Config updated: experiment_block = "{block_value}"')
     return new_block
 
 
@@ -157,7 +155,7 @@ def main() -> None:
         entry = init_block(blocks_path)
         update_config_toml(config_path, "on")
         print(f"Initialized block 1 (injection=ON) at {entry['started_at']}")
-        print("Config updated: experiment_block = \"on\"")
+        print('Config updated: experiment_block = "on"')
         return
 
     if not Path(args.db).exists():

--- a/scripts/experiments/sample_outcome_audit.py
+++ b/scripts/experiments/sample_outcome_audit.py
@@ -29,7 +29,7 @@ def _normalize_to_relative(path: str, repo_root: str) -> str:
     """Strip repo root prefix from an absolute path to get a relative path."""
     prefix = repo_root.rstrip(os.sep) + os.sep
     if path.startswith(prefix):
-        return path[len(prefix):]
+        return path[len(prefix) :]
     return path
 
 
@@ -66,9 +66,7 @@ def _relevant_content_paths(
     return selected[:5]
 
 
-def sample_accepted_outcomes(
-    conn: sqlite3.Connection, n: int = 50, repo_root: str = "."
-) -> list[dict]:
+def sample_accepted_outcomes(conn: sqlite3.Connection, n: int = 50, repo_root: str = ".") -> list[dict]:
     """Sample N auto-inferred 'accepted' outcomes, label-blinded."""
     rows = conn.execute(
         """
@@ -112,9 +110,7 @@ def sample_accepted_outcomes(
                 try:
                     parsed = json.loads(turn["files_touched"])
                     if isinstance(parsed, list):
-                        files_touched_all.update(
-                            _normalize_to_relative(f, repo_root_abs) for f in parsed
-                        )
+                        files_touched_all.update(_normalize_to_relative(f, repo_root_abs) for f in parsed)
                 except (json.JSONDecodeError, TypeError):
                     pass
 

--- a/src/entirecontext/cli/archaeology_cmds.py
+++ b/src/entirecontext/cli/archaeology_cmds.py
@@ -33,9 +33,7 @@ def archaeologize(
     arch_config = config.get("decisions", {}).get("archaeology", {})
 
     if not arch_config.get("enabled", True):
-        console.print(
-            "[yellow]Archaeology is disabled in config. Set [decisions.archaeology] enabled = true.[/yellow]"
-        )
+        console.print("[yellow]Archaeology is disabled in config. Set [decisions.archaeology] enabled = true.[/yellow]")
         raise typer.Exit(1)
 
     if limit <= 0:

--- a/src/entirecontext/cli/blame_cmds.py
+++ b/src/entirecontext/cli/blame_cmds.py
@@ -135,8 +135,7 @@ def _render_decision_annotations(file: str, decision_result: dict) -> None:
 
     for s, e in unlinked_ranges:
         console.print(
-            f"  lines {s}-{e}: no recorded decision "
-            "(absence of links, not evidence that no decisions were made)"
+            f"  lines {s}-{e}: no recorded decision (absence of links, not evidence that no decisions were made)"
         )
 
     for s, e in uncommitted_ranges:

--- a/src/entirecontext/cli/compact_cmds.py
+++ b/src/entirecontext/cli/compact_cmds.py
@@ -54,7 +54,9 @@ def compact_cmd(
     db_path = Path(repo_path) / ".entirecontext" / "db" / "local.db"
     if not db_path.exists():
         if execute:
-            console.print("[red]No EntireContext database — refusing to execute (would treat all content as orphans).[/red]")
+            console.print(
+                "[red]No EntireContext database — refusing to execute (would treat all content as orphans).[/red]"
+            )
             raise typer.Exit(1)
         console.print("[dim]No EntireContext database found — nothing to compact.[/dim]")
         return
@@ -62,9 +64,7 @@ def compact_cmd(
     conn = get_db(repo_path)
     try:
         check_and_migrate(conn)
-        report = compact_repo(
-            conn, repo_path, retention_days=retention_days, limit=limit, dry_run=not execute
-        )
+        report = compact_repo(conn, repo_path, retention_days=retention_days, limit=limit, dry_run=not execute)
     finally:
         conn.close()
 
@@ -99,7 +99,9 @@ def _print_report(report: dict[str, Any]) -> None:
         console.print(f"  [green]Freed: {_format_bytes(orphans['bytes_freed'])}[/green]")
 
     if vacuum:
-        console.print(f"\n[bold]DB vacuum:[/bold] {_format_bytes(vacuum['db_before'])} → {_format_bytes(vacuum['db_after'])}")
+        console.print(
+            f"\n[bold]DB vacuum:[/bold] {_format_bytes(vacuum['db_before'])} → {_format_bytes(vacuum['db_after'])}"
+        )
 
 
 def register(app: typer.Typer) -> None:

--- a/src/entirecontext/core/archaeology.py
+++ b/src/entirecontext/core/archaeology.py
@@ -51,7 +51,7 @@ def _is_github_remote(url: str) -> bool:
         return host == "github.com"
     for prefix in ("https://", "http://", "ssh://"):
         if url.startswith(prefix):
-            host = url[len(prefix):].split("/", 1)[0].split("@")[-1].split(":")[0]
+            host = url[len(prefix) :].split("/", 1)[0].split("@")[-1].split(":")[0]
             return host == "github.com"
     return False
 
@@ -68,13 +68,13 @@ def _extract_files_from_patch(patch_text: str) -> list[str]:
             marker = f"{prefix}/"
             if not path.startswith(marker):
                 return None
-            path = path[len(marker):]
+            path = path[len(marker) :]
         return _decode_git_quoted_path(path)
 
     def header_fallback(payload: str) -> str | None:
         for separator in re.finditer(r' (?="?b/)', payload):
-            source = normalize(payload[:separator.start()], "a")
-            destination = normalize(payload[separator.end():], "b")
+            source = normalize(payload[: separator.start()], "a")
+            destination = normalize(payload[separator.end() :], "b")
             if source is not None and source == destination:
                 return destination
         return None
@@ -105,9 +105,7 @@ def _extract_files_from_patch(patch_text: str) -> list[str]:
     return files
 
 
-def _build_signal_bundle(
-    commit_sha: str, message: str, patch_text: str, pr_body: str | None
-) -> SignalBundle:
+def _build_signal_bundle(commit_sha: str, message: str, patch_text: str, pr_body: str | None) -> SignalBundle:
     text_blocks = []
     if message:
         text_blocks.append(message)
@@ -152,22 +150,16 @@ class _ProcessingState:
             needs_pr=pr_bodies and not self.pr_body_processed,
         )
 
-    def resolve_pr_completion(
-        self, pr_fetch: _PrBodyFetch | None, parsed_ok: bool
-    ) -> bool:
+    def resolve_pr_completion(self, pr_fetch: _PrBodyFetch | None, parsed_ok: bool) -> bool:
         if pr_fetch is None:
             return False
-        return (
-            pr_fetch.status is _PrBodyStatus.EMPTY
-            or (pr_fetch.status is _PrBodyStatus.FOUND and parsed_ok)
-        )
+        return pr_fetch.status is _PrBodyStatus.EMPTY or (pr_fetch.status is _PrBodyStatus.FOUND and parsed_ok)
 
 
 def _get_processing_state(conn: sqlite3.Connection, commit_sha: str) -> _ProcessingState:
     try:
         row = conn.execute(
-            "SELECT candidate_count, pr_body_processed "
-            "FROM archaeology_processed WHERE commit_sha = ?",
+            "SELECT candidate_count, pr_body_processed FROM archaeology_processed WHERE commit_sha = ?",
             (commit_sha,),
         ).fetchone()
     except sqlite3.OperationalError as exc:
@@ -232,8 +224,14 @@ def _stream_commits(
     # on \x00 with maxsplit=2 to get (sha, message, patch). %B (not %s) is
     # used so the full commit body reaches the bundle, not just the subject.
     cmd = [
-        "git", "log", "--patch", "--reverse", "--no-merges",
-        "--no-color", "--src-prefix=a/", "--dst-prefix=b/",
+        "git",
+        "log",
+        "--patch",
+        "--reverse",
+        "--no-merges",
+        "--no-color",
+        "--src-prefix=a/",
+        "--dst-prefix=b/",
         "--format=%x1e%H%x00%B%x00",
     ]
 
@@ -285,7 +283,7 @@ def _stream_commits(
             while "\x1e" in buf:
                 idx = buf.index("\x1e")
                 record = buf[:idx].strip()
-                buf = buf[idx + 1:]
+                buf = buf[idx + 1 :]
                 if not record:
                     continue
                 parts = record.split("\x00", maxsplit=2)
@@ -594,9 +592,7 @@ def _process_batch(
                     conn,
                     sha,
                     outcome.candidates_inserted,
-                    pr_body_processed=state.resolve_pr_completion(
-                        pr_fetch, outcome.parsed_ok
-                    ),
+                    pr_body_processed=state.resolve_pr_completion(pr_fetch, outcome.parsed_ok),
                 )
                 result.commits_processed += 1
                 result.candidates_generated += outcome.candidates_inserted

--- a/src/entirecontext/core/auto_apply.py
+++ b/src/entirecontext/core/auto_apply.py
@@ -381,9 +381,7 @@ def _classify_diff_pattern(repo_path: str, session_id: str, overlap_files: list[
     # would inflate total_added and flip replaced→refined.
     try:
         status_cmd = ["git", "status", "--porcelain", "--"] + overlap_files
-        status_result = subprocess.run(
-            status_cmd, cwd=repo_path, capture_output=True, text=True, timeout=5
-        )
+        status_result = subprocess.run(status_cmd, cwd=repo_path, capture_output=True, text=True, timeout=5)
         if status_result.returncode == 0:
             for sline in status_result.stdout.strip().splitlines():
                 if sline.startswith("??"):

--- a/src/entirecontext/core/blame_decisions.py
+++ b/src/entirecontext/core/blame_decisions.py
@@ -87,9 +87,7 @@ def _resolve_blamed_sha(repo_path: str, stored_sha: str, blamed_shas: set[str]) 
     return resolved_sha if resolved_sha in blamed_shas else None
 
 
-def _query_decision_links(
-    conn: sqlite3.Connection, blamed_shas: list[str]
-) -> list[sqlite3.Row]:
+def _query_decision_links(conn: sqlite3.Connection, blamed_shas: list[str]) -> list[sqlite3.Row]:
     rows: list[sqlite3.Row] = []
     select = """SELECT dc.commit_sha, d.id, d.title, d.rationale,
         d.rejected_alternatives, d.staleness_status
@@ -166,9 +164,7 @@ def annotate_file(
         rows = _query_decision_links(conn, shas)
         blamed_sha_set = set(shas)
         blamed_sha_candidates = blamed_sha_set | {
-            sha[:prefix_length]
-            for sha in blamed_sha_set
-            for prefix_length in range(4, len(sha))
+            sha[:prefix_length] for sha in blamed_sha_set for prefix_length in range(4, len(sha))
         }
         resolved_links: dict[str, str | None] = {}
         annotation_keys: set[tuple[str, str]] = set()
@@ -178,9 +174,7 @@ def annotate_file(
             if normalized_stored_sha not in blamed_sha_candidates:
                 continue
             if normalized_stored_sha not in resolved_links:
-                resolved_links[normalized_stored_sha] = _resolve_blamed_sha(
-                    repo_path, stored_sha, blamed_sha_set
-                )
+                resolved_links[normalized_stored_sha] = _resolve_blamed_sha(repo_path, stored_sha, blamed_sha_set)
             resolved_sha = resolved_links[normalized_stored_sha]
             if resolved_sha is None:
                 continue

--- a/src/entirecontext/core/compact.py
+++ b/src/entirecontext/core/compact.py
@@ -10,9 +10,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def find_orphan_content_files(
-    conn: sqlite3.Connection, repo_path: str, *, min_age_seconds: int = 3600
-) -> list[Path]:
+def find_orphan_content_files(conn: sqlite3.Connection, repo_path: str, *, min_age_seconds: int = 3600) -> list[Path]:
     """Find JSONL content files on disk that have no matching turn_content row.
 
     Args:
@@ -180,9 +178,7 @@ def compact_repo(
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     before_date = cutoff.isoformat()
-    consolidation = consolidate_old_turns(
-        conn, repo_path, before_date=before_date, limit=limit, dry_run=dry_run
-    )
+    consolidation = consolidate_old_turns(conn, repo_path, before_date=before_date, limit=limit, dry_run=dry_run)
 
     orphans = remove_orphan_content_files(conn, repo_path, dry_run=dry_run)
 

--- a/src/entirecontext/core/decision_candidates.py
+++ b/src/entirecontext/core/decision_candidates.py
@@ -202,9 +202,7 @@ def confirm_candidate(
                     pass
             elif candidate.get("source_type") == "archaeology" and candidate.get("source_id"):
                 source_id = candidate["source_id"]
-                if len(source_id) in (40, 64) and all(
-                    c in "0123456789abcdef" for c in source_id.lower()
-                ):
+                if len(source_id) in (40, 64) and all(c in "0123456789abcdef" for c in source_id.lower()):
                     try:
                         link_decision_to_commit(conn, decision_id, source_id)
                     except Exception:

--- a/src/entirecontext/core/decision_extraction.py
+++ b/src/entirecontext/core/decision_extraction.py
@@ -269,9 +269,7 @@ def clear_stale_extraction_markers(conn) -> int:
     """
     from .context import transaction
 
-    rows = conn.execute(
-        "SELECT id, metadata FROM sessions WHERE metadata IS NOT NULL"
-    ).fetchall()
+    rows = conn.execute("SELECT id, metadata FROM sessions WHERE metadata IS NOT NULL").fetchall()
 
     cleared = 0
     with transaction(conn):
@@ -1201,9 +1199,7 @@ def run_extraction(
                 outcome.duplicates_skipped += 1
 
     if outcome.bundles_collected > 0 and outcome.drafts_parsed == 0:
-        outcome.warnings.append(
-            f"no_drafts: {outcome.bundles_collected} bundles collected but 0 drafts parsed"
-        )
+        outcome.warnings.append(f"no_drafts: {outcome.bundles_collected} bundles collected but 0 drafts parsed")
 
     if outcome.parsed_ok and session_id is not None:
         mark_session_extracted(conn, session_id)

--- a/src/entirecontext/core/decision_prompt_surfacing.py
+++ b/src/entirecontext/core/decision_prompt_surfacing.py
@@ -329,7 +329,9 @@ def rank_decisions_for_prompt(
     quality_weights = _load_quality_weights(config)
 
     decisions_cfg = config.get("decisions", {})
-    capture = capture_snapshots if capture_snapshots is not None else decisions_cfg.get("capture_ranking_snapshots", False)
+    capture = (
+        capture_snapshots if capture_snapshots is not None else decisions_cfg.get("capture_ranking_snapshots", False)
+    )
 
     ranked, stats = rank_related_decisions(
         conn,

--- a/src/entirecontext/core/decisions.py
+++ b/src/entirecontext/core/decisions.py
@@ -1687,9 +1687,7 @@ def rank_related_decisions(
 
         from .security import DEFAULT_PATTERNS
 
-        extra_patterns = (
-            _capture_config.get("security", {}).get("patterns") if _capture_config else None
-        )
+        extra_patterns = _capture_config.get("security", {}).get("patterns") if _capture_config else None
         if extra_patterns:
             merged = list(dict.fromkeys(DEFAULT_PATTERNS + extra_patterns))
             configured_patterns = merged
@@ -1733,9 +1731,7 @@ def rank_related_decisions(
     return top
 
 
-def backpatch_snapshot_event(
-    conn, *, snapshot_id: str | None, retrieval_event_id: str
-) -> None:
+def backpatch_snapshot_event(conn, *, snapshot_id: str | None, retrieval_event_id: str) -> None:
     """Link a ranking snapshot to its retrieval event after telemetry creation."""
     if snapshot_id is None:
         return

--- a/src/entirecontext/core/embedding.py
+++ b/src/entirecontext/core/embedding.py
@@ -152,8 +152,7 @@ def semantic_search(
             if tql.since and normalized_timestamp < tql.since:
                 continue
             if tql.until and (
-                normalized_timestamp > tql.until
-                or (tql.until_exclusive and normalized_timestamp == tql.until)
+                normalized_timestamp > tql.until or (tql.until_exclusive and normalized_timestamp == tql.until)
             ):
                 continue
 

--- a/src/entirecontext/core/purge.py
+++ b/src/entirecontext/core/purge.py
@@ -118,9 +118,7 @@ def purge_ranking_snapshots(conn, retention_days: int = 90, dry_run: bool = True
         raise ValueError(f"retention_days must be >= 1, got {retention_days}")
     cutoff = conn.execute("SELECT datetime('now', ?)", (f"-{retention_days} days",)).fetchone()[0]
 
-    matched = conn.execute(
-        "SELECT COUNT(*) FROM ranking_snapshots WHERE created_at < ?", (cutoff,)
-    ).fetchone()[0]
+    matched = conn.execute("SELECT COUNT(*) FROM ranking_snapshots WHERE created_at < ?", (cutoff,)).fetchone()[0]
 
     if dry_run:
         return {"matched": matched, "deleted": 0, "dry_run": True}

--- a/src/entirecontext/core/search.py
+++ b/src/entirecontext/core/search.py
@@ -50,7 +50,9 @@ def regex_search(
 ) -> list[dict]:
     """Regex search across turns/sessions/events."""
     if target == "turn":
-        results = _regex_search_turns(conn, pattern, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit)
+        results = _regex_search_turns(
+            conn, pattern, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit
+        )
     elif target == "session":
         results = _regex_search_sessions(conn, pattern, since, until, until_exclusive, limit)
     elif target == "event":
@@ -62,7 +64,9 @@ def regex_search(
     return _apply_query_redaction(results, config)
 
 
-def _regex_search_turns(conn, pattern: str, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit) -> list[dict]:
+def _regex_search_turns(
+    conn, pattern: str, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit
+) -> list[dict]:
     from .tql import TQLContext, apply_temporal_filters
 
     query = """
@@ -229,7 +233,9 @@ def fts_search(
 ) -> list[dict]:
     """FTS5 full-text search."""
     if target == "turn":
-        results = _fts_search_turns(conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit)
+        results = _fts_search_turns(
+            conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit
+        )
     elif target == "session":
         results = _fts_search_sessions(conn, query, since, until, until_exclusive, limit)
     elif target == "event":
@@ -239,7 +245,9 @@ def fts_search(
     return _apply_query_redaction(results, config)
 
 
-def _fts_search_turns(conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit) -> list[dict]:
+def _fts_search_turns(
+    conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit
+) -> list[dict]:
     from .tql import TQLContext, apply_temporal_filters
 
     sql = """
@@ -362,7 +370,9 @@ def hybrid_search(
 ) -> list[dict]:
     """Hybrid search combining FTS5 relevance and recency via RRF."""
     if target == "turn":
-        results = _hybrid_search_turns(conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit, k)
+        results = _hybrid_search_turns(
+            conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit, k
+        )
     elif target == "session":
         results = _hybrid_search_sessions(conn, query, since, until, until_exclusive, limit, k)
     elif target == "event":
@@ -391,7 +401,9 @@ def _fuse_and_rank(fts_results: list[dict], ts_key: str, limit: int, k: int) -> 
     return results
 
 
-def _hybrid_search_turns(conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit, k) -> list[dict]:
+def _hybrid_search_turns(
+    conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit, k
+) -> list[dict]:
     fetch_multiplier = 10 if file_filter else 3
     fts_results = _fts_search_turns(
         conn, query, file_filter, commit_filter, agent_filter, since, until, until_exclusive, limit * fetch_multiplier

--- a/src/entirecontext/core/tql.py
+++ b/src/entirecontext/core/tql.py
@@ -104,9 +104,7 @@ def _resolve_git_ref(ref: str, repo_path: str) -> str | None:
     return None
 
 
-def apply_temporal_filters(
-    conditions: list[str], params: list[Any], tql: TQLContext | None, column: str
-) -> None:
+def apply_temporal_filters(conditions: list[str], params: list[Any], tql: TQLContext | None, column: str) -> None:
     """Append datetime()-normalized WHERE clauses for since/until bounds."""
     if not tql:
         return

--- a/src/entirecontext/db/migrations/v015.py
+++ b/src/entirecontext/db/migrations/v015.py
@@ -28,12 +28,8 @@ def _create_ranking_snapshots(conn: sqlite3.Connection) -> None:
 
 
 def _create_ranking_snapshots_indexes(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_event_id ON ranking_snapshots(retrieval_event_id)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_created_at ON ranking_snapshots(created_at DESC)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_event_id ON ranking_snapshots(retrieval_event_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_ranking_snapshots_created_at ON ranking_snapshots(created_at DESC)")
 
 
 MIGRATION_STEPS = [

--- a/src/entirecontext/db/migrations/v016.py
+++ b/src/entirecontext/db/migrations/v016.py
@@ -6,9 +6,7 @@ import sqlite3
 
 
 def _create_archaeology_processed(conn: sqlite3.Connection) -> None:
-    row = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'"
-    ).fetchone()
+    row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='archaeology_processed'").fetchone()
     if row is not None:
         return
     conn.execute(
@@ -80,9 +78,7 @@ def _rebuild_decision_candidates(conn: sqlite3.Connection) -> None:
     conn.execute("DROP TABLE IF EXISTS fts_decision_candidates")
 
     conn.execute(_WIDENED_DDL)
-    conn.execute(
-        f"INSERT INTO decision_candidates_new SELECT {_COLUMNS} FROM decision_candidates"
-    )
+    conn.execute(f"INSERT INTO decision_candidates_new SELECT {_COLUMNS} FROM decision_candidates")
     conn.execute("DROP TABLE decision_candidates")
     conn.execute("ALTER TABLE decision_candidates_new RENAME TO decision_candidates")
 
@@ -91,21 +87,15 @@ def _rebuild_decision_candidates(conn: sqlite3.Connection) -> None:
 
 
 def _create_indexes(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_review ON decision_candidates(review_status)")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key)"
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id)"
-    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_dedup ON decision_candidates(dedup_key)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_decision_candidates_session ON decision_candidates(session_id)")
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS uniq_decision_candidates_source_dedup "
         "ON decision_candidates(source_type, source_id, dedup_key)"

--- a/src/entirecontext/db/migrations/v017.py
+++ b/src/entirecontext/db/migrations/v017.py
@@ -8,10 +8,7 @@ import sqlite3
 def _add_pr_body_processed(conn: sqlite3.Connection) -> None:
     columns = {row[1] for row in conn.execute("PRAGMA table_info(archaeology_processed)")}
     if "pr_body_processed" not in columns:
-        conn.execute(
-            "ALTER TABLE archaeology_processed "
-            "ADD COLUMN pr_body_processed INTEGER NOT NULL DEFAULT 0"
-        )
+        conn.execute("ALTER TABLE archaeology_processed ADD COLUMN pr_body_processed INTEGER NOT NULL DEFAULT 0")
 
 
 MIGRATION_STEPS = [_add_pr_body_processed]

--- a/src/entirecontext/hooks/decision_hooks.py
+++ b/src/entirecontext/hooks/decision_hooks.py
@@ -182,6 +182,7 @@ def on_session_start_decisions(data: dict[str, Any]) -> str | None:
 
         config = _load_decisions_config(repo_path)
         from ..core.config import is_experiment_off
+
         if is_experiment_off(config):
             return None
         if not config.get("show_related_on_start", False):
@@ -561,6 +562,7 @@ def on_post_tool_use_decisions(data: dict[str, Any]) -> str | None:
         try:
             config = load_config(repo_path)
             from ..core.config import is_experiment_off
+
             if is_experiment_off(config.get("decisions", {})):
                 return None
             if not config.get("capture", {}).get("auto_capture", True):

--- a/src/entirecontext/hooks/handler.py
+++ b/src/entirecontext/hooks/handler.py
@@ -267,7 +267,10 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
                     except (ValueError, TypeError):
                         pass
                 surfaced, _, snap_id = rank_decisions_for_prompt(
-                    conn, repo_path=repo_path, prompt_text=prompt_text, config=config,
+                    conn,
+                    repo_path=repo_path,
+                    prompt_text=prompt_text,
+                    config=config,
                     capture_snapshots=capture_snapshots,
                 )
                 trimmed = optimize_for_context_budget(
@@ -374,8 +377,11 @@ def _handle_user_prompt(data: dict[str, Any]) -> int:
                         if trimmed:
                             for d in trimmed:
                                 record_retrieval_selection(
-                                    pdi_conn, evt["id"], result_type="decision",
-                                    result_id=d["id"], rank=d.get("rank", 0),
+                                    pdi_conn,
+                                    evt["id"],
+                                    result_type="decision",
+                                    result_id=d["id"],
+                                    rank=d.get("rank", 0),
                                 )
                 finally:
                     pdi_conn.close()

--- a/src/entirecontext/hooks/turn_capture.py
+++ b/src/entirecontext/hooks/turn_capture.py
@@ -200,7 +200,10 @@ def on_user_prompt(data: dict[str, Any], *, _resolved_repo_path: object = _GIT_R
         # before the worker launches, and guarded inside the helper so a
         # launch failure cannot roll back the turn insert.
         from ..core.config import is_experiment_off
-        if not is_experiment_off(config.get("decisions", {})) and config.get("decisions", {}).get("surface_on_user_prompt", False):
+
+        if not is_experiment_off(config.get("decisions", {})) and config.get("decisions", {}).get(
+            "surface_on_user_prompt", False
+        ):
             _maybe_launch_prompt_surfacing_worker(repo_path, session_id, turn_id, prompt, config)
     finally:
         conn.close()

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -83,10 +83,7 @@ class TestExtractFilesFromPatch:
         assert _extract_files_from_patch(patch) == ["my file.py"]
 
     def test_path_containing_separator_text(self):
-        patch = (
-            "diff --git a/dir b/name b/dir b/name\n"
-            "--- a/dir b/name\n+++ b/dir b/name\n"
-        )
+        patch = "diff --git a/dir b/name b/dir b/name\n--- a/dir b/name\n+++ b/dir b/name\n"
         assert _extract_files_from_patch(patch) == ["dir b/name"]
 
     def test_deleted_path_uses_source_header(self):
@@ -119,10 +116,7 @@ class TestExtractFilesFromPatch:
         assert _extract_files_from_patch(patch) == ["a.py", "b.py"]
 
     def test_octal_quoted_destination_path(self):
-        patch = (
-            'diff --git "a/old.py" "b/\\355\\225\\234.py"\n'
-            '--- a/old.py\n+++ "b/\\355\\225\\234.py"\n'
-        )
+        patch = 'diff --git "a/old.py" "b/\\355\\225\\234.py"\n--- a/old.py\n+++ "b/\\355\\225\\234.py"\n'
         assert _extract_files_from_patch(patch) == ["한.py"]
 
 
@@ -140,9 +134,7 @@ class TestBuildSignalBundle:
         assert "diff" in bundle.text_blocks
 
     def test_message_included_in_text_blocks(self):
-        bundle = _build_signal_bundle(
-            "abc123", "fix: handle edge case\n\nThis explains why.", "diff content", None
-        )
+        bundle = _build_signal_bundle("abc123", "fix: handle edge case\n\nThis explains why.", "diff content", None)
         assert "fix: handle edge case\n\nThis explains why." in bundle.text_blocks
 
     def test_message_precedes_pr_body_and_patch(self):
@@ -289,9 +281,7 @@ class TestStreamCommits:
 
     def test_both_refs_since_until(self, git_repo):
         _make_commits(git_repo, 4)
-        log = subprocess.run(
-            ["git", "log", "--format=%H"], cwd=git_repo, capture_output=True, text=True, check=True
-        )
+        log = subprocess.run(["git", "log", "--format=%H"], cwd=git_repo, capture_output=True, text=True, check=True)
         shas_newest_first = log.stdout.strip().splitlines()
         since_sha = shas_newest_first[3]  # oldest commit
         until_sha = shas_newest_first[1]
@@ -311,9 +301,7 @@ class TestStreamCommits:
 
     def test_bad_ref_reports_warning_not_silent_empty(self, git_repo):
         warnings: list[str] = []
-        commits = list(
-            _stream_commits(str(git_repo), since="not-a-real-ref", until=None, limit=10, warnings=warnings)
-        )
+        commits = list(_stream_commits(str(git_repo), since="not-a-real-ref", until=None, limit=10, warnings=warnings))
         assert commits == []
         assert warnings
         assert "git log failed" in warnings[0]
@@ -463,7 +451,10 @@ class TestArchaeologize:
             patch("entirecontext.core.archaeology._fetch_pr_body") as fetch,
         ):
             result = archaeologize(
-                ec_db, "/repo", pr_bodies=True, dry_run=True,
+                ec_db,
+                "/repo",
+                pr_bodies=True,
+                dry_run=True,
                 progress_callback=progress.append,
             )
         assert result.patch_pending == 1
@@ -905,27 +896,19 @@ class TestCommitAction:
 class TestResolvePrCompletion:
     def test_found_parsed(self):
         state = _ProcessingState()
-        assert state.resolve_pr_completion(
-            _PrBodyFetch(_PrBodyStatus.FOUND, body="x"), True
-        ) is True
+        assert state.resolve_pr_completion(_PrBodyFetch(_PrBodyStatus.FOUND, body="x"), True) is True
 
     def test_found_unparsed(self):
         state = _ProcessingState()
-        assert state.resolve_pr_completion(
-            _PrBodyFetch(_PrBodyStatus.FOUND, body="x"), False
-        ) is False
+        assert state.resolve_pr_completion(_PrBodyFetch(_PrBodyStatus.FOUND, body="x"), False) is False
 
     def test_empty(self):
         state = _ProcessingState()
-        assert state.resolve_pr_completion(
-            _PrBodyFetch(_PrBodyStatus.EMPTY), False
-        ) is True
+        assert state.resolve_pr_completion(_PrBodyFetch(_PrBodyStatus.EMPTY), False) is True
 
     def test_failure(self):
         state = _ProcessingState()
-        assert state.resolve_pr_completion(
-            _PrBodyFetch(_PrBodyStatus.FAILURE), False
-        ) is False
+        assert state.resolve_pr_completion(_PrBodyFetch(_PrBodyStatus.FAILURE), False) is False
 
     def test_none(self):
         state = _ProcessingState()

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -45,9 +45,7 @@ def test_dry_run_on_fixture(git_repo):
                 "GIT_AUTHOR_EMAIL": "test@test.com",
                 "GIT_COMMITTER_NAME": "Test",
                 "GIT_COMMITTER_EMAIL": "test@test.com",
-                "PATH": subprocess.check_output(
-                    ["bash", "-c", "echo $PATH"]
-                ).decode().strip(),
+                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
             },
         )
     result = subprocess.run(
@@ -102,9 +100,7 @@ def test_read_only_v16_dry_run_reports_separate_queues_without_migration(git_rep
         (git_repo / f"legacy{i}.py").write_text(f"x = {i}")
         subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
         subprocess.run(["git", "commit", "-m", f"feat: legacy {i}"], cwd=git_repo, check=True)
-    shas = subprocess.check_output(
-        ["git", "log", "-2", "--format=%H"], cwd=git_repo, text=True
-    ).splitlines()
+    shas = subprocess.check_output(["git", "log", "-2", "--format=%H"], cwd=git_repo, text=True).splitlines()
 
     db_path = git_repo / ".entirecontext" / "db" / "local.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_archaeology_integration.py
+++ b/tests/test_archaeology_integration.py
@@ -87,10 +87,7 @@ def test_dry_run_no_writes(arch_repo, ec_db):
 
 
 def test_source_type_archaeology_on_candidates(arch_repo, ec_db):
-    mock_response = (
-        '[{"title": "Test decision", "rationale": "Test", "scope": "test", '
-        '"rejected_alternatives": []}]'
-    )
+    mock_response = '[{"title": "Test decision", "rationale": "Test", "scope": "test", "rejected_alternatives": []}]'
     with patch(
         "entirecontext.core.decision_extraction.call_extraction_llm",
         return_value=mock_response,
@@ -114,7 +111,9 @@ def single_commit_repo(ec_repo):
     )
     sha = subprocess.run(
         ["git", "-C", str(ec_repo), "rev-parse", "HEAD"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.strip()
     return ec_repo, sha
 
@@ -126,7 +125,11 @@ def test_branch_a_fully_processed_skip(single_commit_repo, ec_db):
 
     callback = MagicMock()
     result = archaeologize(
-        ec_db, str(repo), pr_bodies=True, limit=1, progress_callback=callback,
+        ec_db,
+        str(repo),
+        pr_bodies=True,
+        limit=1,
+        progress_callback=callback,
     )
 
     assert result.commits_skipped == 1
@@ -142,7 +145,11 @@ def test_branch_b_tokenless_pr_only_skip_with_callback(single_commit_repo, ec_db
     monkeypatch.setattr("entirecontext.core.archaeology._get_github_token", lambda: None)
     callback = MagicMock()
     result = archaeologize(
-        ec_db, str(repo), pr_bodies=True, limit=1, progress_callback=callback,
+        ec_db,
+        str(repo),
+        pr_bodies=True,
+        limit=1,
+        progress_callback=callback,
     )
 
     assert result.commits_skipped == 1

--- a/tests/test_archaeology_streaming.py
+++ b/tests/test_archaeology_streaming.py
@@ -1,4 +1,5 @@
 """Tests for streaming Popen in _stream_commits and lazy archaeologize."""
+
 import subprocess
 from io import StringIO
 from types import SimpleNamespace
@@ -41,9 +42,7 @@ class TestStreamingPopen:
         monkeypatch.setattr("entirecontext.core.archaeology.subprocess.Popen", lambda *a, **kw: proc)
         warnings = []
 
-        assert list(_stream_commits("/repo", None, None, 10, warnings=warnings)) == [
-            (sha, "message", "patch")
-        ]
+        assert list(_stream_commits("/repo", None, None, 10, warnings=warnings)) == [(sha, "message", "patch")]
         assert warnings == []
         proc.terminate.assert_not_called()
 
@@ -97,8 +96,10 @@ class TestStreamingPopen:
         repo = str(git_repo)
         # Detect default branch name (may be main or master depending on git config)
         branch = subprocess.run(
-            ["git", "branch", "--show-current"], cwd=repo,
-            capture_output=True, text=True,
+            ["git", "branch", "--show-current"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         # Create a branch, commit, merge back with --no-ff
         subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True)
@@ -108,7 +109,8 @@ class TestStreamingPopen:
         subprocess.run(["git", "checkout", branch], cwd=repo, check=True)
         subprocess.run(
             ["git", "merge", "feature", "--no-ff", "-m", "Merge branch feature"],
-            cwd=repo, check=True,
+            cwd=repo,
+            check=True,
         )
 
         results = list(_stream_commits(repo, since=None, until=None, limit=100))
@@ -164,5 +166,6 @@ class TestLazyArchaeologize:
         subprocess.run(["git", "commit", "-m", "test lazy"], cwd=repo, check=True)
 
         from entirecontext.core.archaeology import archaeologize
+
         result = archaeologize(ec_db, repo, dry_run=True, limit=10)
         assert result.commits_scanned >= 1

--- a/tests/test_blame_decisions.py
+++ b/tests/test_blame_decisions.py
@@ -26,8 +26,7 @@ def _annotate_high_distinct_sha_file(ec_repo, ec_db, monkeypatch, traced_stateme
     link_decision_to_commit(ec_db, exact_decision["id"], shas[0])
     link_decision_to_commit(ec_db, abbreviated_decision["id"], shas[-1][:8])
     blame_output = "".join(
-        f"{sha} {line_number} {line_number} 1\n\tline {line_number}\n"
-        for line_number, sha in enumerate(shas, start=1)
+        f"{sha} {line_number} {line_number} 1\n\tline {line_number}\n" for line_number, sha in enumerate(shas, start=1)
     )
 
     def fake_run(command, **kwargs):
@@ -52,9 +51,7 @@ def _annotate_high_distinct_sha_file(ec_repo, ec_db, monkeypatch, traced_stateme
 
 
 class TestAnnotateFile:
-    def test_high_distinct_sha_count_survives_expression_depth_limit(
-        self, ec_repo, ec_db, monkeypatch
-    ):
+    def test_high_distinct_sha_count_survives_expression_depth_limit(self, ec_repo, ec_db, monkeypatch):
         result, shas, exact_decision, abbreviated_decision = _annotate_high_distinct_sha_file(
             ec_repo, ec_db, monkeypatch
         )
@@ -72,13 +69,9 @@ class TestAnnotateFile:
         _annotate_high_distinct_sha_file(ec_repo, ec_db, monkeypatch, traced_statements)
 
         candidate_queries = [
-            statement
-            for statement in traced_statements
-            if "FROM decision_commits dc JOIN decisions d" in statement
+            statement for statement in traced_statements if "FROM decision_commits dc JOIN decisions d" in statement
         ]
-        exact_queries = [
-            statement for statement in candidate_queries if "WHERE dc.commit_sha IN (" in statement
-        ]
+        exact_queries = [statement for statement in candidate_queries if "WHERE dc.commit_sha IN (" in statement]
         abbreviated_queries = [
             statement for statement in candidate_queries if "length(dc.commit_sha) >= 4" in statement
         ]
@@ -90,9 +83,7 @@ class TestAnnotateFile:
             assert match is not None
             assert len(match.group(1).split(",")) <= 400
 
-    def test_unrelated_abbreviated_links_do_not_invoke_git_resolution(
-        self, ec_repo, ec_db, monkeypatch
-    ):
+    def test_unrelated_abbreviated_links_do_not_invoke_git_resolution(self, ec_repo, ec_db, monkeypatch):
         full_sha = "abcdef0123" * 4
         relevant_abbreviation = full_sha[:8]
         decision = create_decision(ec_db, title="Relevant abbreviated SHA decision")
@@ -128,8 +119,10 @@ class TestAnnotateFile:
         case_variants = [
             "".join(characters)
             for characters in product(
-                *((character.lower(), character.upper()) if character.isalpha() else (character,)
-                  for character in relevant_abbreviation)
+                *(
+                    (character.lower(), character.upper()) if character.isalpha() else (character,)
+                    for character in relevant_abbreviation
+                )
             )
         ]
         decision = create_decision(ec_db, title="Case-variant abbreviated SHA decision")

--- a/tests/test_confirm_commit_link.py
+++ b/tests/test_confirm_commit_link.py
@@ -201,9 +201,7 @@ class TestArchaeologyCommitLink:
     def test_archaeology_candidate_links_source_id_as_commit(self, ec_repo, ec_db):
         """INV5: archaeology candidate with 40-char hex source_id -> decision_commits row created."""
         source_id = "a" * 40
-        cid = _seed_archaeology_candidate(
-            ec_db, ec_repo, session_id="inv5-archaeology-hex40", source_id=source_id
-        )
+        cid = _seed_archaeology_candidate(ec_db, ec_repo, session_id="inv5-archaeology-hex40", source_id=source_id)
         result = confirm_candidate(ec_db, cid, reviewer="test")
 
         assert result["promoted"] is True
@@ -219,9 +217,7 @@ class TestArchaeologyCommitLink:
     def test_archaeology_non_hex_source_id_no_link(self, ec_repo, ec_db):
         """INV6: non-hex source_id -> no link, promotion succeeds."""
         source_id = "not-a-commit-sha-zzzzzzzzzzzzzzzzzzzzzzzz"
-        cid = _seed_archaeology_candidate(
-            ec_db, ec_repo, session_id="inv6-archaeology-nonhex", source_id=source_id
-        )
+        cid = _seed_archaeology_candidate(ec_db, ec_repo, session_id="inv6-archaeology-nonhex", source_id=source_id)
         result = confirm_candidate(ec_db, cid, reviewer="test")
 
         assert result["promoted"] is True
@@ -234,9 +230,7 @@ class TestArchaeologyCommitLink:
     def test_archaeology_sha256_source_id_links(self, ec_repo, ec_db):
         """INV5b: 64-char SHA-256 source_id -> link created."""
         source_id = "b" * 64
-        cid = _seed_archaeology_candidate(
-            ec_db, ec_repo, session_id="inv5b-archaeology-sha256", source_id=source_id
-        )
+        cid = _seed_archaeology_candidate(ec_db, ec_repo, session_id="inv5b-archaeology-sha256", source_id=source_id)
         result = confirm_candidate(ec_db, cid, reviewer="test")
 
         assert result["promoted"] is True

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -479,9 +479,7 @@ class TestMigration:
 
     def test_migrate_v14_to_v15_adds_ranking_snapshots(self):
         conn = get_memory_db()
-        conn.execute(
-            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)"
-        )
+        conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)")
         conn.execute("INSERT INTO schema_version (version, description) VALUES (14, 'v14')")
         # ranking_snapshots FK target
         conn.execute(
@@ -491,24 +489,25 @@ class TestMigration:
         conn.commit()
 
         # Verify table does not exist yet
-        row = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='ranking_snapshots'"
-        ).fetchone()
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='ranking_snapshots'").fetchone()
         assert row is None
 
         check_and_migrate(conn)
 
         # Table exists
-        row = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='ranking_snapshots'"
-        ).fetchone()
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='ranking_snapshots'").fetchone()
         assert row is not None
 
         # Columns are correct
         cols = {r[1] for r in conn.execute("PRAGMA table_info(ranking_snapshots)").fetchall()}
         expected = {
-            "id", "retrieval_event_id", "input_files", "input_diff_text",
-            "input_commits", "scored_candidates", "effective_limit",
+            "id",
+            "retrieval_event_id",
+            "input_files",
+            "input_diff_text",
+            "input_commits",
+            "scored_candidates",
+            "effective_limit",
             "created_at",
         }
         assert expected.issubset(cols)
@@ -518,15 +517,11 @@ class TestMigration:
         assert col_info["retrieval_event_id"] == 0  # notnull=0 means nullable
 
         # Verify schema version
-        ver = conn.execute(
-            "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
-        ).fetchone()[0]
+        ver = conn.execute("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").fetchone()[0]
         assert ver == SCHEMA_VERSION
 
         # FK works: can insert with NULL retrieval_event_id
-        conn.execute(
-            "INSERT INTO ranking_snapshots (id, scored_candidates, effective_limit) VALUES ('s1', '[]', 5)"
-        )
+        conn.execute("INSERT INTO ranking_snapshots (id, scored_candidates, effective_limit) VALUES ('s1', '[]', 5)")
         row = conn.execute("SELECT * FROM ranking_snapshots WHERE id='s1'").fetchone()
         assert row is not None
         conn.close()

--- a/tests/test_decision_candidates_batch.py
+++ b/tests/test_decision_candidates_batch.py
@@ -56,9 +56,7 @@ class TestHappyPath:
         assert result["skipped_below_threshold"] == 0
 
         for sid in source_ids:
-            row = ec_db.execute(
-                "SELECT decision_id FROM decision_commits WHERE commit_sha = ?", (sid,)
-            ).fetchone()
+            row = ec_db.execute("SELECT decision_id FROM decision_commits WHERE commit_sha = ?", (sid,)).fetchone()
             assert row is not None
             assert row["decision_id"] in result["confirmed"]
 
@@ -69,9 +67,7 @@ class TestHappyPath:
             for i, c in enumerate(confidences)
         ]
 
-        result = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.2, dry_run=True
-        )
+        result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.2, dry_run=True)
 
         assert result["dry_run"] is True
         assert result["total_pending"] == 4
@@ -90,9 +86,7 @@ class TestHappyPath:
 
 class TestEdgeCases:
     @pytest.mark.parametrize("threshold", [float("nan"), float("inf"), float("-inf")])
-    def test_non_finite_min_confidence_is_rejected_without_mutation(
-        self, ec_repo, ec_db, threshold
-    ):
+    def test_non_finite_min_confidence_is_rejected_without_mutation(self, ec_repo, ec_db, threshold):
         candidate_id = _seed_candidate(
             ec_db,
             source_type="archaeology",
@@ -119,12 +113,8 @@ class TestEdgeCases:
 
     def test_source_type_filter_leaves_other_types_untouched(self, ec_repo, ec_db):
         arch_id = _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(1), confidence=0.9)
-        assessment_id = _seed_candidate(
-            ec_db, source_type="assessment", source_id="assessment-1", confidence=0.9
-        )
-        checkpoint_id = _seed_candidate(
-            ec_db, source_type="checkpoint", source_id="checkpoint-1", confidence=0.9
-        )
+        assessment_id = _seed_candidate(ec_db, source_type="assessment", source_id="assessment-1", confidence=0.9)
+        checkpoint_id = _seed_candidate(ec_db, source_type="checkpoint", source_id="checkpoint-1", confidence=0.9)
 
         result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.0)
 
@@ -142,9 +132,7 @@ class TestEdgeCases:
             for i in range(1, 13)
         ]
 
-        result = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, page_size=5
-        )
+        result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, page_size=5)
 
         assert result["failed"] == []
         assert sorted(result["confirmed"]) == sorted(result["confirmed"])
@@ -157,8 +145,7 @@ class TestEdgeCases:
 class TestErrorHandling:
     def test_single_candidate_failure_rolls_back_and_batch_continues(self, ec_repo, ec_db, monkeypatch):
         ids = [
-            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
-            for i in (1, 2, 3)
+            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9) for i in (1, 2, 3)
         ]
         fail_id = ids[1]
         fail_title = get_candidate(ec_db, fail_id)["title"]
@@ -183,9 +170,7 @@ class TestErrorHandling:
         assert row["review_status"] == "pending"
         assert row["promoted_decision_id"] is None
 
-    def test_already_confirmed_candidate_lands_in_failed_and_batch_continues(
-        self, ec_repo, ec_db, monkeypatch
-    ):
+    def test_already_confirmed_candidate_lands_in_failed_and_batch_continues(self, ec_repo, ec_db, monkeypatch):
         pre_id = _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(1), confidence=0.9)
         confirm_candidate(ec_db, pre_id, reviewer="pre")
         pre_row = get_candidate(ec_db, pre_id)
@@ -215,12 +200,9 @@ class TestErrorHandling:
         other_row = get_candidate(ec_db, other_id)
         assert other_row["review_status"] == "confirmed"
 
-    def test_small_page_size_with_failures_does_not_starve_low_confidence_candidate(
-        self, ec_repo, ec_db, monkeypatch
-    ):
+    def test_small_page_size_with_failures_does_not_starve_low_confidence_candidate(self, ec_repo, ec_db, monkeypatch):
         fail_ids = [
-            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
-            for i in (1, 2, 3)
+            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9) for i in (1, 2, 3)
         ]
         fail_titles = {get_candidate(ec_db, cid)["title"] for cid in fail_ids}
         low_id = _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(4), confidence=0.5)
@@ -236,9 +218,7 @@ class TestErrorHandling:
 
         monkeypatch.setattr(decisions_module, "create_decision", flaky_create_decision)
 
-        result = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, page_size=2
-        )
+        result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, page_size=2)
 
         assert sorted(result["failed"]) == sorted(fail_ids)
         assert len(result["confirmed"]) == 1
@@ -259,8 +239,7 @@ class TestRerunSemantics:
         self, ec_repo, ec_db, monkeypatch
     ):
         ids = [
-            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
-            for i in (1, 2, 3)
+            _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9) for i in (1, 2, 3)
         ]
         fail_id = ids[1]
         fail_title = get_candidate(ec_db, fail_id)["title"]
@@ -308,9 +287,7 @@ class TestRerunSemantics:
 
 
 class TestEmbeddingIntegration:
-    def test_embedding_called_once_for_batch_when_auto_embed_and_repo_path(
-        self, ec_repo, ec_db, monkeypatch
-    ):
+    def test_embedding_called_once_for_batch_when_auto_embed_and_repo_path(self, ec_repo, ec_db, monkeypatch):
         monkeypatch.setattr(
             "entirecontext.core.config.load_config",
             lambda path=None: {"decisions": {"auto_embed": True}},
@@ -324,9 +301,7 @@ class TestEmbeddingIntegration:
         for i in (1, 2, 3):
             _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
 
-        result = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo)
-        )
+        result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo))
 
         assert len(result["confirmed"]) == 3
         assert len(calls) == 1
@@ -369,9 +344,7 @@ class TestEmbeddingIntegration:
 
         _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(1), confidence=0.9)
 
-        confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, repo_path=None
-        )
+        confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, repo_path=None)
 
         assert calls == []
 
@@ -389,9 +362,7 @@ class TestEmbeddingIntegration:
         for i in (1, 2, 3):
             _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
 
-        result = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo)
-        )
+        result = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo))
 
         assert len(result["confirmed"]) == 3
         assert result["failed"] == []
@@ -408,15 +379,11 @@ class TestEmbeddingIntegration:
         )
 
         _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(1), confidence=0.9)
-        result1 = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo)
-        )
+        result1 = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo))
         assert len(result1["confirmed"]) == 1
         assert len(calls) == 1
 
         _seed_candidate(ec_db, source_type="archaeology", source_id=_hex_sha(2), confidence=0.9)
-        result2 = confirm_candidates_batch(
-            ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo)
-        )
+        result2 = confirm_candidates_batch(ec_db, source_type="archaeology", min_confidence=0.5, repo_path=str(ec_repo))
         assert len(result2["confirmed"]) == 1
         assert len(calls) == 2

--- a/tests/test_decision_candidates_batch_cli.py
+++ b/tests/test_decision_candidates_batch_cli.py
@@ -48,8 +48,7 @@ class TestConfirmBatchCLI:
         monkeypatch.chdir(ec_repo)
         conn = get_db(str(ec_repo))
         ids = [
-            _seed_candidate(conn, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9)
-            for i in (1, 2, 3)
+            _seed_candidate(conn, source_type="archaeology", source_id=_hex_sha(i), confidence=0.9) for i in (1, 2, 3)
         ]
         conn.close()
 
@@ -76,9 +75,7 @@ class TestConfirmBatchCLI:
         ]
         conn.close()
 
-        result = runner.invoke(
-            app, ["decision", "candidates", "confirm-batch", "--min-confidence", "0.5", "--dry-run"]
-        )
+        result = runner.invoke(app, ["decision", "candidates", "confirm-batch", "--min-confidence", "0.5", "--dry-run"])
 
         assert result.exit_code == 0
         assert "Total pending: 3" in result.stdout

--- a/tests/test_e2e_autonomous_loop.py
+++ b/tests/test_e2e_autonomous_loop.py
@@ -30,16 +30,16 @@ def _write_repo_config(repo: Path, body: str) -> None:
     cfg.write_text(body, encoding="utf-8")
 
 
-_MOCK_LLM_RESPONSE = json.dumps([
-    {
-        "title": "Use SQLite WAL mode for concurrent reads",
-        "rationale": "WAL allows readers and writers to operate concurrently",
-        "scope": "database",
-        "rejected_alternatives": [
-            {"alternative": "Default journal mode", "reason": "Blocks concurrent readers"}
-        ],
-    }
-])
+_MOCK_LLM_RESPONSE = json.dumps(
+    [
+        {
+            "title": "Use SQLite WAL mode for concurrent reads",
+            "rationale": "WAL allows readers and writers to operate concurrently",
+            "scope": "database",
+            "rejected_alternatives": [{"alternative": "Default journal mode", "reason": "Blocks concurrent readers"}],
+        }
+    ]
+)
 
 
 class TestAutonomousLoopE2E:
@@ -48,37 +48,48 @@ class TestAutonomousLoopE2E:
     def test_full_loop(self, ec_repo, ec_db, monkeypatch):
         repo_path = str(ec_repo)
 
-        _write_repo_config(ec_repo, "\n".join([
-            "[decisions]",
-            "auto_extract = true",
-            "infer_applied_on_session_end = true",
-            "infer_outcome_type = true",
-            "",
-            "[decisions.ranking]",
-            "file_exact_weight = 10.0",
-        ]))
+        _write_repo_config(
+            ec_repo,
+            "\n".join(
+                [
+                    "[decisions]",
+                    "auto_extract = true",
+                    "infer_applied_on_session_end = true",
+                    "infer_outcome_type = true",
+                    "",
+                    "[decisions.ranking]",
+                    "file_exact_weight = 10.0",
+                ]
+            ),
+        )
 
         (ec_repo / "src").mkdir(exist_ok=True)
         (ec_repo / "src" / "db.py").write_text("# database module\n")
         subprocess.run(["git", "add", "."], cwd=repo_path, capture_output=True)
         subprocess.run(
             ["git", "commit", "-m", "feat: add WAL mode"],
-            cwd=repo_path, capture_output=True,
+            cwd=repo_path,
+            capture_output=True,
         )
         commit_hash = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=repo_path, capture_output=True, text=True,
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
 
         project_id = ec_db.execute("SELECT id FROM projects LIMIT 1").fetchone()["id"]
 
         # ── CAPTURE ──
         session1 = create_session(ec_db, project_id)
-        for i, (user, assistant) in enumerate([
-            ("How should we configure SQLite?", "We decided to use WAL mode"),
-            ("What about the journal?", "WAL lets readers not block writers"),
-            ("Update src/db.py", "Updated src/db.py with WAL pragma"),
-        ], 1):
+        for i, (user, assistant) in enumerate(
+            [
+                ("How should we configure SQLite?", "We decided to use WAL mode"),
+                ("What about the journal?", "WAL lets readers not block writers"),
+                ("Update src/db.py", "Updated src/db.py with WAL pragma"),
+            ],
+            1,
+        ):
             turn = create_turn(
                 ec_db,
                 session_id=session1["id"],
@@ -95,8 +106,7 @@ class TestAutonomousLoopE2E:
 
         cp_id = str(uuid.uuid4())
         ec_db.execute(
-            "INSERT INTO checkpoints (id, session_id, git_commit_hash, diff_summary) "
-            "VALUES (?, ?, ?, ?)",
+            "INSERT INTO checkpoints (id, session_id, git_commit_hash, diff_summary) VALUES (?, ?, ?, ?)",
             (cp_id, session1["id"], commit_hash, "src/db.py | 3 +++"),
         )
         ec_db.commit()
@@ -113,14 +123,11 @@ class TestAutonomousLoopE2E:
         from entirecontext.core.decision_extraction import run_extraction
 
         extraction = run_extraction(ec_db, session1["id"], repo_path)
-        assert extraction.candidates_inserted > 0, (
-            f"Expected candidates, got: {extraction.__dict__}"
-        )
+        assert extraction.candidates_inserted > 0, f"Expected candidates, got: {extraction.__dict__}"
 
         # Confirm candidate → decision
         candidate = ec_db.execute(
-            "SELECT id, title, rationale, scope FROM decision_candidates "
-            "WHERE review_status = 'pending' LIMIT 1"
+            "SELECT id, title, rationale, scope FROM decision_candidates WHERE review_status = 'pending' LIMIT 1"
         ).fetchone()
         assert candidate is not None
 

--- a/tests/test_experiment_block.py
+++ b/tests/test_experiment_block.py
@@ -45,10 +45,12 @@ class TestExperimentBlockOff:
 
         decisions_cfg = _decisions_config("off")
         with patch("entirecontext.hooks.decision_hooks._load_decisions_config", return_value=decisions_cfg):
-            result = on_session_start_decisions({
-                "session_id": "test-sess",
-                "cwd": str(ec_repo),
-            })
+            result = on_session_start_decisions(
+                {
+                    "session_id": "test-sess",
+                    "cwd": str(ec_repo),
+                }
+            )
         assert result is None
 
     def test_post_tool_use_suppressed(self):
@@ -64,12 +66,14 @@ class TestExperimentBlockOff:
             patch("entirecontext.db.get_db", return_value=mock_conn),
             patch("entirecontext.hooks.decision_hooks._find_ec_repo_root", return_value="/tmp/repo"),
         ):
-            result = on_post_tool_use_decisions({
-                "session_id": "test-sess",
-                "cwd": "/tmp/repo",
-                "tool_name": "Write",
-                "tool_input": {"file_path": "/tmp/repo/foo.py"},
-            })
+            result = on_post_tool_use_decisions(
+                {
+                    "session_id": "test-sess",
+                    "cwd": "/tmp/repo",
+                    "tool_name": "Write",
+                    "tool_input": {"file_path": "/tmp/repo/foo.py"},
+                }
+            )
         assert result is None
         mock_conn.execute.assert_not_called()
 
@@ -95,12 +99,14 @@ class TestExperimentBlockOff:
         ):
             from entirecontext.hooks.turn_capture import on_user_prompt
 
-            on_user_prompt({
-                "hook_type": "UserPromptSubmit",
-                "session_id": session["id"],
-                "cwd": str(ec_repo),
-                "prompt": "test",
-            })
+            on_user_prompt(
+                {
+                    "hook_type": "UserPromptSubmit",
+                    "session_id": session["id"],
+                    "cwd": str(ec_repo),
+                    "prompt": "test",
+                }
+            )
             mock_launch.assert_not_called()
 
     def test_sync_pdi_suppressed(self):
@@ -120,11 +126,13 @@ class TestExperimentBlockOff:
             patch("entirecontext.hooks.turn_capture.on_user_prompt"),
             patch("entirecontext.db.get_db") as mock_get_db,
         ):
-            result = _handle_user_prompt({
-                "session_id": "test-sess",
-                "cwd": "/tmp/repo",
-                "prompt": "test",
-            })
+            result = _handle_user_prompt(
+                {
+                    "session_id": "test-sess",
+                    "cwd": "/tmp/repo",
+                    "prompt": "test",
+                }
+            )
         assert result == 0
         mock_get_db.assert_not_called()
 
@@ -137,10 +145,12 @@ class TestExperimentBlockOn:
 
         decisions_cfg = _decisions_config("on", show_related_on_start=False)
         with patch("entirecontext.hooks.decision_hooks._load_decisions_config", return_value=decisions_cfg):
-            result = on_session_start_decisions({
-                "session_id": "test-sess",
-                "cwd": "/tmp/repo",
-            })
+            result = on_session_start_decisions(
+                {
+                    "session_id": "test-sess",
+                    "cwd": "/tmp/repo",
+                }
+            )
         assert result is None
 
 

--- a/tests/test_llm_backend.py
+++ b/tests/test_llm_backend.py
@@ -24,11 +24,15 @@ class TestCLIBackendClaude:
     def test_unwraps_json_array_response(self, mock_run):
         """claude output is a JSON array; result is in the {type:result} item."""
         result_text = '[{"title": "Use Redis", "rationale": "faster"}]'
-        mock_run.return_value = type("Result", (), {
-            "returncode": 0,
-            "stdout": self._make_claude_output(result_text),
-            "stderr": "",
-        })()
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": self._make_claude_output(result_text),
+                "stderr": "",
+            },
+        )()
 
         backend = CLIBackend(command="claude")
         output = backend.complete("system prompt", "user text")
@@ -39,11 +43,15 @@ class TestCLIBackendClaude:
     def test_unwraps_dict_response(self, mock_run):
         """Backward compat: dict envelope still works."""
         result_text = "[]"
-        mock_run.return_value = type("Result", (), {
-            "returncode": 0,
-            "stdout": json.dumps({"result": result_text, "type": "result"}),
-            "stderr": "",
-        })()
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": json.dumps({"result": result_text, "type": "result"}),
+                "stderr": "",
+            },
+        )()
 
         backend = CLIBackend(command="claude")
         output = backend.complete("system prompt", "user text")
@@ -53,11 +61,15 @@ class TestCLIBackendClaude:
     @patch("entirecontext.core.llm.subprocess.run")
     def test_returns_raw_on_unparseable(self, mock_run):
         """If output is not valid JSON, return as-is."""
-        mock_run.return_value = type("Result", (), {
-            "returncode": 0,
-            "stdout": "not json at all",
-            "stderr": "",
-        })()
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": "not json at all",
+                "stderr": "",
+            },
+        )()
 
         backend = CLIBackend(command="claude")
         output = backend.complete("system prompt", "user text")
@@ -67,11 +79,15 @@ class TestCLIBackendClaude:
     @patch("entirecontext.core.llm.subprocess.run")
     def test_codex_backend_passthrough(self, mock_run):
         """Codex backend should not apply claude unwrap logic."""
-        mock_run.return_value = type("Result", (), {
-            "returncode": 0,
-            "stdout": "raw codex output",
-            "stderr": "",
-        })()
+        mock_run.return_value = type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": "raw codex output",
+                "stderr": "",
+            },
+        )()
 
         backend = CLIBackend(command="codex")
         output = backend.complete("system prompt", "user text")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -426,9 +426,7 @@ class TestMCPToolIntegration:
 
         result = json.loads(asyncio.run(ec_search("auth", until="missing-ref", repos=["repo-a"])))
 
-        assert result == {
-            "error": "Cannot resolve temporal reference 'missing-ref': not a valid git ref or date"
-        }
+        assert result == {"error": "Cannot resolve temporal reference 'missing-ref': not a valid git ref or date"}
         cross_search.assert_not_called()
 
     def test_ec_search_semantic_import_error(self, mock_repo_db):

--- a/tests/test_migration_v016.py
+++ b/tests/test_migration_v016.py
@@ -41,9 +41,7 @@ CREATE TABLE decision_candidates (
 def v15_db():
     """A genuine schema-v15 database: narrow decision_candidates CHECK, no archaeology_processed."""
     conn = get_memory_db()
-    conn.execute(
-        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)"
-    )
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)")
     conn.execute("INSERT INTO schema_version (version, description) VALUES (15, 'v15')")
 
     # FK targets referenced by decision_candidates (foreign_keys=ON requires them to exist).
@@ -53,15 +51,9 @@ def v15_db():
     conn.execute("CREATE TABLE decisions (id TEXT PRIMARY KEY)")
 
     conn.execute(_V15_DECISION_CANDIDATES_DDL)
-    conn.execute(
-        "CREATE INDEX idx_decision_candidates_review ON decision_candidates(review_status)"
-    )
-    conn.execute(
-        "CREATE INDEX idx_decision_candidates_source ON decision_candidates(source_type, source_id)"
-    )
-    conn.execute(
-        "CREATE INDEX idx_decision_candidates_confidence ON decision_candidates(confidence DESC)"
-    )
+    conn.execute("CREATE INDEX idx_decision_candidates_review ON decision_candidates(review_status)")
+    conn.execute("CREATE INDEX idx_decision_candidates_source ON decision_candidates(source_type, source_id)")
+    conn.execute("CREATE INDEX idx_decision_candidates_confidence ON decision_candidates(confidence DESC)")
     conn.execute("CREATE INDEX idx_decision_candidates_dedup ON decision_candidates(dedup_key)")
     conn.execute("CREATE INDEX idx_decision_candidates_session ON decision_candidates(session_id)")
     conn.execute(
@@ -124,9 +116,7 @@ def test_source_type_accepts_archaeology(v15_db):
         "(id, title, source_type, source_id, confidence, dedup_key) "
         "VALUES ('test1', 'Test', 'archaeology', 'abc123', 0.5, 'dk1')"
     )
-    row = v15_db.execute(
-        "SELECT source_type FROM decision_candidates WHERE id = 'test1'"
-    ).fetchone()
+    row = v15_db.execute("SELECT source_type FROM decision_candidates WHERE id = 'test1'").fetchone()
     assert row["source_type"] == "archaeology"
 
 
@@ -147,9 +137,7 @@ def test_existing_candidates_preserved(v15_db):
         "VALUES ('pre1', 'Existing', 'session', 's1', 0.7, 'dk0', 'reason')"
     )
     apply_migrations(v15_db, 15, 16)
-    row = v15_db.execute(
-        "SELECT title, source_type, rationale FROM decision_candidates WHERE id = 'pre1'"
-    ).fetchone()
+    row = v15_db.execute("SELECT title, source_type, rationale FROM decision_candidates WHERE id = 'pre1'").fetchone()
     assert row["title"] == "Existing"
     assert row["source_type"] == "session"
     assert row["rationale"] == "reason"
@@ -170,9 +158,7 @@ def test_fts_triggers_work_after_migration(v15_db):
 
 def test_archaeology_processed_schema(v15_db):
     apply_migrations(v15_db, 15, 16)
-    v15_db.execute(
-        "INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc123', 3)"
-    )
+    v15_db.execute("INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc123', 3)")
     row = v15_db.execute(
         "SELECT commit_sha, candidate_count, processed_at FROM archaeology_processed WHERE commit_sha = 'abc123'"
     ).fetchone()

--- a/tests/test_migration_v017.py
+++ b/tests/test_migration_v017.py
@@ -10,9 +10,7 @@ from entirecontext.db.migration import apply_migrations
 @pytest.fixture
 def v16_db():
     conn = get_memory_db()
-    conn.execute(
-        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)"
-    )
+    conn.execute("CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT, description TEXT)")
     conn.execute("INSERT INTO schema_version (version, description) VALUES (16, 'v16')")
     conn.execute(
         "CREATE TABLE archaeology_processed ("
@@ -25,19 +23,13 @@ def v16_db():
 
 
 def test_v16_rows_default_to_pr_incomplete(v16_db):
-    v16_db.execute(
-        "INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc', 2)"
-    )
+    v16_db.execute("INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc', 2)")
     apply_migrations(v16_db, 16, 17)
-    row = v16_db.execute(
-        "SELECT candidate_count, pr_body_processed FROM archaeology_processed"
-    ).fetchone()
+    row = v16_db.execute("SELECT candidate_count, pr_body_processed FROM archaeology_processed").fetchone()
     assert tuple(row) == (2, 0)
 
 
 def test_v16_read_only_state_fallback(v16_db):
-    v16_db.execute(
-        "INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc', 2)"
-    )
+    v16_db.execute("INSERT INTO archaeology_processed (commit_sha, candidate_count) VALUES ('abc', 2)")
     state = _get_processing_state(v16_db, "abc")
     assert state == _ProcessingState(True, False, 2)

--- a/tests/test_ranking_snapshot_backpatch.py
+++ b/tests/test_ranking_snapshot_backpatch.py
@@ -21,9 +21,7 @@ def test_backpatch_links_snapshot_to_event(ec_db):
 
     backpatch_snapshot_event(conn, snapshot_id="snap-1", retrieval_event_id="evt-1")
 
-    row = conn.execute(
-        "SELECT retrieval_event_id FROM ranking_snapshots WHERE id = ?", ("snap-1",)
-    ).fetchone()
+    row = conn.execute("SELECT retrieval_event_id FROM ranking_snapshots WHERE id = ?", ("snap-1",)).fetchone()
     assert row["retrieval_event_id"] == "evt-1"
 
 
@@ -106,9 +104,7 @@ def test_session_start_wiring_backpatches_snapshot(ec_repo, ec_db, monkeypatch):
     on_session_start_decisions(data)
 
     # A snapshot should exist and be backpatched
-    row = conn.execute(
-        "SELECT id, retrieval_event_id FROM ranking_snapshots"
-    ).fetchone()
+    row = conn.execute("SELECT id, retrieval_event_id FROM ranking_snapshots").fetchone()
     assert row is not None, "Expected a ranking snapshot to be captured"
     assert row["retrieval_event_id"] is not None, "Expected retrieval_event_id to be backpatched"
 
@@ -188,9 +184,7 @@ def test_mcp_ec_decision_related_backpatches_snapshot(ec_repo, ec_db, monkeypatc
     assert "error" not in payload
 
     # A snapshot should exist and be backpatched
-    row = conn.execute(
-        "SELECT id, retrieval_event_id FROM ranking_snapshots"
-    ).fetchone()
+    row = conn.execute("SELECT id, retrieval_event_id FROM ranking_snapshots").fetchone()
     assert row is not None, "Expected a ranking snapshot to be captured"
     assert row["retrieval_event_id"] == "evt-test-1"
 
@@ -263,9 +257,7 @@ def test_worker_path_backpatches_snapshot(ec_repo, ec_db, monkeypatch):
     conn2 = get_db(repo_path)
     try:
         # A snapshot should exist and be backpatched with a real event_id
-        row = conn2.execute(
-            "SELECT id, retrieval_event_id FROM ranking_snapshots"
-        ).fetchone()
+        row = conn2.execute("SELECT id, retrieval_event_id FROM ranking_snapshots").fetchone()
         assert row is not None, "Expected a ranking snapshot from the worker path"
         assert row["retrieval_event_id"] is not None, "Expected retrieval_event_id to be backpatched"
     finally:

--- a/tests/test_ranking_snapshot_integration.py
+++ b/tests/test_ranking_snapshot_integration.py
@@ -40,9 +40,7 @@ def test_full_snapshot_lifecycle(ec_db):
         latency_ms=1,
     )
     backpatch_snapshot_event(conn, snapshot_id=snapshot_id, retrieval_event_id=event["id"])
-    row = conn.execute(
-        "SELECT retrieval_event_id FROM ranking_snapshots WHERE id = ?", (snapshot_id,)
-    ).fetchone()
+    row = conn.execute("SELECT retrieval_event_id FROM ranking_snapshots WHERE id = ?", (snapshot_id,)).fetchone()
     assert row["retrieval_event_id"] == event["id"]
 
     # 4. Verify snapshot content

--- a/tests/test_ranking_snapshot_security.py
+++ b/tests/test_ranking_snapshot_security.py
@@ -19,9 +19,7 @@ def test_seeded_secret_never_stored(ec_db):
         "ghp_1234567890abcdefABCDEF1234567890abcd",
         "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test.signature",
     ]
-    diff_with_secrets = "\n".join(
-        f"+API_KEY = '{s}'" for s in planted_secrets
-    )
+    diff_with_secrets = "\n".join(f"+API_KEY = '{s}'" for s in planted_secrets)
 
     results, stats = rank_related_decisions(
         conn,

--- a/tests/test_search_redaction.py
+++ b/tests/test_search_redaction.py
@@ -66,7 +66,9 @@ def test_regex_search_events_with_since_filter(conn):
     )
     conn.commit()
 
-    results = _regex_search_events(conn, "deploy", since="2025-01-01T00:00:00", until=None, until_exclusive=False, limit=10)
+    results = _regex_search_events(
+        conn, "deploy", since="2025-01-01T00:00:00", until=None, until_exclusive=False, limit=10
+    )
     assert len(results) == 1
     assert results[0]["id"] == new_event_id
 

--- a/tests/test_tql_integration.py
+++ b/tests/test_tql_integration.py
@@ -67,7 +67,10 @@ def conn_with_turns(tmp_path):
     ]
     for t in turns:
         db.execute("INSERT INTO turns VALUES (?, ?, ?, ?, ?, ?, ?)", t)
-        db.execute("INSERT INTO fts_turns(rowid, user_message, assistant_summary) VALUES (last_insert_rowid(), ?, ?)", (t[2], t[3]))
+        db.execute(
+            "INSERT INTO fts_turns(rowid, user_message, assistant_summary) VALUES (last_insert_rowid(), ?, ?)",
+            (t[2], t[3]),
+        )
 
     events = [
         (str(uuid4()), "milestone", "auth v1", "first auth release", "done", "2026-02-01 00:00:00"),


### PR DESCRIPTION
## Purpose

Close the second half of the gap #209 opened. That PR made the lint rule set explicit; formatting was still enforced nowhere, and 44 Python files had drifted from `ruff format` output with nothing measuring it.

## Commits

| Commit | Change |
|---|---|
| `2c61043` | `style:` mechanical reformat of the 44 drifted files |
| `9ff713e` | `chore(ci):` the gate, the Markdown exclusion, and ADR 0007 |

Split so the policy change is reviewable without scrolling through 44 files of whitespace.

## The Markdown question

Ruff 0.16 formats Python code blocks inside Markdown. With Markdown in scope the drift is 58 files, not 44. The extra 14 are all under `docs/superpowers/` — plans and specs that record what was proposed at a point in time:

```
docs/superpowers/plans/2026-04-04-decision-hooks.md:279
    check=True, capture_output=True,
```

Reformatting that rewrites the record of what was written, and improves no shipped code. So the exclusion is scoped to the formatter only:

```toml
[tool.ruff.format]
exclude = ["docs/**/*.md"]
```

Lint coverage is unchanged — this is `[tool.ruff.format]`, not `[tool.ruff]`.

## Test evidence

The reformat touches 44 source and test files, so behaviour neutrality needs the full suite, not a subset:

```
pytest -q -rs   ->  2172 passed, 1 skipped in 117.07s
SKIPPED [1] tests/test_hooks_performance.py:125: Set RECORD_PERF=1 to record results to docs/perf/
```

The single skip is the opt-in perf recorder, not a gap.

Config verification:

```
ruff format --check .   before exclusion  ->  58 files would be reformatted
ruff format --check .   after exclusion   ->  44 files would be reformatted
ruff format .                             ->  44 files reformatted
ruff format --check .   after apply       ->  284 files already formatted
ruff check .                              ->  All checks passed!
```

## Conflict surface

The reformat commit touches 44 files. Checked against the two live worktrees at the time of writing — `feat/roadmap-completion` and `docs/blame-sha-lookup-retro` — the overlap with the reformatted set is zero files. Future long-running branches will need a rebase; ADR 0007 records this.

## Unrelated finding, not addressed here

While repairing the local environment for this work, `tests/test_mcp.py` turned out to skip its 119 tests whenever the `mcp` extra is absent. CI installs `uv sync --extra dev` only (`.github/workflows/ci.yml:28,47,67`), so those 119 tests never run in CI. They pass locally with the extra installed:

```
pytest tests/test_mcp.py -q  ->  119 passed
```

That is a separate CI coverage gap, deliberately not mixed into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
