### PR TITLE
fix(test): isolate tests from host git config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,23 @@ import pytest
 import tests.conftest_hypothesis  # noqa: F401
 
 
+def git_commit_env() -> dict[str, str]:
+    """Environment for subprocess git commits that must pass ``env=`` explicitly.
+
+    ``env=`` replaces the inherited environment rather than extending it, so a
+    hand-built mapping silently drops the variables ``hermetic_git_config`` sets
+    and lets host configuration back in. Building on ``os.environ`` keeps the
+    isolation, and carries PATH along without a separate lookup.
+    """
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    }
+
+
 @pytest.fixture(autouse=True)
 def hermetic_git_config(monkeypatch):
     """Isolate every git invocation from the host's global and system config.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,26 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 
 import pytest
 
 import tests.conftest_hypothesis  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def hermetic_git_config(monkeypatch):
+    """Isolate every git invocation from the host's global and system config.
+
+    Whatever the developer has set globally — commit.gpgsign, signing keys,
+    aliases, hook paths — otherwise leaks into the repos these tests build, so a
+    test's outcome depends on whose machine it runs on. Individual fixtures used
+    to disable commit.gpgsign one at a time; each new call site reintroduced the
+    same failure until it was patched too.
+    """
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_archaeology.py
+++ b/tests/test_archaeology.py
@@ -23,16 +23,11 @@ from entirecontext.core.archaeology import (
     ArchaeologyResult,
 )
 from entirecontext.core.decision_extraction import ExtractionOutcome
+from tests.conftest import git_commit_env
 
 
 def _make_commits(git_repo, n, prefix="c"):
-    env = {
-        "GIT_AUTHOR_NAME": "Test",
-        "GIT_AUTHOR_EMAIL": "test@test.com",
-        "GIT_COMMITTER_NAME": "Test",
-        "GIT_COMMITTER_EMAIL": "test@test.com",
-        "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-    }
+    env = git_commit_env()
     for i in range(n):
         (git_repo / f"{prefix}{i}.txt").write_text(f"content {i}")
         subprocess.run(["git", "add", "."], cwd=git_repo, check=True)
@@ -187,13 +182,7 @@ class TestStreamCommits:
                 ["git", "commit", "-m", f"commit {i}"],
                 cwd=git_repo,
                 check=True,
-                env={
-                    "GIT_AUTHOR_NAME": "Test",
-                    "GIT_AUTHOR_EMAIL": "test@test.com",
-                    "GIT_COMMITTER_NAME": "Test",
-                    "GIT_COMMITTER_EMAIL": "test@test.com",
-                    "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-                },
+                env=git_commit_env(),
             )
         commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=10))
         assert len(commits) >= 3
@@ -210,13 +199,7 @@ class TestStreamCommits:
                 ["git", "commit", "-m", f"c{i}"],
                 cwd=git_repo,
                 check=True,
-                env={
-                    "GIT_AUTHOR_NAME": "Test",
-                    "GIT_AUTHOR_EMAIL": "test@test.com",
-                    "GIT_COMMITTER_NAME": "Test",
-                    "GIT_COMMITTER_EMAIL": "test@test.com",
-                    "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-                },
+                env=git_commit_env(),
             )
         commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=2))
         assert len(commits) == 2
@@ -239,13 +222,7 @@ class TestStreamCommits:
             ],
             cwd=git_repo,
             check=True,
-            env={
-                "GIT_AUTHOR_NAME": "Test",
-                "GIT_AUTHOR_EMAIL": "test@test.com",
-                "GIT_COMMITTER_NAME": "Test",
-                "GIT_COMMITTER_EMAIL": "test@test.com",
-                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-            },
+            env=git_commit_env(),
         )
         commits = list(_stream_commits(str(git_repo), since=None, until=None, limit=1))
         assert len(commits) == 1

--- a/tests/test_archaeology_cli.py
+++ b/tests/test_archaeology_cli.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from entirecontext.cli import app
 from entirecontext.cli import decisions_cmds
+from tests.conftest import git_commit_env
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -40,13 +41,7 @@ def test_dry_run_on_fixture(git_repo):
             ["git", "commit", "-m", f"feat: add file{i}"],
             cwd=git_repo,
             check=True,
-            env={
-                "GIT_AUTHOR_NAME": "Test",
-                "GIT_AUTHOR_EMAIL": "test@test.com",
-                "GIT_COMMITTER_NAME": "Test",
-                "GIT_COMMITTER_EMAIL": "test@test.com",
-                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-            },
+            env=git_commit_env(),
         )
     result = subprocess.run(
         ["uv", "run", "ec", "archaeologize", "--dry-run"],
@@ -69,13 +64,7 @@ def test_dry_run_does_not_create_db(git_repo):
             ["git", "commit", "-m", f"feat: add file{i}"],
             cwd=git_repo,
             check=True,
-            env={
-                "GIT_AUTHOR_NAME": "Test",
-                "GIT_AUTHOR_EMAIL": "test@test.com",
-                "GIT_COMMITTER_NAME": "Test",
-                "GIT_COMMITTER_EMAIL": "test@test.com",
-                "PATH": subprocess.check_output(["bash", "-c", "echo $PATH"]).decode().strip(),
-            },
+            env=git_commit_env(),
         )
     result = subprocess.run(
         ["uv", "run", "ec", "archaeologize", "--dry-run"],

--- a/tests/test_git_isolation.py
+++ b/tests/test_git_isolation.py
@@ -1,0 +1,56 @@
+"""Regression tests for host git-config isolation.
+
+The suite builds real git repos and commits in them. Without isolation, whatever
+the developer sets globally — commit.gpgsign, core.hooksPath, aliases — changes
+what those commands do, so results depend on whose machine runs them. CI cannot
+catch that: runners have no such configuration, so the failures appear only
+locally.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from tests.conftest import git_commit_env
+
+
+def _git(args: list[str], cwd, env=None) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, env=env)
+    return result.stdout.strip()
+
+
+class TestHermeticGitConfig:
+    def test_global_and_system_config_are_redirected(self):
+        assert os.environ["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert os.environ["GIT_CONFIG_SYSTEM"] == os.devnull
+
+    def test_git_sees_no_global_config(self, git_repo):
+        assert _git(["config", "--global", "--list"], git_repo) == ""
+
+    def test_git_sees_no_system_config(self, git_repo):
+        assert _git(["config", "--system", "--list"], git_repo) == ""
+
+    def test_repo_local_config_still_applies(self, git_repo):
+        """Isolation must not break the per-repo identity fixtures set."""
+        assert _git(["config", "--local", "--get", "user.email"], git_repo) == "test@test.com"
+
+
+class TestGitCommitEnv:
+    def test_carries_the_isolation_variables(self):
+        """env= replaces rather than extends, so the helper must pass these through."""
+        env = git_commit_env()
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+
+    def test_carries_path(self):
+        assert git_commit_env()["PATH"] == os.environ["PATH"]
+
+    def test_sets_commit_identity(self):
+        env = git_commit_env()
+        assert env["GIT_AUTHOR_EMAIL"] == "test@test.com"
+        assert env["GIT_COMMITTER_EMAIL"] == "test@test.com"
+
+    def test_isolation_reaches_subprocesses_given_an_explicit_env(self, git_repo):
+        """A subprocess run with env=git_commit_env() must not see host config."""
+        assert _git(["config", "--global", "--list"], git_repo, env=git_commit_env()) == ""


### PR DESCRIPTION
## Purpose

Stop patching the same host-config leak one call site at a time.

## The recurring failure

Tests build real git repos and commit in them. Whatever the developer has set in their **global** git config leaks into those repos. On a host with `commit.gpgsign=true` and an SSH signing key that requires confirmation, `git commit` fails:

```
CalledProcessError: ['git', ..., 'commit', '--allow-empty', '-m', 'init'] returned exit status 128
Signing ... failed: agent refused operation
```

Three commits have addressed this, each covering only the call sites known at the time:

| commit | covered | missed |
|---|---|---|
| `5701996` | `conftest.py` fixtures | helpers that build their own repos |
| `5b0aed8` | `test_sync_integration.py`, `test_tql_integration.py` | `test_project_cmds.py` |
| — | — | found while verifying #212 |

The third miss was mine: I checked `test_project_cmds.py` while writing `5b0aed8`, saw `git init` without a commit in the first matches, and concluded it was unaffected. `test_install_resolves_hooks_dir_in_linked_worktree` at line 494 does commit.

## Why the pattern repeats

**CI cannot catch it.** GitHub runners have no signing configured, so every one of these failures is invisible in CI and appears only for developers whose global config sets it. There is no gate to fail; the only detection is someone running the suite locally and reading the traceback.

**Each new test reintroduces it.** Any future test that builds its own repo starts broken again, and the fix is only applied once someone hits it.

## Change

One autouse fixture in `tests/conftest.py`:

```python
@pytest.fixture(autouse=True)
def hermetic_git_config(monkeypatch):
    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
```

The leak is global-scoped — verified on this host:

```
git config --global --get commit.gpgsign  ->  true
git config --global --get gpg.format      ->  ssh
git config --local  --get commit.gpgsign  ->  (unset)
```

So redirecting `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` closes the entire class, not just signing: aliases, `core.hooksPath`, `init.defaultBranch`, and anything else a developer sets globally.

Repo-local config is untouched, so fixtures that set `user.email` and `user.name` per repo keep working.

## Test evidence

The specific failure, before and after:

```
before  ->  1 failed  (test_install_resolves_hooks_dir_in_linked_worktree)
after   ->  1 passed
```

Full suite on this host:

```
before  ->  1 failed, 2171 passed, 1 skipped
after   ->  2172 passed, 1 skipped in 123.90s
```

Lint:

```
ruff check .          ->  All checks passed!
ruff format --check . ->  284 files already formatted
```

## Left in place deliberately

The per-fixture `commit.gpgsign false` calls added by `5701996` and `5b0aed8` are now redundant. They are harmless and removing them is unrelated cleanup, so this PR leaves them. Noting it here so the redundancy is a recorded choice rather than an oversight.

EC decision: `4a3e6bcc-9588-4000-83b2-54b09a2c9c26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
