### PR TITLE
docs(lessons): regenerate after recording feedback on 16c24bc6

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,6 +1,6 @@
 # Lessons Learned
 
-_Generated from 46 assessed changes._
+_Generated from 47 assessed changes._
 
 ## 🟢 Expand (increases future options)
 
@@ -175,6 +175,12 @@ _Assessment: 84288d4f | 2026-02-20T10:48:16.009213+00:00_
 _Assessment: dd6184a2 | 2026-02-20T08:51:22.221135+00:00_
 
 ## 🟡 Neutral
+
+### ✅ Merge pull request #215 from teslamint/chore/mypy-mcp-runtime (16c24bc6)
+
+**Feedback:** agree — Correct as neutral for roadmap-position purposes: neither PR adds product surface. But the type-safety change is not cosmetic — 60 of 127 mypy errors came from one unnarrowable Connection | None shape, and replacing it means future MCP tools start from a checked baseline rather than inheriting the union. The MD024 fix likewise restores anchor reachability in a generated file, not just tidiness.
+
+_Assessment: 16c24bc6 | 2026-08-12T03:33:14.568011+00:00_
 
 ### ✅ All three approved regression scenarios are delivered. Full suite passed 2114 tests with 1 skip; Ruff and mypy passed. One non-blocking session-embedding regression-test coverage gap remains. (a1661d20)
 


### PR DESCRIPTION
## Purpose

`ec futures feedback` auto-distills `LESSONS.md`. Recording the agree verdict on assessment `16c24bc6` (the MCP-typing work from #215) rewrote the file, leaving main dirty. Committing the generated output through a branch rather than pushing to protected main.

## Evidence

This is the first regeneration on real data since #214 made headings unique:

```
$ rg -c '^### ' LESSONS.md
47
$ rg '^### ' LESSONS.md | sort | uniq -d | wc -l
0
```

Before #214, `### ❌ Auto-assessed checkpoint` alone appeared 7 times in this file.

Generated output only — no source or test changes.