### PR TITLE
fix(mcp): stop ec mcp serve from silently succeeding on missing SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ semantic = [
     "sentence-transformers>=3.0.0",
 ]
 mcp = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
 ]
 dev = [
     "hatchling>=1.27,<2",

--- a/src/entirecontext/cli/mcp_cmds.py
+++ b/src/entirecontext/cli/mcp_cmds.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import typer
 from rich.console import Console
 
-console = Console()
+# stderr: `ec mcp serve` speaks JSON-RPC over stdout, so diagnostics must not
+# touch stdout even on the failure paths.
+console = Console(stderr=True)
 mcp_app = typer.Typer(help="MCP server management")
 
 
@@ -14,11 +16,14 @@ def mcp_serve():
     """Start the MCP server (stdio transport)."""
     try:
         from ..mcp.server import run_server
+    except ImportError as exc:
+        console.print(f"[red]MCP server module import failed: {exc}[/red]")
+        console.print("[yellow]Install the extra: uv tool install --force 'entirecontext[mcp] @ <repo path>'[/yellow]")
+        raise typer.Exit(1) from exc
 
-        run_server()
-    except ImportError:
-        console.print("[red]MCP not available. Install with: pip install 'entirecontext[mcp]'[/red]")
-        raise typer.Exit(1)
+    # Deliberately outside the try: exceptions raised inside run_server keep
+    # their own traceback instead of being misreported as an import problem.
+    run_server()
 
 
 def register(app: typer.Typer) -> None:

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -8,12 +8,14 @@ from typing import Any
 # Declared before the import so the ImportError fallback is an assignment to an
 # existing name rather than a redefinition of the imported class.
 FastMCP: Any
+_FASTMCP_IMPORT_ERROR: ImportError | None = None
 try:
     from mcp.server.fastmcp import FastMCP as _FastMCP
 
     FastMCP = _FastMCP
-except ImportError:
+except ImportError as exc:
     FastMCP = None
+    _FASTMCP_IMPORT_ERROR = exc
 
 mcp: Any = FastMCP("entirecontext") if FastMCP is not None else None
 
@@ -132,8 +134,13 @@ if mcp:
 def run_server() -> None:
     """Run the MCP server (stdio transport)."""
     if mcp is None:
-        print("MCP not available. Install with: pip install 'entirecontext[mcp]'")
-        return
+        # Keep the original ImportError, if any, in the chain for accurate
+        # diagnosis. Raising (instead of print+return) gives a non-zero exit
+        # code and keeps stdout clean of non-JSON-RPC text.
+        raise RuntimeError(
+            "MCP SDK unavailable: 'from mcp.server.fastmcp import FastMCP' failed. "
+            "Install the extra: uv tool install --force 'entirecontext[mcp] @ <repo path>'"
+        ) from _FASTMCP_IMPORT_ERROR
     import sys
     from entirecontext import __version__
 

--- a/tests/test_mcp_cmds.py
+++ b/tests/test_mcp_cmds.py
@@ -4,22 +4,55 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from entirecontext.cli import app
+from entirecontext.mcp import server as server_module
 
 runner = CliRunner()
 
 
 class TestMcpServe:
     def test_import_error(self):
-        with patch("entirecontext.cli.mcp_cmds.console"):
-            with patch.dict("sys.modules", {"entirecontext.mcp": None, "entirecontext.mcp.server": None}):
-                result = runner.invoke(app, ["mcp", "serve"])
-                assert result.exit_code == 1
+        with patch.dict("sys.modules", {"entirecontext.mcp.server": None}):
+            result = runner.invoke(app, ["mcp", "serve"])
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert "MCP server module import failed" in result.stderr
 
     def test_success(self):
         with patch("entirecontext.mcp.server.run_server") as mock_run:
             result = runner.invoke(app, ["mcp", "serve"])
             assert result.exit_code == 0
             mock_run.assert_called_once()
+            assert result.stdout == ""
+
+    def test_run_server_import_error_propagates(self):
+        """Regression: run_server() raising ImportError must not be swallowed."""
+        with patch.object(server_module, "run_server", side_effect=ImportError("boom")):
+            result = runner.invoke(app, ["mcp", "serve"])
+        assert result.exit_code == 1
+        assert "boom" in str(result.exception)
+        assert "MCP server module import failed" not in result.stderr
+
+    def test_run_server_sdk_missing_raises(self):
+        """When the MCP SDK is unavailable, run_server must raise, not return."""
+        with (
+            patch.object(server_module, "mcp", None),
+            patch.object(server_module, "_FASTMCP_IMPORT_ERROR", ImportError("no mcp")),
+        ):
+            with pytest.raises(RuntimeError, match="MCP SDK unavailable"):
+                server_module.run_server()
+
+    def test_run_server_sdk_missing_message_mentions_install(self):
+        """The RuntimeError message includes install guidance but no 'MCP not available' duplicate."""
+        with (
+            patch.object(server_module, "mcp", None),
+            patch.object(server_module, "_FASTMCP_IMPORT_ERROR", ImportError("no mcp")),
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                server_module.run_server()
+            msg = str(excinfo.value)
+            assert "Install the extra" in msg
+            assert "MCP not available" not in msg

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ dev = [
 requires-dist = [
     { name = "hatchling", marker = "extra == 'dev'", specifier = ">=1.27,<2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },


### PR DESCRIPTION
# Fix `ec mcp serve` silent failure on missing MCP SDK

## Problem
`ec mcp serve` was failing in two ways:
1. The installed `entirecontext` uv tool venv was stale: `pyproject.toml` declared the `mcp` extra, but the venv contained no MCP SDK. Reinstalling with the local repo path fixes that.
2. `src/entirecontext/cli/mcp_cmds.py` wrapped the call to `run_server()` inside the same `try/except ImportError` that guarded the import, so any internal `ImportError` was misreported as "install the extra". Meanwhile `src/entirecontext/mcp/server.py` printed the same message to **stdout** and returned, making the process exit 0 — a silent success that polluted the stdio JSON-RPC stream.

## Changes
- `src/entirecontext/cli/mcp_cmds.py`
  - Narrow `try/except ImportError` to only the import statement.
  - Call `run_server()` **outside** the `try`, so internal exceptions propagate with their original traceback.
  - Use `Console(stderr=True)` so diagnostics never touch stdout.
  - Keep an explicit, accurate install hint.
- `src/entirecontext/mcp/server.py`
  - Capture the original `ImportError` in `_FASTMCP_IMPORT_ERROR`.
  - Replace `print(...)` + `return` with `raise RuntimeError(...) from _FASTMCP_IMPORT_ERROR`, yielding a non-zero exit code and a clean stdout.
  - Remove the duplicated "MCP not available" wording; the phrase now appears nowhere in `src/`.
- `pyproject.toml`
  - Pin `mcp>=1.0.0,<2` because `mcp==2.0.0` removed `FastMCP` from `mcp.server.fastmcp`.
- `tests/test_mcp_cmds.py`
  - Import-error path exits 1 and writes to stderr, stdout stays empty.
  - Regression: an `ImportError("boom")` raised inside `run_server()` propagates unmodified, not swallowed as an import-hint message.
  - SDK-missing path raises `RuntimeError` with install guidance, no duplicate wording.

## Verification
- Static gates: `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src` — all pass.
- Module tests: `uv run pytest tests/test_mcp_cmds.py tests/test_mcp.py -q` — 127 passed.
- Full suite: `uv run pytest -q` — 2297 passed, 1 skipped.
- Empirical (with MCP 1.29.0 reinstalled from the local checkout):
  - `ec mcp serve </dev/null` → exit 0, stdout 0 bytes, stderr `[ec-mcp] starting v0.14.0`.
  - `tools/list` over stdio JSON-RPC → 29 `ec_*` tools, raw payload 25,846 bytes.
- The old "MCP not available" string is gone from the codebase.

## Traceability
- Plan: `docs/plans/2026-08-19-001-fix-mcp-serve-silent-failure-plan.md`
- No governing spec/ADR exists for this bug-fix handoff; `scripts/validate_plan.py` not invoked.
