### PR TITLE
feat(mcp): migrate server to MCP SDK 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,6 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      # mcp is installed ahead of need. Today every entirecontext.mcp module sits
-      # under ignore_errors = true (ADR 0002), so mypy reports nothing there either
-      # way. When those overrides are lifted, mypy must see the real FastMCP types
-      # rather than the FastMCP = None fallback in mcp/server.py.
       - name: Install dependencies
         run: uv sync --extra dev --extra mcp
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -403,7 +403,7 @@ All PR #205 carry-forwards are registered under v0.16.0 above.
 
 - [x] **Lift the `entirecontext.mcp.*` mypy overrides** — all nine MCP modules sat under `ignore_errors = true`, hiding 127 errors across 2,261 lines. Removed in three stages: annotate `runtime.py` (127 → 106), replace the `resolve_repo` tuple-plus-error-payload shape with a raising `open_repo` (106 → 48, since 60 errors traced to the unnarrowable `Connection | None`), then annotate the remaining modules (48 → 0). `mypy src/entirecontext/` now enforces the whole package in CI. ADR 0002's override list is nine entries shorter. Surfaced by review on PR #212.
 
-- [ ] **Migrate MCP server to SDK 2.0** — `mcp>=1.0.0,<2` is pinned in PR #228 because `mcp==2.0.0` removed `mcp.server.fastmcp.FastMCP`. A deliberate migration to `mcp.server.MCPServer` (or the new high-level API) is needed before the pin can be relaxed. _(dependency, P3; carry-forward from PR #228, ADR 0017)_
+- [x] **Migrate MCP server to SDK 2.0** — `FastMCP` → `MCPServer` import migration completed; pin relaxed to `mcp>=2.0.0,<3`. _(dependency, P3; carry-forward from PR #228, ADR 0017 → superseded by ADR 0018)_
 
 - [x] **`distill_lessons` emits duplicate Markdown headings** — every `LESSONS.md` heading came from `impact_summary` alone, so repeated summaries (`Auto-assessed checkpoint` ×7, identical `chore(deps)` bumps) collided and all but the first anchor became unreachable. Fixed by appending the short assessment ID to the heading; `test_distill_lessons_headings_are_unique_per_assessment` guards it. No markdownlint config or CI step was added — the unit test is the enforcement point. Surfaced by CodeRabbit review on PR #206.
 

--- a/docs/adr/0017-pin-mcp-extra-below-2.md
+++ b/docs/adr/0017-pin-mcp-extra-below-2.md
@@ -1,6 +1,6 @@
 # 0017. Pin MCP Extra Below 2.0 and Raise on Missing SDK
 
-**Status:** accepted  
+**Status:** superseded-by-0018  
 **Date:** 2026-08-19  
 **EC Decision:** `4676448c-f2b8-4f2c-b2f5-9d75862b26e8`
 

--- a/docs/adr/0018-migrate-mcp-server-to-sdk-2.md
+++ b/docs/adr/0018-migrate-mcp-server-to-sdk-2.md
@@ -1,0 +1,54 @@
+# 0018. Migrate MCP Server to SDK 2.0
+
+**Status:** accepted  
+**Date:** 2026-08-19  
+**Supersedes:** 0017
+
+## Context
+
+ADR 0017 pinned `mcp>=1.0.0,<2` because MCP SDK 2.0.0 removed
+`mcp.server.fastmcp.FastMCP`. The pin was a deliberate stopgap; a
+migration to the 2.0 API was deferred to a separate release loop.
+
+Dependabot PR #222 attempted to relax the pin to `<3` but failed CI
+because `mcp.server.fastmcp` no longer exists in 2.0.
+
+## Decision
+
+1. Replace `from mcp.server.fastmcp import FastMCP` with
+   `from mcp.server import MCPServer` in `server.py`.
+2. Rename the fallback variable from `_FASTMCP_IMPORT_ERROR` to
+   `_MCP_IMPORT_ERROR` (class-name-agnostic).
+3. Pin `mcp>=2.0.0,<3` in `pyproject.toml`, dropping 1.x support.
+   The `mcp` extra is optional and installed in isolation via
+   `uv tool install`, so backwards compatibility is unnecessary.
+4. Update coordinated test references in `test_mcp_cmds.py` and
+   `test_contract_sync.py`.
+5. Update the architecture diagram in `docs/spec.md`.
+
+## Dependency Changes
+
+MCP 2.0.0 changes the transitive dependency tree:
+
+| Added | Removed |
+|-------|---------|
+| `httpx2` (+ `httpcore2`, `httpx2-jsfetch`) | `httpx-sse` |
+| `mcp-types` | `pydantic-settings` |
+| `opentelemetry-api` | `python-dotenv` |
+| `truststore` | |
+
+The `httpx` → `httpx2` transition follows the broader Python ecosystem
+shift. Conflict risk is mitigated by `uv tool install` isolation.
+
+## Consequences
+
+- The MCP server works with `mcp>=2.0.0`.
+- `ec mcp serve` stdio transport behavior is unchanged (`mcp.run()`
+  defaults to stdio).
+- Rollback: revert the pin to `>=1.0.0,<2` and the import to
+  `mcp.server.fastmcp.FastMCP`.
+- All 28 MCP tool functions use `async def` with the `mcp.tool()(fn)`
+  decorator pattern, which is unchanged in SDK 2.0. No tool
+  registration code requires modification.
+- Future MCP 2.x point releases are accepted by the `<3` upper bound.
+  CI (mypy + pytest) guards against regressions.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -37,7 +37,7 @@ This document describes the behavior implemented in the current codebase at a re
 User / Agent
   ├─ CLI (ec, Typer)
   ├─ Claude Code Hooks
-  └─ MCP Server (stdio, FastMCP)
+  └─ MCP Server (stdio, MCPServer)
 
 Core Engine
   ├─ Capture (sessions/turns)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ semantic = [
     "sentence-transformers>=3.0.0",
 ]
 mcp = [
-    "mcp>=1.0.0,<2",
+    "mcp>=2.0.0,<3",
 ]
 dev = [
     "hatchling>=1.27,<2",

--- a/src/entirecontext/mcp/server.py
+++ b/src/entirecontext/mcp/server.py
@@ -5,19 +5,17 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
-# Declared before the import so the ImportError fallback is an assignment to an
-# existing name rather than a redefinition of the imported class.
-FastMCP: Any
-_FASTMCP_IMPORT_ERROR: ImportError | None = None
+MCPServer: Any
+_MCP_IMPORT_ERROR: ImportError | None = None
 try:
-    from mcp.server.fastmcp import FastMCP as _FastMCP
+    from mcp.server import MCPServer as _MCPServer
 
-    FastMCP = _FastMCP
+    MCPServer = _MCPServer
 except ImportError as exc:
-    FastMCP = None
-    _FASTMCP_IMPORT_ERROR = exc
+    MCPServer = None
+    _MCP_IMPORT_ERROR = exc
 
-mcp: Any = FastMCP("entirecontext") if FastMCP is not None else None
+mcp: Any = MCPServer("entirecontext") if MCPServer is not None else None
 
 
 def _get_repo_db() -> tuple[sqlite3.Connection, str]:
@@ -138,9 +136,9 @@ def run_server() -> None:
         # diagnosis. Raising (instead of print+return) gives a non-zero exit
         # code and keeps stdout clean of non-JSON-RPC text.
         raise RuntimeError(
-            "MCP SDK unavailable: 'from mcp.server.fastmcp import FastMCP' failed. "
+            "MCP SDK unavailable: 'from mcp.server import MCPServer' failed. "
             "Install the extra: uv tool install --force 'entirecontext[mcp] @ <repo path>'"
-        ) from _FASTMCP_IMPORT_ERROR
+        ) from _MCP_IMPORT_ERROR
     import sys
     from entirecontext import __version__
 

--- a/tests/test_contract_sync.py
+++ b/tests/test_contract_sync.py
@@ -18,7 +18,7 @@ drift. The parity test below is strictly stronger.
 IMPLICIT CONTRACT NOTE: the parity test assumes tools register via the
 ``mcp.tool()(fn)`` pattern with ``registered_name == fn.__name__``. The
 ``_FakeMCP.tool()`` honors an optional ``name=`` kwarg override (matching
-real ``FastMCP.tool()``'s signature) but does NOT capture ``mcp.add_tool()``
+real ``MCPServer.tool()``'s signature) but does NOT capture ``mcp.add_tool()``
 calls. If a future registration uses either of those escape hatches, update
 the fake and/or the AST extractor at that time.
 """
@@ -37,9 +37,9 @@ SERVER_PY = REPO_ROOT / "src" / "entirecontext" / "mcp" / "server.py"
 
 
 class _FakeMCP:
-    """Minimal FastMCP stand-in that captures tool-registration names.
+    """Minimal MCPServer stand-in that captures tool-registration names.
 
-    Honors the ``name=`` kwarg override like real ``FastMCP.tool()`` does,
+    Honors the ``name=`` kwarg override like real ``MCPServer.tool()`` does,
     so a future ``mcp.tool(name="ec_alias")(fn)`` registration would be
     captured under the alias, not ``fn.__name__``.
     """

--- a/tests/test_mcp_cmds.py
+++ b/tests/test_mcp_cmds.py
@@ -40,7 +40,7 @@ class TestMcpServe:
         """When the MCP SDK is unavailable, run_server must raise, not return."""
         with (
             patch.object(server_module, "mcp", None),
-            patch.object(server_module, "_FASTMCP_IMPORT_ERROR", ImportError("no mcp")),
+            patch.object(server_module, "_MCP_IMPORT_ERROR", ImportError("no mcp")),
         ):
             with pytest.raises(RuntimeError, match="MCP SDK unavailable"):
                 server_module.run_server()
@@ -49,7 +49,7 @@ class TestMcpServe:
         """The RuntimeError message includes install guidance but no 'MCP not available' duplicate."""
         with (
             patch.object(server_module, "mcp", None),
-            patch.object(server_module, "_FASTMCP_IMPORT_ERROR", ImportError("no mcp")),
+            patch.object(server_module, "_MCP_IMPORT_ERROR", ImportError("no mcp")),
         ):
             with pytest.raises(RuntimeError) as excinfo:
                 server_module.run_server()

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ dev = [
 requires-dist = [
     { name = "hatchling", marker = "extra == 'dev'", specifier = ">=1.27,<2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
@@ -609,6 +609,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -624,12 +637,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -707,11 +737,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -910,15 +940,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -928,9 +958,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1228,6 +1271,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1354,20 +1409,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,15 +1459,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -2132,6 +2164,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrate MCP server from `FastMCP` (SDK 1.x) to `MCPServer` (SDK 2.0)
- Update `pyproject.toml` pin from `mcp>=1.0.0,<2` to `mcp>=2.0.0,<3`
- Rename `_FASTMCP_IMPORT_ERROR` → `_MCP_IMPORT_ERROR` (class-name-agnostic)
- Supersede ADR 0017 with ADR 0018 (documents dependency landscape changes)
- Check off ROADMAP carry-forward item from PR #228
- Remove stale CI workflow comment about mypy overrides

## Changed files

| File | Change |
|------|--------|
| `src/entirecontext/mcp/server.py` | Import path, class name, variable name, error message |
| `pyproject.toml` + `uv.lock` | Pin update + lock regeneration |
| `tests/test_mcp_cmds.py` | Patch target `_MCP_IMPORT_ERROR` |
| `tests/test_contract_sync.py` | Docstring references |
| `docs/spec.md` | Architecture diagram |
| `docs/adr/0017-*.md` | Status → superseded-by-0018 |
| `docs/adr/0018-*.md` | New ADR with dependency changes |
| `ROADMAP.md` | Item checked off |
| `.github/workflows/ci.yml` | Stale comment removed |

## Dependency changes (MCP 2.0)

| Added | Removed |
|-------|---------|
| `httpx2` (+`httpcore2`, `httpx2-jsfetch`) | `httpx-sse` |
| `mcp-types` | `pydantic-settings` |
| `opentelemetry-api` | `python-dotenv` |
| `truststore` | |

## Test evidence

```
$ uv run pytest --tb=short -q
2297 passed, 1 skipped in 126.83s

$ uv run mypy src/entirecontext/
Success: no issues found in 125 source files
```

## Review process

- Independent design review (critic agent): REVISE → revised with full blast radius
- Independent code review: COMMENT (2 MEDIUM fixed, 1 LOW skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)